### PR TITLE
fix(security): use sanitised filename in backup Content-Disposition header

### DIFF
--- a/src/routes/api/admin/backups/download/+server.ts
+++ b/src/routes/api/admin/backups/download/+server.ts
@@ -64,7 +64,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 
 		await logAudit(locals.user, 'backup:download', {
 			resourceType: 'DatabaseBackup',
-			resourceName: filename
+			resourceName: safeFilename
 		});
 
 		return new Response(stream as any, {


### PR DESCRIPTION
## Summary

- The `Content-Disposition` header in the backup download endpoint was using the raw user-supplied `filename` query parameter, allowing header injection or response-splitting via crafted filenames (e.g. containing quotes, newlines, or `../`).
- Fix derives the download filename from the resolved file path using `basename(filePath)`, which is already validated and sanitised by `getBackupPath`.

## Test plan

- [x] Download a legitimate backup — filename in the `Content-Disposition` header matches the backup file name.
- [x] Request with a crafted filename (e.g. `../../etc/passwd`, `foo"%0d%0aX-Injected: bad`) — `getBackupPath` returns `null` and the endpoint returns 404 before reaching the header.
- [x] Run `bun run format`, `bun run lint`, `bun run check` — all pass.

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitize backup filenames used in download headers to prevent unsafe or unexpected characters from affecting downloads.
  * Use the sanitized filename in audit logs so recorded resource names match what users receive, improving consistency and security of backup downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->