### PR TITLE
fix(docs): make OpenAPI spec endpoint cluster-independent

### DIFF
--- a/src/routes/api/docs/openapi.json/+server.ts
+++ b/src/routes/api/docs/openapi.json/+server.ts
@@ -12,11 +12,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 		throw error(401, 'Authentication required');
 	}
 
-	if (!locals.cluster) {
-		throw error(400, 'Missing cluster context');
-	}
-
-	await requirePermission(locals.user, 'read', undefined, undefined, locals.cluster);
+	await requirePermission(locals.user, 'read');
 
 	const registry = createRegistry();
 


### PR DESCRIPTION
## Summary

- Removes the `locals.cluster` guard from `GET /api/docs/openapi.json`
- The OpenAPI spec is static metadata and has no dependency on any cluster
- Permission check is now called without a cluster scope — any authenticated user with `read` permission can retrieve the schema
- The docs page (`/api/docs`) was already cluster-independent and remains unchanged

## Test plan

- [x] `GET /api/docs/openapi.json` returns 200 when authenticated without a cluster cookie/context
- [x] `GET /api/docs/openapi.json` still returns 401 when unauthenticated
- [x] Swagger UI / Scalar API reference loads the spec without needing a cluster context
- [x] `bun run lint`, `bun run check`, `bun run format` all pass

Closes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API authentication flow by streamlining permission validation logic. Users will no longer encounter the "Missing cluster context" error in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->