### PR TITLE
perf(search): cache Fuse instances by items reference to avoid rebuilding index

### DIFF
--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -11,8 +11,19 @@ export interface SearchOptions {
 // WeakMap allows entries to be garbage collected when the items array is no longer in use.
 const fuseCache = new WeakMap<object, Map<string, Fuse<unknown>>>();
 
+/**
+ * Returns a cached Fuse instance for the given items array and options.
+ *
+ * **Callers must treat `items` as immutable.** The cache ({@link fuseCache}) is
+ * keyed by the `items` array reference, so mutating the array in place will
+ * cause {@link getFuseInstance} to return a stale index without rebuilding it.
+ * Pass a new array reference whenever the contents change.
+ *
+ * Future improvement: include a content hash in the options key to
+ * auto-detect in-place mutations.
+ */
 function getFuseInstance<T>(items: T[], keys: string[], caseSensitive: boolean): Fuse<T> {
-	const optionsKey = JSON.stringify([...keys].sort()) + String(caseSensitive);
+	const optionsKey = JSON.stringify({ keys: [...keys].sort(), caseSensitive });
 
 	let byOptions = fuseCache.get(items as object);
 	if (!byOptions) {


### PR DESCRIPTION
## Summary

Closes #150.

- `advancedSearch()` previously constructed a `new Fuse(items, options)` on every call, rebuilding the full search index on every keystroke
- Adds a `WeakMap`-based cache in `src/lib/utils/search.ts` keyed by the `items` array reference (outer) and serialised options (inner)
- When the same dataset is reused, only `fuse.search(query)` runs — index construction happens once

## Test plan

- [x] Type in the resource list search box and confirm results remain correct
- [x] Verify audit log search still works as expected
- [x] Confirm that switching between different resource lists (different `items` references) correctly rebuilds the index
- [x] Run `bun run check` — no type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized search performance through improved instance management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->