### PR TITLE
fix(security): prevent raw error messages leaking to client in diff API

### DIFF
--- a/src/lib/server/kubernetes/flux/diff-errors.ts
+++ b/src/lib/server/kubernetes/flux/diff-errors.ts
@@ -1,0 +1,36 @@
+export type DiffErrorResponse = { status: number; message: string };
+
+export function classifyDiffError(err: unknown): DiffErrorResponse {
+	const message = err instanceof Error ? err.message : String(err);
+
+	if (message.includes('not in gzip format')) {
+		return {
+			status: 500,
+			message:
+				'The artifact downloaded from source-controller is not a valid gzip archive. ' +
+				'This usually indicates the source-controller service is returning an error page instead of the artifact. ' +
+				'Check that the source-controller is running and the GitRepository/Bucket has reconciled successfully.'
+		};
+	} else if (message.includes('tar:')) {
+		return {
+			status: 500,
+			message: 'Failed to extract source artifact. Check server logs for details.'
+		};
+	} else if (message.includes('kustomize')) {
+		return {
+			status: 500,
+			message: 'Kustomize build failed. Check server logs for details.'
+		};
+	} else if (message.includes('timeout')) {
+		return {
+			status: 504,
+			message:
+				'Operation timed out. The kustomization may be too large or the source artifact is unavailable.'
+		};
+	}
+
+	return {
+		status: 500,
+		message: 'Failed to compute diff. Please try again or check the source artifact.'
+	};
+}


### PR DESCRIPTION
## Summary

- Replace the raw `err.message` fallback in the diff API catch block with a generic client-safe message
- Sanitise the `tar:` and `kustomize` error branches for consistency — both previously forwarded raw tool output to the client
- Full error details continue to be logged server-side via `console.error` (already in place on line 524)

## Test plan

- [x] Trigger a diff request that hits the tar extraction error path and confirm the response body no longer contains raw `tar` output or file paths
- [x] Trigger a kustomize build failure and confirm the response body shows the generic message
- [x] Trigger any other unhandled error and confirm the generic fallback message is returned
- [x] Confirm server logs still contain the full error detail in all cases

Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized client-facing error messages for diff failures to avoid leaking internal details and direct users to check server logs for diagnostics.

* **Tests**
  * Added comprehensive tests ensuring errors are logged server-side while client responses remain sanitized across extraction, build, timeout, and generic failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->