### PR TITLE
fix(inventory): add ImageUpdateAutomation nodes to inventory tree

### DIFF
--- a/src/routes/inventory/+page.server.ts
+++ b/src/routes/inventory/+page.server.ts
@@ -172,7 +172,11 @@ export const load: PageServerLoad = async ({ cookies }) => {
 					imageUpdateNodes
 						.filter((un) => un.ref.namespace === policyNode.ref.namespace)
 						.forEach((un) => {
-							if (!policyNode.children.some((c) => c.ref.name === un.ref.name)) {
+							if (
+								!policyNode.children.some(
+									(c) => c.ref.name === un.ref.name && c.ref.namespace === un.ref.namespace
+								)
+							) {
 								policyNode.children.push(un);
 							}
 						});
@@ -227,7 +231,9 @@ export const load: PageServerLoad = async ({ cookies }) => {
 
 	// Determine which image automation nodes are top-level (not children of a policy)
 	const topLevelImageUpdateNodes = imageUpdateNodes.filter((un) => {
-		return !imagePolicyNodes.some((pn) => pn.children.some((c) => c.ref.name === un.ref.name));
+		return !imagePolicyNodes.some((pn) =>
+			pn.children.some((c) => c.ref.name === un.ref.name && c.ref.namespace === un.ref.namespace)
+		);
 	});
 
 	return {


### PR DESCRIPTION
## Summary
This PR fixes issue #14 where `ImageUpdateAutomation` resources were missing from the inventory tree.

## Changes
- Assigned the result of `ImageUpdateAutomation` node creation to `imageUpdateNodes`.
- Updated the `Sources` tree building logic to include `ImageUpdateAutomation` nodes when they reference a `GitRepository`.
- Updated the `Image Automation` tree building logic to nest `ImageUpdateAutomation` nodes under their corresponding `ImagePolicy` (when in the same namespace).
- Added logic to handle `ImageUpdateAutomation` nodes that might not be parented by a policy as top-level nodes in the Image Automation tree.

## Testing
- Verified with `bun run check` and `bun run lint`.
- Manual verification of logic flow.

Fixes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for image automation resources in inventory, including repositories, policies, and update automations
  * Image automation resources now display as top-level entries when not nested under policies
  * Enhanced relationship tracking between image resources and automations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->