### PR TITLE
fix(security): use explicit sql.param() for user-controlled RBAC inputs

### DIFF
--- a/src/lib/server/rbac.ts
+++ b/src/lib/server/rbac.ts
@@ -58,9 +58,9 @@ export async function checkPermission(
 		or(
 			eq(rbacPolicies.action, action),
 			// Admin action allows everything below it
-			and(eq(rbacPolicies.action, 'admin'), sql`${action} IN ('read', 'write')`),
+			and(eq(rbacPolicies.action, 'admin'), sql`${sql.param(action)} IN ('read', 'write')`),
 			// Write action allows read
-			and(eq(rbacPolicies.action, 'write'), eq(sql`${action}`, 'read'))
+			and(eq(rbacPolicies.action, 'write'), eq(sql`${sql.param(action)}`, 'read'))
 		)
 	];
 
@@ -82,7 +82,7 @@ export async function checkPermission(
 				// null pattern means all namespaces
 				sql`${rbacPolicies.namespacePattern} IS NULL`,
 				// Match namespace against pattern (supports wildcards)
-				sql`${namespace} GLOB ${rbacPolicies.namespacePattern}`
+				sql`${sql.param(namespace)} GLOB ${rbacPolicies.namespacePattern}`
 			)
 		);
 	}


### PR DESCRIPTION
## Summary

- In `checkPermission` (`src/lib/server/rbac.ts`), `action` and `namespace` values originate from API parameters and were interpolated directly into Drizzle `sql\`\`` expressions
- While Drizzle's `sql` tagged template already binds plain values as bound parameters (not string concatenation), using `sql.param()` makes the parameterization **explicit** and removes all ambiguity
- Changed three expressions: `action` in the hierarchy IN-check, `action` in the write→read `eq`, and `namespace` in the GLOB pattern match

## Test plan

- [x] Run `bun run check` — no type errors
- [x] Run `bun run lint` — no lint warnings/errors
- [x] Run `bun run format` — no formatting changes
- [x] Manually verify RBAC permission checks still work correctly for read/write/admin hierarchy and namespace glob matching

Closes #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parameterized dynamic user-provided values in database queries for action and namespace filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->