### PR TITLE
fix(k8s): strip managedFields from resource viewer and editor (#94)

### DIFF
--- a/src/lib/components/flux/ActionButtons.svelte
+++ b/src/lib/components/flux/ActionButtons.svelte
@@ -8,6 +8,7 @@
 	import type { FluxResource } from '$lib/types/flux';
 	import { RefreshCw, Play, Pause, Loader2, Pencil } from 'lucide-svelte';
 	import { resourceCache } from '$lib/stores/resourceCache.svelte';
+	import { sanitizeResource } from '$lib/utils/kubernetes';
 	import yaml from 'js-yaml';
 
 	let {
@@ -30,7 +31,8 @@
 	// Serialize resource to YAML for editing
 	const resourceYaml = $derived.by(() => {
 		try {
-			return yaml.dump(resource, { noRefs: true, lineWidth: -1 });
+			const sanitized = sanitizeResource(resource);
+			return yaml.dump(sanitized, { noRefs: true, lineWidth: -1 });
 		} catch (err) {
 			console.error('Failed to serialize resource:', err);
 			return '';

--- a/src/lib/utils/kubernetes.ts
+++ b/src/lib/utils/kubernetes.ts
@@ -1,0 +1,17 @@
+/**
+ * Sanitizes a Kubernetes resource by removing internal metadata that should not be visible to users.
+ * Specifically removes managedFields (FieldsV1) and other internal fields.
+ */
+export function sanitizeResource<T>(resource: T): T {
+	if (!resource || typeof resource !== 'object') return resource;
+
+	// Deep clone to avoid mutating the original object
+	const sanitized = JSON.parse(JSON.stringify(resource));
+
+	if (sanitized.metadata) {
+		// Remove managedFields which contains FieldsV1 metadata (Issue #94)
+		delete sanitized.metadata.managedFields;
+	}
+
+	return sanitized as T;
+}

--- a/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
+++ b/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
@@ -16,6 +16,7 @@
 	import CodeViewer from '$lib/components/common/CodeViewer.svelte';
 	import type { FluxResource, K8sCondition } from '$lib/types/flux';
 	import { resourceCache } from '$lib/stores/resourceCache.svelte';
+	import { sanitizeResource } from '$lib/utils/kubernetes';
 
 	interface K8sEvent {
 		type: 'Normal' | 'Warning';
@@ -568,7 +569,7 @@
 			</div>
 		{:else if activeTab === 'yaml'}
 			<CodeViewer
-				data={data.resource as unknown as Record<string, unknown>}
+				data={sanitizeResource(resource) as unknown as Record<string, unknown>}
 				title="Full Resource Manifest"
 			/>
 		{/if}


### PR DESCRIPTION
This PR strips out the raw Kubernetes internal field management metadata (managedFields) from the resource viewer and editor, as requested in issue #94.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Resource manifests are now automatically sanitized when displayed and edited in YAML format. Extraneous metadata is removed to provide a cleaner view of resource configurations, making review and management easier without unnecessary clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->