### PR TITLE
fix(ui): resolve focus loss in labels filter input

### DIFF
--- a/src/lib/components/flux/FilterBar.svelte
+++ b/src/lib/components/flux/FilterBar.svelte
@@ -6,12 +6,11 @@
 	interface Props {
 		filters: FilterState;
 		namespaces: string[];
-		onFilterChange: (filters: FilterState) => void;
 		onClearFilters: () => void;
 		hasActiveFilters: boolean;
 	}
 
-	let { filters, namespaces, onFilterChange, onClearFilters, hasActiveFilters }: Props = $props();
+	let { filters = $bindable(), namespaces, onClearFilters, hasActiveFilters }: Props = $props();
 
 	const statusOptions: { value: ResourceHealth | 'all'; label: string; color: string }[] = [
 		{ value: 'all', label: 'All Status', color: 'bg-muted text-muted-foreground' },
@@ -24,17 +23,17 @@
 
 	function handleNamespaceChange(e: Event) {
 		const target = e.target as HTMLSelectElement;
-		onFilterChange({ ...filters, namespace: target.value });
+		filters.namespace = target.value;
 	}
 
 	function handleStatusChange(e: Event) {
 		const target = e.target as HTMLSelectElement;
-		onFilterChange({ ...filters, status: target.value as ResourceHealth | 'all' });
+		filters.status = target.value as ResourceHealth | 'all';
 	}
 
 	function handleLabelsChange(e: Event) {
 		const target = e.target as HTMLInputElement;
-		onFilterChange({ ...filters, labels: target.value });
+		filters.labels = target.value;
 	}
 </script>
 

--- a/src/routes/resources/[type]/+page.svelte
+++ b/src/routes/resources/[type]/+page.svelte
@@ -133,23 +133,43 @@
 		goto(resolve(`/resources/${data.resourceType}/${namespace}/${name}`));
 	}
 
-	function updateFilters(newFilters: FilterState) {
-		// Update URL with new filters
-		const params = filtersToSearchParams(newFilters);
-		void goto(`?${params.toString()}`, { replaceState: true, noScroll: true });
+	// Sync filters to URL with debounce to avoid focus loss during typing
+	$effect(() => {
+		// Capture all reactive dependencies we want to track
+		const currentFilters = {
+			search: filters.search,
+			namespace: filters.namespace,
+			status: filters.status,
+			labels: filters.labels,
+			useRegex: filters.useRegex
+		};
+
+		const timeoutId = setTimeout(() => {
+			const params = filtersToSearchParams(currentFilters);
+			const newSearch = params.toString();
+
+			if (newSearch !== $page.url.search.toString().replace(/^\?/, '')) {
+				void goto(`?${newSearch}`, {
+					replaceState: true,
+					noScroll: true,
+					keepFocus: true
+				});
+				lastSearchParams = `?${newSearch}`;
+			}
+		}, 300); // 300ms debounce
+
+		return () => clearTimeout(timeoutId);
+	});
+
+	function clearFilters() {
+		filters.search = defaultFilterState.search;
+		filters.namespace = defaultFilterState.namespace;
+		filters.status = defaultFilterState.status;
+		filters.labels = defaultFilterState.labels;
 	}
 
 	function handleSearch() {
-		// handleSearch is now handled by the filteredItems binding,
-		// but we still need it for URL sync if we want to keep that
-	}
-
-	function handleFilterChange(newFilters: FilterState) {
-		updateFilters(newFilters);
-	}
-
-	function clearFilters() {
-		updateFilters({ ...defaultFilterState });
+		// Search is handled by reactive filtering of filteredResources
 	}
 </script>
 
@@ -197,13 +217,7 @@
 			</div>
 		</div>
 		<!-- Filter Bar -->
-		<FilterBar
-			{filters}
-			{namespaces}
-			onFilterChange={handleFilterChange}
-			onClearFilters={clearFilters}
-			{hasActiveFilters}
-		/>
+		<FilterBar bind:filters {namespaces} onClearFilters={clearFilters} {hasActiveFilters} />
 	</div>
 
 	<!-- Error Alert -->


### PR DESCRIPTION
## Summary
This PR fixes a bug where the Labels filter input field loses focus after a single keystroke, making it difficult to type multi-character labels.

## Changes
- Updated `FilterBar.svelte` to use bindable `filters` prop.
- Implemented debounced URL synchronization in `+page.svelte` using Svelte 5 `$effect`.
- Added `keepFocus: true` to `goto` calls to preserve input focus during navigation.

## Testing
- Verified that typing in the Labels filter input no longer causes focus loss.
- Confirmed that filters still correctly synchronize with the URL after the debounce period.
- Checked that other filters (Namespace, Status) still work as expected.

## Related Issues
Fixes #62