### PR TITLE
feat(templates): improve resource template coverage and fix gaps (#87)

### DIFF
--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -2902,7 +2902,14 @@ spec:
 				{ label: 'GitLab', value: 'gitlab' },
 				{ label: 'Bitbucket', value: 'bitbucket' },
 				{ label: 'Harbor', value: 'harbor' },
-				{ label: 'Generic', value: 'generic' }
+				{ label: 'DockerHub', value: 'dockerhub' },
+				{ label: 'Quay', value: 'quay' },
+				{ label: 'Nexus', value: 'nexus' },
+				{ label: 'ACR', value: 'acr' },
+				{ label: 'GCR', value: 'gcr' },
+				{ label: 'CDEvents', value: 'cdevents' },
+				{ label: 'Generic Webhook', value: 'generic' },
+				{ label: 'Generic HMAC', value: 'generic-hmac' }
 			],
 			description: 'Type of webhook receiver'
 		},


### PR DESCRIPTION
This PR improves the FluxCD resource templates by fixing missing or incorrect fields identified in the recent audit (Issue #87).

Changes:
- Fix sparseCheckout path in GitRepository
- Add bitbucket and gitlab to GitRepository provider
- Remove retryInterval from Kustomization template
- Add valuesFiles to HelmRelease template
- Add missing notification provider types
- Verified critical fields for Alert and Receiver are present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many new provider/receiver options (Rocket, Google Chat, Webex, Matrix, Lark, Telegram, GitLab, Gitea, Bitbucket, Bitbucket Server, Azure DevOps, Google Pub/Sub, Grafana, Generic Webhook, Generic HMAC)
  * Added Values Files configuration for Helm releases (support for multiple values files)

* **Improvements**
  * Updated sparse checkout field structure to read from the new nested path
<!-- end of auto-generated comment: release notes by coderabbit.ai -->