### PR TITLE
fix(layout): set default fluxVersion in error state

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -2,6 +2,8 @@ import type { LayoutServerLoad } from './$types';
 import pkg from '../../package.json';
 import { serializeUser } from '$lib/server/auth';
 
+const DEFAULT_FLUX_VERSION = 'v2.x.x';
+
 export const load: LayoutServerLoad = async ({ fetch, locals }) => {
 	try {
 		const [healthRes, versionRes] = await Promise.all([
@@ -10,7 +12,7 @@ export const load: LayoutServerLoad = async ({ fetch, locals }) => {
 		]);
 
 		const healthData = healthRes.ok ? await healthRes.json() : null;
-		const versionData = versionRes.ok ? await versionRes.json() : { version: 'v2.x.x' };
+		const versionData = versionRes.ok ? await versionRes.json() : { version: DEFAULT_FLUX_VERSION };
 
 		return {
 			health: {
@@ -32,7 +34,7 @@ export const load: LayoutServerLoad = async ({ fetch, locals }) => {
 				availableClusters: [],
 				error: error instanceof Error ? error.message : 'Failed to connect to cluster API'
 			},
-			fluxVersion: 'v2.x.x',
+			fluxVersion: DEFAULT_FLUX_VERSION,
 			gyreVersion: pkg.version,
 			user: serializeUser(locals.user)
 		};


### PR DESCRIPTION
Fixes #147. Sets default fluxVersion in layout error state to ensure consistent API contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the app can’t determine the Flux version: a default version is now used consistently to prevent missing/incorrect version displays and related errors, ensuring stable and predictable version info for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->