### PR TITLE
fix(templates): update FluxCD resource templates to match CRDs

### DIFF
--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -924,14 +924,30 @@ spec:
 				},
 				{ name: 'kind', label: 'Kind', path: 'kind', type: 'string', required: true },
 				{
-					name: 'expression',
-					label: 'CEL Expression',
-					path: 'expression',
+					name: 'inProgress',
+					label: 'In Progress Expression',
+					path: 'inProgress',
 					type: 'textarea',
-					required: true
+					description: 'CEL expression to check if the resource is still progressing'
+				},
+				{
+					name: 'failed',
+					label: 'Failed Expression',
+					path: 'failed',
+					type: 'textarea',
+					description: 'CEL expression to check if the resource has failed'
+				},
+				{
+					name: 'current',
+					label: 'Current Expression',
+					path: 'current',
+					type: 'textarea',
+					required: true,
+					description: 'CEL expression to check if the resource is healthy'
 				}
 			],
-			description: 'CEL expressions for health assessment'
+			description: 'CEL expressions for health assessment. Evaluation order: inProgress → failed → current',
+			helpText: 'CEL expressions evaluated in order: inProgress (progressing), failed (unhealthy), current (healthy).'
 		},
 		{
 			name: 'timeout',
@@ -1798,10 +1814,10 @@ export const BUCKET_TEMPLATE: ResourceTemplate = {
 	description: 'Sources from an S3-compatible bucket',
 	kind: 'Bucket',
 	group: 'source.toolkit.fluxcd.io',
-	version: 'v1beta2',
+	version: 'v1',
 	category: 'sources',
 	plural: 'buckets',
-	yaml: `apiVersion: source.toolkit.fluxcd.io/v1beta2
+	yaml: `apiVersion: source.toolkit.fluxcd.io/v1
 kind: Bucket
 metadata:
   name: example


### PR DESCRIPTION
## Summary

Updates all 13 FluxCD resource templates in `src/lib/templates/index.ts` to align with the currently installed CRDs and official API specifications.

## Changes

- **GitRepository:** Added `provider`, `serviceAccountName`, `sparseCheckout`. Corrected provider options.
- **HelmRepository:** Added `provider`, `accessFrom`.
- **Kustomization:** Added `deletionPolicy`, `healthChecks`, `healthCheckExprs`, `ignoreMissingComponents`.
- **Alert/Receiver:** Added missing `eventMetadata` and `interval`. Confirmed presence of required fields.
- **Image Automation:** Added fields for `ImageRepository`, `ImagePolicy`, and `ImageUpdateAutomation` matching v1beta2 specs.
- **Validation:** Added duration regex validation for `interval` and `timeout` fields.

## Verification

- Verified fields against active cluster CRDs using `kubectl explain`.
- Ran `bun run check` and `bun run lint`.
- Updated `FLUX_TEMPLATE_AUDIT_REPORT.md` with findings.

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template system now supports object-type fields to define nested configurations.
  * Expanded many templates (GitRepository, Helm, OCI, Image, Kustomization, Alerts/Providers, Buckets, Releases) with provider/auth/tls/service-account options, sparse checkout, cross-resource access, health checks and CEL expressions, commit/commit-status metadata, policy selectors, digest-reflection and interval gating, deletion/ignore-missing controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->