### PR TITLE
feat(ui): add in-ui controller logs for resource debugging

### DIFF
--- a/charts/gyre/templates/clusterrole.yaml
+++ b/charts/gyre/templates/clusterrole.yaml
@@ -88,6 +88,7 @@ rules:
     - namespaces
     - events
     - pods
+    - pods/log
     - services
     - configmaps
   verbs: ["get", "list", "watch"]

--- a/src/lib/server/kubernetes/client.ts
+++ b/src/lib/server/kubernetes/client.ts
@@ -1,6 +1,10 @@
 import * as k8s from '@kubernetes/client-node';
 import { loadKubeConfig } from './config.js';
-import { getResourceDef, type FluxResourceType } from './flux/resources.js';
+import {
+	getResourceDef,
+	getResourceTypeByPlural,
+	type FluxResourceType
+} from './flux/resources.js';
 import type { FluxResource, FluxResourceList } from './flux/types.js';
 
 // Cached kubeconfig (single in-cluster config)
@@ -364,6 +368,89 @@ export async function createFluxResource(
 		return response as unknown as FluxResource;
 	} catch (error) {
 		throw handleK8sError(error, `create ${resourceType} in ${namespace}`);
+	}
+}
+
+/**
+ * Get logs for a FluxCD controller responsible for a specific resource
+ */
+export async function getControllerLogs(
+	resourceType: string,
+	namespace: string,
+	name: string,
+	context?: string
+): Promise<string> {
+	let resourceDef = getResourceDef(resourceType);
+	if (!resourceDef) {
+		const key = getResourceTypeByPlural(resourceType);
+		if (key) {
+			resourceDef = getResourceDef(key);
+		}
+	}
+
+	if (!resourceDef) {
+		throw new Error(`Unknown resource type: ${resourceType}`);
+	}
+
+	const controllerName = resourceDef.controller;
+	const coreApi = getCoreV1Api(context);
+
+	try {
+		// 1. Find the controller pod in flux-system namespace
+		// Most Flux installations use the app label
+		const podsResponse = await coreApi.listNamespacedPod({
+			namespace: 'flux-system',
+			labelSelector: `app=${controllerName}`
+		});
+
+		const pods = podsResponse.items;
+		if (pods.length === 0) {
+			// Fallback: try app.kubernetes.io/name label
+			const podsResponseAlt = await coreApi.listNamespacedPod({
+				namespace: 'flux-system',
+				labelSelector: `app.kubernetes.io/name=${controllerName}`
+			});
+			if (podsResponseAlt.items.length === 0) {
+				throw new Error(`No pods found for controller ${controllerName} in namespace flux-system`);
+			}
+			pods.push(...podsResponseAlt.items);
+		}
+
+		// Pick the first running pod
+		const pod = pods.find((p) => p.status?.phase === 'Running') || pods[0];
+		const podName = pod.metadata?.name;
+
+		if (!podName) {
+			throw new Error(`Could not determine pod name for controller ${controllerName}`);
+		}
+
+		// 2. Fetch logs (last 500 lines)
+		const logsResponse = await coreApi.readNamespacedPodLog({
+			name: podName,
+			namespace: 'flux-system',
+			tailLines: 1000
+		});
+
+		const logs = logsResponse;
+
+		// 3. Filter logs for the specific resource
+		// Flux logs are JSON and typically contain "name" and "namespace" fields for the resource being processed.
+		// We grep for both to be as specific as possible.
+		const lines = logs.split('\n');
+		const filteredLines = lines.filter((line) => {
+			if (!line.trim()) return false;
+			// Match both name and namespace of the resource
+			return line.includes(`"${name}"`) && line.includes(`"${namespace}"`);
+		});
+
+		// If filtering yields too little, return more context or all logs
+		if (filteredLines.length < 10) {
+			return logs;
+		}
+
+		return filteredLines.join('\n');
+	} catch (error) {
+		throw handleK8sError(error, `fetch logs for ${controllerName}`);
 	}
 }
 

--- a/src/lib/server/kubernetes/flux/resources.ts
+++ b/src/lib/server/kubernetes/flux/resources.ts
@@ -9,6 +9,7 @@ export interface FluxResourceDef {
 	kind: string;
 	apiVersion: string;
 	namespaced: boolean;
+	controller: string;
 }
 
 /**
@@ -22,7 +23,8 @@ export const FLUX_RESOURCES = {
 		plural: 'gitrepositories',
 		kind: 'GitRepository',
 		apiVersion: 'source.toolkit.fluxcd.io/v1',
-		namespaced: true
+		namespaced: true,
+		controller: 'source-controller'
 	},
 	HelmRepository: {
 		group: 'source.toolkit.fluxcd.io',
@@ -30,7 +32,8 @@ export const FLUX_RESOURCES = {
 		plural: 'helmrepositories',
 		kind: 'HelmRepository',
 		apiVersion: 'source.toolkit.fluxcd.io/v1',
-		namespaced: true
+		namespaced: true,
+		controller: 'source-controller'
 	},
 	HelmChart: {
 		group: 'source.toolkit.fluxcd.io',
@@ -38,7 +41,8 @@ export const FLUX_RESOURCES = {
 		plural: 'helmcharts',
 		kind: 'HelmChart',
 		apiVersion: 'source.toolkit.fluxcd.io/v1',
-		namespaced: true
+		namespaced: true,
+		controller: 'source-controller'
 	},
 	Bucket: {
 		group: 'source.toolkit.fluxcd.io',
@@ -46,7 +50,8 @@ export const FLUX_RESOURCES = {
 		plural: 'buckets',
 		kind: 'Bucket',
 		apiVersion: 'source.toolkit.fluxcd.io/v1',
-		namespaced: true
+		namespaced: true,
+		controller: 'source-controller'
 	},
 	OCIRepository: {
 		group: 'source.toolkit.fluxcd.io',
@@ -54,7 +59,8 @@ export const FLUX_RESOURCES = {
 		plural: 'ocirepositories',
 		kind: 'OCIRepository',
 		apiVersion: 'source.toolkit.fluxcd.io/v1beta2',
-		namespaced: true
+		namespaced: true,
+		controller: 'source-controller'
 	},
 
 	// Kustomize Controller (kustomize.toolkit.fluxcd.io/v1)
@@ -64,7 +70,8 @@ export const FLUX_RESOURCES = {
 		plural: 'kustomizations',
 		kind: 'Kustomization',
 		apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
-		namespaced: true
+		namespaced: true,
+		controller: 'kustomize-controller'
 	},
 
 	// Helm Controller (helm.toolkit.fluxcd.io/v2)
@@ -74,7 +81,8 @@ export const FLUX_RESOURCES = {
 		plural: 'helmreleases',
 		kind: 'HelmRelease',
 		apiVersion: 'helm.toolkit.fluxcd.io/v2',
-		namespaced: true
+		namespaced: true,
+		controller: 'helm-controller'
 	},
 
 	// Notification Controller (notification.toolkit.fluxcd.io)
@@ -84,7 +92,8 @@ export const FLUX_RESOURCES = {
 		plural: 'alerts',
 		kind: 'Alert',
 		apiVersion: 'notification.toolkit.fluxcd.io/v1beta3',
-		namespaced: true
+		namespaced: true,
+		controller: 'notification-controller'
 	},
 	Provider: {
 		group: 'notification.toolkit.fluxcd.io',
@@ -92,7 +101,8 @@ export const FLUX_RESOURCES = {
 		plural: 'providers',
 		kind: 'Provider',
 		apiVersion: 'notification.toolkit.fluxcd.io/v1beta3',
-		namespaced: true
+		namespaced: true,
+		controller: 'notification-controller'
 	},
 	Receiver: {
 		group: 'notification.toolkit.fluxcd.io',
@@ -100,7 +110,8 @@ export const FLUX_RESOURCES = {
 		plural: 'receivers',
 		kind: 'Receiver',
 		apiVersion: 'notification.toolkit.fluxcd.io/v1',
-		namespaced: true
+		namespaced: true,
+		controller: 'notification-controller'
 	},
 
 	// Image Automation Controller (image.toolkit.fluxcd.io/v1)
@@ -110,7 +121,8 @@ export const FLUX_RESOURCES = {
 		plural: 'imagerepositories',
 		kind: 'ImageRepository',
 		apiVersion: 'image.toolkit.fluxcd.io/v1beta2',
-		namespaced: true
+		namespaced: true,
+		controller: 'image-reflector-controller'
 	},
 	ImagePolicy: {
 		group: 'image.toolkit.fluxcd.io',
@@ -118,7 +130,8 @@ export const FLUX_RESOURCES = {
 		plural: 'imagepolicies',
 		kind: 'ImagePolicy',
 		apiVersion: 'image.toolkit.fluxcd.io/v1beta2',
-		namespaced: true
+		namespaced: true,
+		controller: 'image-reflector-controller'
 	},
 	ImageUpdateAutomation: {
 		group: 'image.toolkit.fluxcd.io',
@@ -126,7 +139,8 @@ export const FLUX_RESOURCES = {
 		plural: 'imageupdateautomations',
 		kind: 'ImageUpdateAutomation',
 		apiVersion: 'image.toolkit.fluxcd.io/v1beta2',
-		namespaced: true
+		namespaced: true,
+		controller: 'image-automation-controller'
 	}
 } as const;
 

--- a/src/routes/api/flux/[type]/[namespace]/[name]/logs/+server.ts
+++ b/src/routes/api/flux/[type]/[namespace]/[name]/logs/+server.ts
@@ -1,0 +1,35 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getControllerLogs } from '$lib/server/kubernetes/client';
+import type { FluxResourceType } from '$lib/server/kubernetes/flux/resources';
+import { checkPermission } from '$lib/server/rbac.js';
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+	// Check authentication
+	if (!locals.user) {
+		return error(401, { message: 'Authentication required' });
+	}
+
+	const { type, namespace, name } = params;
+
+	// Check permission for read action
+	const hasPermission = await checkPermission(
+		locals.user,
+		'read',
+		type as FluxResourceType,
+		namespace,
+		locals.cluster
+	);
+
+	if (!hasPermission) {
+		return error(403, { message: 'Permission denied' });
+	}
+
+	try {
+		const logs = await getControllerLogs(type as FluxResourceType, namespace, name, locals.cluster);
+		return json({ logs });
+	} catch (err) {
+		console.error(`Error fetching logs for ${name}:`, err);
+		return error(500, { message: `Failed to fetch logs: ${(err as Error).message}` });
+	}
+};

--- a/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
+++ b/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
@@ -63,7 +63,7 @@
 		return unsubscribe;
 	});
 
-	type TabId = 'overview' | 'spec' | 'status' | 'events' | 'history' | 'yaml';
+	type TabId = 'overview' | 'spec' | 'status' | 'events' | 'logs' | 'history' | 'yaml';
 
 	let activeTab = $state<TabId>('overview');
 
@@ -72,6 +72,55 @@
 	let eventsLoading = $state(false);
 	let eventsError = $state<string | null>(null);
 	let eventsFetched = $state(false);
+
+	// Logs state
+	let logs = $state<string>('');
+	let logsLoading = $state(false);
+	let logsError = $state<string | null>(null);
+	let logsFetched = $state(false);
+	let showRawLogs = $state(false);
+	let logContainer = $state<HTMLDivElement | null>(null);
+
+	const formattedLogs = $derived(
+		logs
+			.split('\n')
+			.filter((line) => line.trim())
+			.map((line) => {
+				try {
+					const parsed = JSON.parse(line);
+					return {
+						ts: parsed.ts ? new Date(parsed.ts).toLocaleTimeString() : '',
+						level: (parsed.level || 'info').toUpperCase(),
+						msg: parsed.msg || parsed.message || line,
+						full: line
+					};
+				} catch {
+					return { ts: '', level: 'INFO', msg: line, full: line };
+				}
+			})
+	);
+
+	function getLevelClass(level: string) {
+		switch (level) {
+			case 'ERROR':
+			case 'FATAL':
+				return 'text-red-400 font-bold';
+			case 'WARN':
+			case 'WARNING':
+				return 'text-yellow-400 font-bold';
+			case 'DEBUG':
+				return 'text-blue-400';
+			default:
+				return 'text-green-400';
+		}
+	}
+
+	// Autoscroll to bottom when logs change
+	$effect(() => {
+		if (logs && logContainer && !showRawLogs) {
+			logContainer.scrollTop = logContainer.scrollHeight;
+		}
+	});
 
 	// History state
 	let history = $state<
@@ -85,6 +134,7 @@
 		{ id: 'spec', label: 'Spec' },
 		{ id: 'status', label: 'Status' },
 		{ id: 'events', label: 'Events' },
+		{ id: 'logs', label: 'Logs' },
 		{ id: 'history', label: 'History' },
 		{ id: 'yaml', label: 'YAML' }
 	];
@@ -116,6 +166,33 @@
 			eventsError = err instanceof Error ? err.message : 'Failed to load events';
 		} finally {
 			eventsLoading = false;
+		}
+	}
+
+	// Fetch logs when the Logs tab is selected
+	async function fetchLogs() {
+		if (logsFetched) return;
+
+		logsLoading = true;
+		logsError = null;
+
+		try {
+			const response = await fetch(
+				`/api/flux/${data.resourceType}/${data.namespace}/${data.name}/logs`
+			);
+
+			if (!response.ok) {
+				const errData = await response.json();
+				throw new Error(errData.message || `Failed to fetch logs: ${response.statusText}`);
+			}
+
+			const result = await response.json();
+			logs = result.logs || '';
+			logsFetched = true;
+		} catch (err) {
+			logsError = err instanceof Error ? err.message : 'Failed to load logs';
+		} finally {
+			logsLoading = false;
 		}
 	}
 
@@ -177,6 +254,12 @@
 	$effect(() => {
 		if (activeTab === 'events' && !eventsFetched) {
 			fetchEvents();
+		}
+	});
+
+	$effect(() => {
+		if (activeTab === 'logs' && !logsFetched) {
+			fetchLogs();
 		}
 	});
 
@@ -368,6 +451,87 @@
 					</button>
 				</div>
 				<EventsList {events} loading={eventsLoading} error={eventsError} />
+			</div>
+		{:else if activeTab === 'logs'}
+			<div
+				class="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800"
+			>
+				<div class="mb-4 flex items-center justify-between">
+					<h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Controller Logs</h3>
+					<div class="flex items-center gap-6">
+						<label
+							class="flex cursor-pointer items-center gap-2 text-sm text-gray-500 transition-colors select-none hover:text-gray-700 dark:hover:text-gray-300"
+						>
+							<input
+								type="checkbox"
+								class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+								bind:checked={showRawLogs}
+							/>
+							Raw JSON
+						</label>
+						<button
+							type="button"
+							class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 disabled:opacity-50 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+							onclick={() => {
+								logsFetched = false;
+								fetchLogs();
+							}}
+							disabled={logsLoading}
+						>
+							<svg
+								class="h-4 w-4 {logsLoading ? 'animate-spin' : ''}"
+								fill="none"
+								stroke="currentColor"
+								viewBox="0 0 24 24"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+								/>
+							</svg>
+							Refresh
+						</button>
+					</div>
+				</div>
+
+				{#if logsLoading}
+					<div class="flex h-64 items-center justify-center">
+						<div
+							class="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"
+						></div>
+					</div>
+				{:else if logsError}
+					<div
+						class="rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400"
+					>
+						{logsError}
+					</div>
+				{:else if !logs}
+					<div class="py-12 text-center text-gray-500 dark:text-gray-400">
+						No relevant logs found in the controller for this resource.
+					</div>
+				{:else}
+					<div class="relative rounded-lg bg-gray-950 shadow-inner">
+						<div
+							bind:this={logContainer}
+							class="scrollbar-thin scrollbar-track-gray-900 scrollbar-thumb-gray-700 max-h-[600px] overflow-auto p-4 font-mono text-xs leading-relaxed whitespace-pre-wrap text-gray-300"
+						>
+							{#if showRawLogs}
+								<code>{logs}</code>
+							{:else}
+								{#each formattedLogs as line}
+									<div class="mb-1 flex gap-3 last:mb-0">
+										<span class="shrink-0 text-gray-500">[{line.ts}]</span>
+										<span class="shrink-0 {getLevelClass(line.level)}">{line.level}</span>
+										<span class="break-words">{line.msg}</span>
+									</div>
+								{/each}
+							{/if}
+						</div>
+					</div>
+				{/if}
 			</div>
 		{:else if activeTab === 'history'}
 			<div


### PR DESCRIPTION
## Summary
This PR implements the 'In-UI Controller Logs' feature, allowing users to view relevant FluxCD controller logs directly within the Resource Detail view.

## Changes
- **Controller Mappings**: Added `controller` field to `FluxResourceDef` and mapped all FluxCD resource types to their respective controllers.
- **Log Fetching**: Added `getControllerLogs` utility to fetch and filter logs from controller pods in the `flux-system` namespace.
- **API Endpoint**: Created a secure API endpoint at `/api/flux/[type]/[namespace]/[name]/logs` with RBAC checks.
- **Log Viewer UI**: Added a professional 'k9s-style' log viewer tab to the Resource Detail page with:
    - Automatic JSON log formatting (Timestamp, Level, Message).
    - Level-based color coding (Error, Warn, Info).
    - Word wrapping for better readability.
    - Persistent autoscroll to the latest logs.
    - Toggle for raw JSON view.
- **RBAC Permissions**: Updated Helm chart `ClusterRole` to include `pods/log` permissions.

## Testing
- Verified Svelte 5 runes usage.
- Ran `bun run check`, `bun run lint`, and `bun run format`.
- Manual verification of log fetching and filtering logic.

## Screenshots (if applicable)
[Log viewer provides a clean, dark terminal-like experience group with actions on the right]

## Related Issues
Fixes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a Logs tab to resource detail pages displaying controller logs with automatic filtering and retrieval
* Log viewer supports formatted and raw JSON views with timestamp, level, and message details
* Implemented auto-scrolling log display with manual refresh capability
* Renamed History tab to "Version History" for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->