### PR TITLE
fix(db): use fs/promises mkdir in ensureDbDirectory

### DIFF
--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import Database from 'better-sqlite3';
-import { mkdir, mkdirSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import * as schema from './schema.js';
 
@@ -15,7 +16,7 @@ console.log(`[DB] Database location: ${databaseUrl}`);
 async function ensureDbDirectory() {
 	const dir = dirname(databaseUrl);
 	try {
-		await mkdir(dir, { recursive: true }, () => {});
+		await mkdir(dir, { recursive: true });
 	} catch {
 		// Directory might already exist
 	}


### PR DESCRIPTION
## Summary

- Replaces the callback-based `mkdir` from `node:fs` with the promise-based `mkdir` from `node:fs/promises` in `ensureDbDirectory()`
- Removes the spurious no-op callback argument from the `mkdir` call
- The `mkdirSync` import is kept from `node:fs` for the sync path (`ensureDbDirectorySync`)

## Problem

The previous code passed a callback to `mkdir`, which means Node.js used the callback API and returned `undefined`. `await undefined` resolves immediately, so `ensureDbDirectory()` returned before the directory was actually created — introducing a race condition where `getDb()` could open `new Database(databaseUrl)` before the directory existed.

## Fix

```ts
import { mkdir } from 'node:fs/promises';
// ...
await mkdir(dir, { recursive: true });
```

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal directory initialization mechanisms to utilize modern asynchronous API patterns while keeping synchronous operations unchanged. All existing functionality, behavior, and error handling remain fully preserved. This modernization maintains complete backward compatibility with no impact to end-user experience or system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->