### PR TITLE
feat(polling): add targeted auto-refresh to resource detail page

### DIFF
--- a/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
+++ b/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto, invalidate } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { eventsStore } from '$lib/stores/events.svelte';
+	import { createAutoRefresh } from '$lib/utils/polling.svelte';
 	import { onMount } from 'svelte';
 	import StatusBadge from '$lib/components/flux/StatusBadge.svelte';
 	import ActionButtons from '$lib/components/flux/ActionButtons.svelte';
@@ -72,6 +73,16 @@
 	const resource = $derived(
 		resourceCache.getResource(data.resourceType, data.namespace, data.name) || data.resource
 	);
+
+	// Auto-refresh setup with targeted invalidation
+	createAutoRefresh({
+		invalidate: async () => {
+			await Promise.all([
+				invalidate(`flux:resource:${data.resourceType}:${data.namespace}:${data.name}`),
+				invalidate('gyre:layout')
+			]);
+		}
+	});
 
 	// Sync initial data to cache on mount
 	onMount(() => {


### PR DESCRIPTION
## Summary

- Extends targeted invalidation to the resource detail page (`[type]/[namespace]/[name]/+page.svelte`)
- `createAutoRefresh` now uses `flux:resource:<type>:<ns>:<name>` and `gyre:layout` keys instead of falling back to `invalidateAll()`
- The auto-refresh user preference now applies consistently across both the resource list and detail pages

## Context

The core work for this issue was already done in #148 (commit `66de4a8`) which added the `invalidate` option to `createAutoRefresh` and applied it to the resource list page. This PR completes the effort by extending targeted invalidation to the resource detail page, which was previously missing `createAutoRefresh` entirely.

## Test plan

- [x] Enable auto-refresh in preferences
- [x] Navigate to a resource detail page (`/resources/<type>/<ns>/<name>`)
- [x] Verify the page refreshes at the configured interval without triggering unrelated load functions (admin, other resource types, etc.)
- [x] Verify the layout health/version also refreshes alongside the resource detail

Closes #162.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource pages now automatically refresh when data is updated, ensuring you always see the latest information without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->