### PR TITLE
feat(resources): add live Kubernetes object tree graph

### DIFF
--- a/src/lib/components/flux/ResourceGraph.svelte
+++ b/src/lib/components/flux/ResourceGraph.svelte
@@ -1,0 +1,578 @@
+<script lang="ts">
+	import type { ResourceHealth, GraphNode } from '$lib/types/view';
+	import { SvelteSet } from 'svelte/reactivity';
+
+	interface Props {
+		root: GraphNode;
+	}
+
+	let { root }: Props = $props();
+
+	// --- Layout constants ---
+	const NODE_W = 190;
+	const NODE_H = 64;
+	const H_GAP = 28;
+	const V_GAP = 72;
+
+	// --- Zoom / pan state ---
+	let svgEl = $state<SVGSVGElement | null>(null);
+	let transform = $state({ x: 40, y: 40, scale: 1 });
+	let isPanning = $state(false);
+	let panStart = $state({ x: 0, y: 0, tx: 0, ty: 0 });
+
+	// Collapsed node IDs
+	let collapsed = new SvelteSet<string>();
+
+	// Selected node
+	let selectedNode = $state<GraphNode | null>(null);
+
+	// --- Layout computation ---
+	interface LayoutNode {
+		node: GraphNode;
+		x: number;
+		y: number;
+		children: LayoutNode[];
+	}
+
+	function subtreeWidth(node: GraphNode): number {
+		if (collapsed.has(node.id) || node.children.length === 0) return NODE_W;
+		const total =
+			node.children.reduce((s, c) => s + subtreeWidth(c), 0) +
+			H_GAP * (node.children.length - 1);
+		return Math.max(NODE_W, total);
+	}
+
+	function buildLayout(node: GraphNode, xOffset: number, depth: number): LayoutNode {
+		const width = subtreeWidth(node);
+		const cx = xOffset + width / 2;
+		const cy = depth * (NODE_H + V_GAP);
+
+		const layout: LayoutNode = {
+			node,
+			x: cx - NODE_W / 2,
+			y: cy,
+			children: []
+		};
+
+		if (!collapsed.has(node.id) && node.children.length > 0) {
+			let childX = xOffset;
+			for (const child of node.children) {
+				const cw = subtreeWidth(child);
+				layout.children.push(buildLayout(child, childX, depth + 1));
+				childX += cw + H_GAP;
+			}
+		}
+
+		return layout;
+	}
+
+	function collectNodes(layout: LayoutNode, out: LayoutNode[] = []): LayoutNode[] {
+		out.push(layout);
+		for (const c of layout.children) collectNodes(c, out);
+		return out;
+	}
+
+	interface Edge {
+		x1: number;
+		y1: number;
+		x2: number;
+		y2: number;
+	}
+
+	function collectEdges(layout: LayoutNode, out: Edge[] = []): Edge[] {
+		for (const c of layout.children) {
+			out.push({
+				x1: layout.x + NODE_W / 2,
+				y1: layout.y + NODE_H,
+				x2: c.x + NODE_W / 2,
+				y2: c.y
+			});
+			collectEdges(c, out);
+		}
+		return out;
+	}
+
+	const layout = $derived(buildLayout(root, 0, 0));
+	const allNodes = $derived(collectNodes(layout));
+	const allEdges = $derived(collectEdges(layout));
+
+	const canvasW = $derived(
+		allNodes.reduce((m, n) => Math.max(m, n.x + NODE_W), 0) + 40
+	);
+	const canvasH = $derived(
+		allNodes.reduce((m, n) => Math.max(m, n.y + NODE_H), 0) + 40
+	);
+
+	// --- Health colors ---
+	const healthBg: Record<ResourceHealth, string> = {
+		healthy: '#16a34a',
+		progressing: '#d97706',
+		failed: '#dc2626',
+		suspended: '#6b7280',
+		unknown: '#6b7280'
+	};
+
+	const healthBgLight: Record<ResourceHealth, string> = {
+		healthy: '#f0fdf4',
+		progressing: '#fffbeb',
+		failed: '#fef2f2',
+		suspended: '#f9fafb',
+		unknown: '#f9fafb'
+	};
+
+	const healthBgDark: Record<ResourceHealth, string> = {
+		healthy: '#14532d',
+		progressing: '#451a03',
+		failed: '#450a0a',
+		suspended: '#1f2937',
+		unknown: '#1f2937'
+	};
+
+	const healthText: Record<ResourceHealth, string> = {
+		healthy: '#15803d',
+		progressing: '#b45309',
+		failed: '#b91c1c',
+		suspended: '#4b5563',
+		unknown: '#4b5563'
+	};
+
+	// Kind icons (emoji fallbacks for SVG)
+	const kindIcon: Record<string, string> = {
+		Kustomization: '⚙',
+		HelmRelease: '⎈',
+		Deployment: '📦',
+		StatefulSet: '🗃',
+		DaemonSet: '🔁',
+		ReplicaSet: '📋',
+		Pod: '🫙',
+		Service: '🌐',
+		ConfigMap: '📄',
+		Secret: '🔑',
+		ServiceAccount: '👤',
+		Namespace: '📁',
+		Ingress: '↗',
+		PersistentVolumeClaim: '💾'
+	};
+
+	// --- Zoom / pan handlers ---
+	function onWheel(e: WheelEvent) {
+		e.preventDefault();
+		const factor = e.deltaY < 0 ? 1.1 : 0.9;
+		const newScale = Math.max(0.2, Math.min(3, transform.scale * factor));
+
+		// Zoom toward cursor
+		const rect = svgEl!.getBoundingClientRect();
+		const mx = e.clientX - rect.left;
+		const my = e.clientY - rect.top;
+
+		transform = {
+			x: mx - (mx - transform.x) * (newScale / transform.scale),
+			y: my - (my - transform.y) * (newScale / transform.scale),
+			scale: newScale
+		};
+	}
+
+	function onMouseDown(e: MouseEvent) {
+		if (e.button !== 0) return;
+		isPanning = true;
+		panStart = { x: e.clientX, y: e.clientY, tx: transform.x, ty: transform.y };
+	}
+
+	function onMouseMove(e: MouseEvent) {
+		if (!isPanning) return;
+		transform = {
+			...transform,
+			x: panStart.tx + (e.clientX - panStart.x),
+			y: panStart.ty + (e.clientY - panStart.y)
+		};
+	}
+
+	function onMouseUp() {
+		isPanning = false;
+	}
+
+	function fitToView() {
+		if (!svgEl || allNodes.length === 0) return;
+		const rect = svgEl.getBoundingClientRect();
+		const padding = 40;
+		const scaleX = (rect.width - padding * 2) / canvasW;
+		const scaleY = (rect.height - padding * 2) / canvasH;
+		const scale = Math.min(scaleX, scaleY, 1);
+		transform = {
+			x: padding + (rect.width - padding * 2 - canvasW * scale) / 2,
+			y: padding,
+			scale
+		};
+	}
+
+	// Fit to view on root change
+	$effect(() => {
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+		root; // reactive dependency
+		setTimeout(fitToView, 50);
+	});
+
+	function toggleCollapse(nodeId: string) {
+		if (collapsed.has(nodeId)) {
+			collapsed.delete(nodeId);
+		} else {
+			collapsed.add(nodeId);
+		}
+	}
+
+	function selectNode(node: GraphNode, e: MouseEvent) {
+		e.stopPropagation();
+		selectedNode = selectedNode?.id === node.id ? null : node;
+	}
+
+	function conditionBadge(status: string) {
+		if (status === 'True') return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300';
+		if (status === 'False') return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300';
+		return 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
+	}
+
+	let isDark = $state(false);
+	$effect(() => {
+		isDark = window.matchMedia('(prefers-color-scheme: dark)').matches ||
+			document.documentElement.classList.contains('dark');
+	});
+</script>
+
+<div class="flex h-full flex-col gap-0">
+	<!-- Toolbar -->
+	<div
+		class="flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700"
+	>
+		<div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+			<span>{allNodes.length} objects</span>
+			<span>·</span>
+			<span>Scroll to zoom · Drag to pan · Click node for details</span>
+		</div>
+		<div class="flex items-center gap-2">
+			<button
+				type="button"
+				onclick={fitToView}
+				class="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+			>
+				Fit to view
+			</button>
+			<button
+				type="button"
+				onclick={() => (transform = { ...transform, scale: Math.min(3, transform.scale * 1.2) })}
+				class="rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+				aria-label="Zoom in"
+			>
+				＋
+			</button>
+			<button
+				type="button"
+				onclick={() => (transform = { ...transform, scale: Math.max(0.2, transform.scale * 0.8) })}
+				class="rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+				aria-label="Zoom out"
+			>
+				－
+			</button>
+		</div>
+	</div>
+
+	<!-- Main area: graph + detail panel -->
+	<div class="flex min-h-0 flex-1">
+		<!-- SVG canvas -->
+		<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+		<svg
+			bind:this={svgEl}
+			class="flex-1 cursor-grab bg-gray-50 dark:bg-gray-900 {isPanning ? 'cursor-grabbing' : ''}"
+			role="application"
+			aria-label="Kubernetes object tree graph"
+			onwheel={onWheel}
+			onmousedown={onMouseDown}
+			onmousemove={onMouseMove}
+			onmouseup={onMouseUp}
+			onmouseleave={onMouseUp}
+			onclick={() => (selectedNode = null)}
+			onkeydown={(e) => e.key === 'Escape' && (selectedNode = null)}
+		>
+			<defs>
+				<marker id="arrow" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+					<path d="M0,0 L0,6 L6,3 z" fill="#d1d5db" />
+				</marker>
+			</defs>
+
+			<g transform="translate({transform.x},{transform.y}) scale({transform.scale})">
+				<!-- Edges -->
+				{#each allEdges as edge, i (i)}
+					{@const mx = (edge.x1 + edge.x2) / 2}
+					{@const my1 = edge.y1 + (edge.y2 - edge.y1) * 0.4}
+					{@const my2 = edge.y1 + (edge.y2 - edge.y1) * 0.6}
+					<path
+						d="M{edge.x1},{edge.y1} C{edge.x1},{my1} {edge.x2},{my2} {edge.x2},{edge.y2}"
+						fill="none"
+						stroke="#d1d5db"
+						stroke-width="1.5"
+						class="dark:stroke-gray-600"
+					/>
+					<!-- suppress unused mx -->
+					{#if false}{mx}{/if}
+				{/each}
+
+				<!-- Nodes -->
+				{#each allNodes as ln (ln.node.id)}
+					{@const n = ln.node}
+					{@const isSelected = selectedNode?.id === n.id}
+					{@const hasChildren = n.children.length > 0}
+					{@const isCollapsed = collapsed.has(n.id)}
+					{@const bg = isDark ? healthBgDark[n.health] : healthBgLight[n.health]}
+					{@const border = healthBg[n.health]}
+					{@const textCol = healthText[n.health]}
+					{@const icon = kindIcon[n.kind] || '◆'}
+
+					<!-- Node card -->
+					<g
+						transform="translate({ln.x},{ln.y})"
+						role="button"
+						tabindex="0"
+						aria-label="{n.kind} {n.name}"
+						onclick={(e) => selectNode(n, e)}
+						onkeydown={(e) => e.key === 'Enter' && selectNode(n, e as unknown as MouseEvent)}
+						style="cursor: pointer"
+					>
+						<!-- Background rect -->
+						<rect
+							width={NODE_W}
+							height={NODE_H}
+							rx="8"
+							fill={bg}
+							stroke={isSelected ? '#3b82f6' : border}
+							stroke-width={isSelected ? 2.5 : 1.5}
+							filter={isSelected ? 'drop-shadow(0 0 6px rgba(59,130,246,0.5))' : ''}
+						/>
+
+						<!-- Status stripe on left -->
+						<rect x="0" y="0" width="4" height={NODE_H} rx="8" fill={border} />
+						<rect x="0" y="8" width="4" height={NODE_H - 16} fill={border} />
+
+						<!-- Icon -->
+						<text
+							x="18"
+							y={NODE_H / 2 + 5}
+							font-size="16"
+							text-anchor="middle"
+							dominant-baseline="middle"
+							style="user-select: none"
+						>
+							{icon}
+						</text>
+
+						<!-- Kind label -->
+						<text
+							x="32"
+							y="18"
+							font-size="9"
+							fill={textCol}
+							font-weight="600"
+							font-family="ui-monospace, monospace"
+							style="user-select: none; text-transform: uppercase; letter-spacing: 0.05em"
+						>
+							{n.kind}
+						</text>
+
+						<!-- Resource name -->
+						<text
+							x="32"
+							y="35"
+							font-size="12"
+							fill={isDark ? '#f3f4f6' : '#111827'}
+							font-weight="500"
+							font-family="ui-sans-serif, sans-serif"
+							style="user-select: none"
+						>
+							{n.name.length > 18 ? n.name.slice(0, 17) + '…' : n.name}
+						</text>
+
+						<!-- Namespace (if different from root) -->
+						{#if n.namespace && n.namespace !== root.namespace}
+							<text
+								x="32"
+								y="50"
+								font-size="9"
+								fill={isDark ? '#9ca3af' : '#6b7280'}
+								font-family="ui-sans-serif, sans-serif"
+								style="user-select: none"
+							>
+								{n.namespace}
+							</text>
+						{/if}
+
+						<!-- Health badge -->
+						<text
+							x={NODE_W - 10}
+							y={NODE_H / 2 + 4}
+							font-size="9"
+							fill={textCol}
+							font-weight="600"
+							text-anchor="end"
+							font-family="ui-sans-serif, sans-serif"
+							style="user-select: none"
+						>
+							{n.health === 'healthy' ? '✓' : n.health === 'failed' ? '✗' : n.health === 'progressing' ? '◐' : '—'}
+						</text>
+
+						<!-- Collapse/expand toggle for nodes with children -->
+						{#if hasChildren}
+							<g
+								role="button"
+								tabindex="0"
+								aria-label={isCollapsed ? 'Expand' : 'Collapse'}
+								transform="translate({NODE_W / 2 - 8},{NODE_H - 2})"
+								onclick={(e) => {
+									e.stopPropagation();
+									toggleCollapse(n.id);
+								}}
+								onkeydown={(e) => {
+									if (e.key === 'Enter') {
+										e.stopPropagation();
+										toggleCollapse(n.id);
+									}
+								}}
+								style="cursor: pointer"
+							>
+								<circle cx="8" cy="6" r="7" fill={isDark ? '#374151' : '#e5e7eb'} />
+								<text
+									x="8"
+									y="10"
+									font-size="9"
+									text-anchor="middle"
+									fill={isDark ? '#d1d5db' : '#4b5563'}
+									font-weight="bold"
+									style="user-select: none"
+								>
+									{isCollapsed ? '+' : '−'}
+								</text>
+							</g>
+						{/if}
+					</g>
+				{/each}
+			</g>
+		</svg>
+
+		<!-- Detail panel -->
+		{#if selectedNode}
+			{@const n = selectedNode}
+			<div
+				class="w-72 shrink-0 overflow-y-auto border-l border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+			>
+				<div class="border-b border-gray-200 p-4 dark:border-gray-700">
+					<div class="flex items-start justify-between">
+						<div>
+							<div class="font-mono text-xs font-semibold tracking-widest text-gray-400 uppercase">
+								{n.kind}
+							</div>
+							<div class="mt-0.5 break-all font-semibold text-gray-900 dark:text-gray-100">
+								{n.name}
+							</div>
+							{#if n.namespace}
+								<div class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{n.namespace}</div>
+							{/if}
+						</div>
+						<button
+							type="button"
+							onclick={() => (selectedNode = null)}
+							class="rounded p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+							aria-label="Close panel"
+						>
+							<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M6 18L18 6M6 6l12 12"
+								/>
+							</svg>
+						</button>
+					</div>
+
+					<!-- Health badge -->
+					<span
+						class="mt-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize {n.health ===
+						'healthy'
+							? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300'
+							: n.health === 'failed'
+								? 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
+								: n.health === 'progressing'
+									? 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300'
+									: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'}"
+					>
+						{n.health}
+					</span>
+				</div>
+
+				<!-- Details -->
+				{#if Object.keys(n.details).length > 0}
+					<div class="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+						<h4 class="mb-2 text-xs font-semibold text-gray-500 uppercase dark:text-gray-400">
+							Details
+						</h4>
+						<dl class="space-y-1.5">
+							{#each Object.entries(n.details) as [k, v] (k)}
+								{#if v !== undefined && v !== null}
+									<div class="flex items-start justify-between gap-2 text-xs">
+										<dt class="font-medium text-gray-500 capitalize dark:text-gray-400">
+											{k.replace(/([A-Z])/g, ' $1').toLowerCase()}
+										</dt>
+										<dd class="break-all text-right font-mono text-gray-900 dark:text-gray-100">
+											{String(v)}
+										</dd>
+									</div>
+								{/if}
+							{/each}
+						</dl>
+					</div>
+				{/if}
+
+				<!-- Conditions -->
+				{#if n.conditions.length > 0}
+					<div class="px-4 py-3">
+						<h4 class="mb-2 text-xs font-semibold text-gray-500 uppercase dark:text-gray-400">
+							Conditions
+						</h4>
+						<div class="space-y-2">
+							{#each n.conditions as cond (cond.type)}
+								<div class="rounded-md border border-gray-100 p-2 dark:border-gray-700">
+									<div class="flex items-center justify-between gap-2">
+										<span class="text-xs font-medium text-gray-700 dark:text-gray-300">
+											{cond.type}
+										</span>
+										<span
+											class="rounded-full px-1.5 py-0.5 text-[10px] font-semibold {conditionBadge(cond.status)}"
+										>
+											{cond.status}
+										</span>
+									</div>
+									{#if cond.reason}
+										<div class="mt-1 font-mono text-[10px] text-gray-500 dark:text-gray-400">
+											{cond.reason}
+										</div>
+									{/if}
+									{#if cond.message}
+										<div class="mt-1 text-[10px] text-gray-500 dark:text-gray-400">
+											{cond.message}
+										</div>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
+
+				<!-- Children count -->
+				{#if n.children.length > 0}
+					<div class="border-t border-gray-200 px-4 py-3 dark:border-gray-700">
+						<div class="text-xs text-gray-500 dark:text-gray-400">
+							{n.children.length} child resource{n.children.length !== 1 ? 's' : ''}
+						</div>
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/types/view.ts
+++ b/src/lib/types/view.ts
@@ -9,6 +9,27 @@ export type ViewMode = 'table' | 'grid';
 export type ResourceHealth = 'healthy' | 'progressing' | 'failed' | 'suspended' | 'unknown';
 
 /**
+ * A node in the Kubernetes object tree graph (for Kustomization / HelmRelease tree view)
+ */
+export interface GraphNode {
+	id: string;
+	kind: string;
+	name: string;
+	namespace: string;
+	group: string;
+	version: string;
+	health: ResourceHealth;
+	conditions: Array<{
+		type: string;
+		status: string;
+		reason?: string;
+		message?: string;
+	}>;
+	details: Record<string, unknown>;
+	children: GraphNode[];
+}
+
+/**
  * User preferences for UI
  */
 export interface ViewPreferences {

--- a/src/routes/api/flux/[resourceType]/[namespace]/[name]/tree/+server.ts
+++ b/src/routes/api/flux/[resourceType]/[namespace]/[name]/tree/+server.ts
@@ -1,0 +1,364 @@
+import { json, error } from '@sveltejs/kit';
+import { z } from '$lib/server/openapi';
+import type { RequestHandler } from './$types';
+import {
+	getFluxResource,
+	getCoreV1Api,
+	getAppsV1Api,
+	type ReqCache
+} from '$lib/server/kubernetes/client.js';
+import {
+	getResourceTypeByPlural,
+	getAllResourcePlurals,
+	type FluxResourceType
+} from '$lib/server/kubernetes/flux/resources.js';
+import { parseInventory } from '$lib/server/kubernetes/flux/inventory.js';
+import { getGenericResource } from '$lib/server/kubernetes/client.js';
+import { handleApiError } from '$lib/server/kubernetes/errors.js';
+import { requirePermission } from '$lib/server/rbac.js';
+import type { ResourceHealth, GraphNode } from '$lib/types/view';
+
+export const _metadata = {
+	GET: {
+		summary: 'Get Kubernetes object tree for a Flux resource',
+		description:
+			'Returns the full managed object tree for a Kustomization or HelmRelease, including all inventory resources and their live health status. Deployments are expanded to include their ReplicaSets and Pods.',
+		tags: ['Flux'],
+		request: {
+			params: z.object({
+				resourceType: z.string().openapi({ example: 'kustomizations' }),
+				namespace: z.string().openapi({ example: 'flux-system' }),
+				name: z.string().openapi({ example: 'my-app' })
+			})
+		},
+		responses: {
+			200: {
+				description: 'Object tree with health status',
+				content: { 'application/json': { schema: z.any() } }
+			},
+			400: { description: 'Invalid resource type or missing cluster context' },
+			401: { description: 'Authentication required' },
+			403: { description: 'Permission denied' },
+			404: { description: 'Resource not found' }
+		}
+	}
+};
+
+const WORKLOAD_KINDS = new Set(['Deployment', 'StatefulSet', 'DaemonSet']);
+
+function getHealthFromConditions(
+	conditions: Array<{ type: string; status: string; reason?: string }>,
+	suspended?: boolean,
+	observedGeneration?: number,
+	generation?: number
+): ResourceHealth {
+	if (suspended) return 'suspended';
+	if (!conditions || conditions.length === 0) return 'unknown';
+
+	const stalled = conditions.find((c) => c.type === 'Stalled' || c.type === 'Failed');
+	if (stalled?.status === 'True') return 'failed';
+
+	if (
+		generation !== undefined &&
+		observedGeneration !== undefined &&
+		observedGeneration < generation
+	) {
+		return 'progressing';
+	}
+
+	for (const type of ['Ready', 'Healthy', 'Succeeded', 'Available']) {
+		const cond = conditions.find((c) => c.type === type);
+		if (!cond) continue;
+		if (cond.status === 'True') return 'healthy';
+		if (cond.status === 'False') {
+			if (
+				cond.reason === 'Progressing' ||
+				cond.reason === 'ProgressingWithRetry' ||
+				cond.reason === 'DependencyNotReady'
+			)
+				return 'progressing';
+			return 'failed';
+		}
+		if (cond.status === 'Unknown') return 'progressing';
+	}
+
+	return 'unknown';
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getWorkloadHealth(resource: any): ResourceHealth {
+	if (resource.spec?.suspend) return 'suspended';
+
+	const kind: string = resource.kind || '';
+	const status = resource.status || {};
+	const conditions = status.conditions || [];
+
+	// Check conditions first
+	const h = getHealthFromConditions(
+		conditions,
+		resource.spec?.suspend,
+		status.observedGeneration,
+		resource.metadata?.generation
+	);
+	if (h !== 'unknown') return h;
+
+	// Fallback: replica counts
+	if (kind === 'Deployment' || kind === 'StatefulSet') {
+		const desired = resource.spec?.replicas ?? status.replicas ?? 0;
+		const ready = status.readyReplicas ?? 0;
+		if (desired === 0) return 'healthy';
+		if (ready >= desired) return 'healthy';
+		if (ready > 0) return 'progressing';
+		return 'failed';
+	}
+
+	if (kind === 'DaemonSet') {
+		const desired = status.desiredNumberScheduled ?? 0;
+		const ready = status.numberReady ?? 0;
+		if (desired === 0) return 'healthy';
+		if (ready >= desired) return 'healthy';
+		return 'progressing';
+	}
+
+	if (kind === 'ReplicaSet') {
+		const desired = resource.spec?.replicas ?? 0;
+		if (desired === 0) return 'healthy';
+		const ready = status.readyReplicas ?? 0;
+		return ready >= desired ? 'healthy' : 'progressing';
+	}
+
+	if (kind === 'Pod') {
+		const phase: string = status.phase || '';
+		if (phase === 'Running' || phase === 'Succeeded') return 'healthy';
+		if (phase === 'Failed') return 'failed';
+		if (phase === 'Pending') return 'progressing';
+		return 'unknown';
+	}
+
+	return 'unknown';
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resourceToNode(resource: any, group: string, version: string): GraphNode {
+	const kind: string = resource.kind || 'Unknown';
+	const name: string = resource.metadata?.name || '';
+	const namespace: string = resource.metadata?.namespace || '';
+	const conditions = resource.status?.conditions || [];
+	const health = getWorkloadHealth(resource);
+
+	const details: Record<string, unknown> = {};
+	if (resource.status?.replicas !== undefined) {
+		details.replicas = resource.status.replicas;
+		details.readyReplicas = resource.status.readyReplicas ?? 0;
+	}
+	if (resource.status?.phase) details.phase = resource.status.phase;
+	if (resource.metadata?.creationTimestamp) details.createdAt = resource.metadata.creationTimestamp;
+
+	return {
+		id: `${namespace}/${kind}/${name}`,
+		kind,
+		name,
+		namespace,
+		group,
+		version,
+		health,
+		conditions,
+		details,
+		children: []
+	};
+}
+
+/**
+ * GET /api/flux/{resourceType}/{namespace}/{name}/tree
+ * Returns the full managed Kubernetes object tree for a Kustomization or HelmRelease.
+ */
+export const GET: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) throw error(401, { message: 'Authentication required' });
+	if (!locals.cluster) throw error(400, { message: 'Cluster context required' });
+
+	const { resourceType, namespace, name } = params;
+
+	const resolvedType: FluxResourceType | undefined = getResourceTypeByPlural(resourceType);
+	if (!resolvedType) {
+		const validPlurals = getAllResourcePlurals();
+		throw error(400, {
+			message: `Invalid resource type: ${resourceType}. Valid types: ${validPlurals.join(', ')}`
+		});
+	}
+
+	// Only Kustomizations and HelmReleases have inventory
+	if (resolvedType !== 'Kustomization' && resolvedType !== 'HelmRelease') {
+		throw error(400, {
+			message: 'Object tree is only available for Kustomizations and HelmReleases'
+		});
+	}
+
+	await requirePermission(locals.user, 'read', resolvedType, namespace, locals.cluster);
+
+	const reqCache: ReqCache = new Map();
+
+	try {
+		const root = await getFluxResource(resolvedType, namespace, name, locals.cluster, reqCache);
+
+		const rootConditions = root.status?.conditions || [];
+		const rootHealth = getHealthFromConditions(
+			rootConditions,
+			root.spec?.suspend as boolean | undefined,
+			root.status?.observedGeneration,
+			root.metadata?.generation
+		);
+
+		const rootNode: GraphNode = {
+			id: `${namespace}/${resolvedType}/${name}`,
+			kind: resolvedType,
+			name,
+			namespace,
+			group:
+				resolvedType === 'Kustomization' ? 'kustomize.toolkit.fluxcd.io' : 'helm.toolkit.fluxcd.io',
+			version: 'v1',
+			health: rootHealth,
+			conditions: rootConditions,
+			details: {
+				revision: root.status?.lastAppliedRevision,
+				interval: root.spec?.interval
+			},
+			children: []
+		};
+
+		const inventoryEntries = root.status?.inventory?.entries || [];
+		if (inventoryEntries.length === 0) {
+			return json({ root: rootNode });
+		}
+
+		const parsed = parseInventory(inventoryEntries);
+		const capped = parsed.slice(0, 100); // limit to 100 resources
+
+		// Fetch all inventory resources in parallel
+		const inventoryResources = await Promise.allSettled(
+			capped.map(async (inv) => {
+				const res = await getGenericResource(
+					inv.group,
+					inv.kind,
+					inv.namespace,
+					inv.name,
+					locals.cluster,
+					reqCache
+				);
+				return { inv, res };
+			})
+		);
+
+		// Collect namespaces that contain workloads for batch listing
+		const workloadNamespaces = new Set<string>();
+		for (const result of inventoryResources) {
+			if (result.status === 'fulfilled') {
+				const { inv, res } = result.value;
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const resAny = res as any;
+				const kind: string = resAny.kind || inv.kind;
+				if (WORKLOAD_KINDS.has(kind) && inv.namespace) {
+					workloadNamespaces.add(inv.namespace);
+				}
+			}
+		}
+
+		// Batch list ReplicaSets and Pods per namespace
+		const replicaSetsByNs = new Map<string, unknown[]>();
+		const podsByNs = new Map<string, unknown[]>();
+
+		if (workloadNamespaces.size > 0) {
+			const appsApi = await getAppsV1Api(locals.cluster, reqCache);
+			const coreApi = await getCoreV1Api(locals.cluster, reqCache);
+
+			await Promise.allSettled(
+				[...workloadNamespaces].map(async (ns) => {
+					const [rsList, podList] = await Promise.allSettled([
+						appsApi.listNamespacedReplicaSet({ namespace: ns }),
+						coreApi.listNamespacedPod({ namespace: ns })
+					]);
+
+					if (rsList.status === 'fulfilled') {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						replicaSetsByNs.set(ns, (rsList.value as any).items || []);
+					}
+					if (podList.status === 'fulfilled') {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						podsByNs.set(ns, (podList.value as any).items || []);
+					}
+				})
+			);
+		}
+
+		// Build child nodes
+		for (const result of inventoryResources) {
+			if (result.status !== 'fulfilled') continue;
+			const { inv, res } = result.value;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const resAny = res as any;
+			const kind: string = resAny.kind || inv.kind;
+
+			const node = resourceToNode(resAny, inv.group, inv.version);
+
+			// Expand workloads → ReplicaSets → Pods
+			if (WORKLOAD_KINDS.has(kind) && inv.namespace) {
+				const uid: string = resAny.metadata?.uid || '';
+				const rsItems = replicaSetsByNs.get(inv.namespace) || [];
+				const podItems = podsByNs.get(inv.namespace) || [];
+
+				// Find ReplicaSets owned by this workload
+				const ownedRS = rsItems.filter(
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					(rs: any) =>
+						(rs.metadata?.ownerReferences || []).some(
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							(ref: any) => ref.uid === uid
+						)
+				);
+
+				for (const rs of ownedRS) {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					const rsAny = rs as any;
+					const rsNode = resourceToNode(rsAny, 'apps', 'v1');
+					const rsUid: string = rsAny.metadata?.uid || '';
+
+					// Find Pods owned by this ReplicaSet
+					const ownedPods = podItems.filter(
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						(pod: any) =>
+							(pod.metadata?.ownerReferences || []).some(
+								// eslint-disable-next-line @typescript-eslint/no-explicit-any
+								(ref: any) => ref.uid === rsUid
+							)
+					);
+
+					// Cap pods per ReplicaSet at 10
+					for (const pod of ownedPods.slice(0, 10)) {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						rsNode.children.push(resourceToNode(pod as any, '', 'v1'));
+					}
+
+					node.children.push(rsNode);
+				}
+			}
+
+			rootNode.children.push(node);
+		}
+
+		// Sort children by health (failed first, then progressing, then healthy)
+		const healthOrder: Record<ResourceHealth, number> = {
+			failed: 0,
+			progressing: 1,
+			unknown: 2,
+			suspended: 3,
+			healthy: 4
+		};
+		rootNode.children.sort((a, b) => healthOrder[a.health] - healthOrder[b.health]);
+
+		return json({ root: rootNode });
+	} catch (err) {
+		throw handleApiError(
+			err,
+			`Error fetching object tree for ${resolvedType} ${namespace}/${name}`
+		);
+	}
+};

--- a/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
+++ b/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
@@ -23,10 +23,12 @@
 	import ImagePolicyDetail from '$lib/components/flux/resources/ImagePolicyDetail.svelte';
 	import ImageUpdateAutomationDetail from '$lib/components/flux/resources/ImageUpdateAutomationDetail.svelte';
 	import InventoryList from '$lib/components/flux/resources/InventoryList.svelte';
+	import ResourceGraph from '$lib/components/flux/ResourceGraph.svelte';
 	import ResourceDiffViewer from '$lib/components/flux/ResourceDiffViewer.svelte';
 	import VersionHistory from '$lib/components/flux/VersionHistory.svelte';
 	import CodeViewer from '$lib/components/common/CodeViewer.svelte';
 	import type { FluxResource, K8sCondition } from '$lib/types/flux';
+	import type { GraphNode } from '$lib/types/view';
 	import { resourceCache } from '$lib/stores/resourceCache.svelte';
 	import { sanitizeResource } from '$lib/utils/kubernetes';
 
@@ -101,7 +103,7 @@
 		return unsubscribe;
 	});
 
-	type TabId = 'overview' | 'spec' | 'status' | 'events' | 'logs' | 'history' | 'diff' | 'yaml';
+	type TabId = 'overview' | 'spec' | 'status' | 'events' | 'logs' | 'history' | 'diff' | 'graph' | 'yaml';
 
 	let activeTab = $state<TabId>('overview');
 
@@ -188,6 +190,12 @@
 	let historyLoading = $state(false);
 	let historyFetched = $state(false);
 
+	// Graph state
+	let graphRoot = $state<GraphNode | null>(null);
+	let graphLoading = $state(false);
+	let graphError = $state<string | null>(null);
+	let graphFetched = $state(false);
+
 	// Detect resource type for specialized views
 	const isGitRepository = $derived(data.resourceType === 'gitrepositories');
 	const isHelmRelease = $derived(data.resourceType === 'helmreleases');
@@ -221,6 +229,11 @@
 		// Drift detection is only available for Kustomizations
 		if (isKustomization) {
 			base.push({ id: 'diff', label: 'Drift (Diff)' });
+		}
+
+		// Object tree graph is available for Kustomizations and HelmReleases
+		if (isKustomization || isHelmRelease) {
+			base.push({ id: 'graph', label: 'Graph' });
 		}
 
 		base.push({ id: 'yaml', label: 'YAML' });
@@ -346,6 +359,32 @@
 		}
 	}
 
+	async function fetchGraph() {
+		if (graphFetched) return;
+
+		graphLoading = true;
+		graphError = null;
+
+		try {
+			const response = await fetch(
+				`/api/flux/${data.resourceType}/${data.namespace}/${data.name}/tree`
+			);
+
+			if (!response.ok) {
+				const errData = await response.json().catch(() => ({ message: response.statusText }));
+				throw new Error(errData.message || `Failed to fetch object tree: ${response.statusText}`);
+			}
+
+			const result = await response.json();
+			graphRoot = result.root || null;
+			graphFetched = true;
+		} catch (err) {
+			graphError = err instanceof Error ? err.message : 'Failed to load object tree';
+		} finally {
+			graphLoading = false;
+		}
+	}
+
 	async function handleRollback(historyId: string, revision: string | null) {
 		const displayRevision = revision ? revision.slice(0, 8) : historyId.slice(0, 8);
 		if (!confirm(`Are you sure you want to rollback to ${displayRevision}?`)) return;
@@ -400,6 +439,12 @@
 	$effect(() => {
 		if (activeTab === 'diff' && !diffsFetched) {
 			fetchDiff();
+		}
+	});
+
+	$effect(() => {
+		if (activeTab === 'graph' && !graphFetched) {
+			fetchGraph();
 		}
 	});
 
@@ -841,6 +886,86 @@
 					</div>
 				{:else}
 					<ResourceDiffViewer {diffs} />
+				{/if}
+			</div>
+		{:else if activeTab === 'graph'}
+			<div
+				class="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+				style="height: 600px"
+			>
+				{#if graphLoading}
+					<div class="flex h-full flex-col items-center justify-center gap-4">
+						<div
+							class="h-10 w-10 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"
+						></div>
+						<p class="animate-pulse text-sm text-gray-500">Loading object tree...</p>
+					</div>
+				{:else if graphError}
+					<div class="flex h-full items-center justify-center p-6">
+						<div
+							class="max-w-md rounded-md border border-red-200 bg-red-50 p-6 dark:border-red-900/50 dark:bg-red-900/20"
+						>
+							<div
+								class="mb-2 flex items-center gap-2 text-base font-semibold text-red-700 dark:text-red-400"
+							>
+								<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+									/>
+								</svg>
+								Failed to load object tree
+							</div>
+							<p class="text-sm text-red-600 dark:text-red-300">{graphError}</p>
+							<button
+								type="button"
+								class="mt-4 inline-flex items-center gap-1.5 rounded-md bg-red-100 px-3 py-1.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-200 dark:bg-red-900/30 dark:text-red-300"
+								onclick={() => {
+									graphFetched = false;
+									fetchGraph();
+								}}
+							>
+								Retry
+							</button>
+						</div>
+					</div>
+				{:else if !graphRoot}
+					<div
+						class="flex h-full items-center justify-center py-12 text-gray-500 dark:text-gray-400"
+					>
+						No managed resources found for this resource.
+					</div>
+				{:else}
+					<div class="flex h-full flex-col">
+						<div
+							class="flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700"
+						>
+							<h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Object Tree</h3>
+							<button
+								type="button"
+								class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+								onclick={() => {
+									graphFetched = false;
+									fetchGraph();
+								}}
+							>
+								<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+									/>
+								</svg>
+								Refresh
+							</button>
+						</div>
+						<div class="min-h-0 flex-1">
+							<ResourceGraph root={graphRoot} />
+						</div>
+					</div>
 				{/if}
 			</div>
 		{:else if activeTab === 'yaml'}


### PR DESCRIPTION
## Summary

Implements the ArgoCD-style interactive dependency graph requested in #134.

- **New API endpoint** `GET /api/flux/{type}/{namespace}/{name}/tree` — fetches the full managed object tree for a Kustomization or HelmRelease. Inventory items are fetched in parallel; workloads (Deployment, StatefulSet, DaemonSet) are expanded to their ReplicaSets → Pods using `ownerReferences` matching.
- **`ResourceGraph` component** — pure SVG interactive graph with:
  - Top-down hierarchical tree layout (custom Reingold-Tilford-style algorithm, no extra dependencies)
  - Color-coded nodes by live health: green (healthy), amber (progressing), red (failed), gray (suspended/unknown)
  - Zoom (scroll wheel) and pan (drag) with fit-to-view button
  - Click any node to open a detail panel showing conditions, replica counts, phase, etc.
  - Collapse/expand subtrees via a toggle button on each node
- **"Graph" tab** added to the resource detail page for Kustomizations and HelmReleases (lazy-loaded on first activation with a Refresh button)
- **`GraphNode` type** added to `$lib/types/view` as a shared client/server type

## Test plan

- [ ] Open a Kustomization or HelmRelease detail page and click the **Graph** tab
- [ ] Verify the root node appears with its inventory resources as children
- [ ] Verify Deployments expand to show ReplicaSets and Pods
- [ ] Verify health colors match actual cluster state (healthy=green, failed=red, etc.)
- [ ] Verify zoom, pan, and fit-to-view controls work
- [ ] Click a node and verify the detail panel shows conditions correctly
- [ ] Click the collapse toggle on a node and verify children hide/show
- [ ] Click Refresh and verify the tree reloads
- [ ] Try on a resource type that is not Kustomization or HelmRelease — Graph tab should not appear

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive resource graph visualization for Kustomizations and HelmReleases with zoom, pan, and node selection capabilities.
  * Graph displays health-based node coloring, status indicators, and hierarchical relationships with collapsible subtrees.
  * Side panel shows detailed information for selected nodes including health status, metadata, and conditions.
  * Keyboard accessibility with Enter to toggle node expansion and Escape to clear selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->