### PR TITLE
fix(layout): tighten Props type contract to match server fallback shape

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,7 +19,8 @@
 				availableClusters: string[];
 				error?: string;
 			};
-			fluxVersion?: string;
+			fluxVersion: string;
+			gyreVersion: string;
 			user: {
 				username: string;
 				role: string;


### PR DESCRIPTION
## Summary

Issue #161 identified two problems:

1. **Server catch block returning an incomplete fallback object** — `fluxVersion`, `gyreVersion`, `availableClusters`, and `user` were missing or `undefined` in the error path.
2. **Layout Props type contract not reflecting the guaranteed shape** — `fluxVersion` was declared optional and `gyreVersion` was absent entirely from the Props interface.

**Problem 1 is already resolved on `main`** via earlier commits:
- `fix(layout): set default fluxVersion in error state`
- `refactor(layout): extract DEFAULT_FLUX_VERSION constant`

The catch block in `src/routes/+layout.server.ts` now returns the full shape matching the success path:
```ts
return {
  health: {
    connected: false,
    clusterName: undefined,
    availableClusters: [],
    error: error instanceof Error ? error.message : 'Failed to connect to cluster API'
  },
  fluxVersion: DEFAULT_FLUX_VERSION,
  gyreVersion: pkg.version,
  user: serializeUser(locals.user)
};
```

**This PR resolves Problem 2** by tightening the `+layout.svelte` Props interface to match what the server guarantees:
- `fluxVersion?: string` → `fluxVersion: string` (always provided, never undefined)
- Added `gyreVersion: string` (was missing from the Props type entirely)

## Test plan

- [x] `bun run format` — no changes
- [x] `bun run check` — 0 errors, 0 warnings
- [x] `bun run lint` — 0 errors, 0 warnings

Closes #161