### PR TITLE
perf(rbac): add in-memory permission cache with TTL

### DIFF
--- a/src/lib/server/rbac-defaults.ts
+++ b/src/lib/server/rbac-defaults.ts
@@ -6,6 +6,7 @@
 import { getDbSync } from './db/index.js';
 import { rbacPolicies, rbacBindings, type User } from './db/schema.js';
 import { eq, and } from 'drizzle-orm';
+import { invalidateUserPermissionCache } from './rbac.js';
 
 /**
  * Default policy IDs (deterministic UUIDs for idempotency)
@@ -108,6 +109,7 @@ export async function bindUserToDefaultPolicies(user: User): Promise<void> {
 			});
 		}
 	}
+	invalidateUserPermissionCache(user.id);
 }
 
 /**
@@ -151,6 +153,7 @@ export async function syncUserPolicyBindings(user: User): Promise<void> {
 		// Remove all bindings for admin users
 		const db = getDbSync();
 		await db.delete(rbacBindings).where(eq(rbacBindings.userId, user.id));
+		invalidateUserPermissionCache(user.id);
 		return;
 	}
 
@@ -162,5 +165,6 @@ export async function syncUserPolicyBindings(user: User): Promise<void> {
 	// Add correct bindings for current role
 	await bindUserToDefaultPolicies(user);
 
+	invalidateUserPermissionCache(user.id);
 	console.log(`   ✓ Synced RBAC bindings for user: ${user.username} (${user.role})`);
 }

--- a/src/lib/server/rbac.ts
+++ b/src/lib/server/rbac.ts
@@ -12,6 +12,71 @@ import { eq, and, or, sql, like } from 'drizzle-orm';
  */
 export type RbacAction = 'read' | 'write' | 'admin';
 
+// ---------------------------------------------------------------------------
+// Permission cache
+// ---------------------------------------------------------------------------
+
+interface CacheEntry {
+	result: boolean;
+	expiresAt: number;
+}
+
+/** TTL for cached permission checks: 5 minutes */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Per-user cache: userId → (permKey → CacheEntry) */
+const permissionCache = new Map<string, Map<string, CacheEntry>>();
+
+export const cacheMetrics = {
+	hits: 0,
+	misses: 0,
+	invalidations: 0
+};
+
+function makeCacheKey(
+	action: RbacAction,
+	resourceType?: string,
+	namespace?: string,
+	clusterId?: string
+): string {
+	return `${action}:${resourceType ?? ''}:${namespace ?? ''}:${clusterId ?? ''}`;
+}
+
+function getCached(userId: string, key: string): boolean | undefined {
+	const userCache = permissionCache.get(userId);
+	if (!userCache) return undefined;
+	const entry = userCache.get(key);
+	if (!entry) return undefined;
+	if (Date.now() > entry.expiresAt) {
+		userCache.delete(key);
+		return undefined;
+	}
+	return entry.result;
+}
+
+function setCached(userId: string, key: string, result: boolean): void {
+	let userCache = permissionCache.get(userId);
+	if (!userCache) {
+		userCache = new Map();
+		permissionCache.set(userId, userCache);
+	}
+	userCache.set(key, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+/** Invalidate all cached permissions for a specific user. */
+export function invalidateUserPermissionCache(userId: string): void {
+	if (permissionCache.delete(userId)) {
+		cacheMetrics.invalidations++;
+	}
+}
+
+/** Invalidate the entire permission cache (e.g. when a policy is deleted). */
+export function invalidateAllPermissionCache(): void {
+	const count = permissionCache.size;
+	permissionCache.clear();
+	cacheMetrics.invalidations += count;
+}
+
 /**
  * Check if a user has permission to perform an action on a resource
  *
@@ -31,6 +96,14 @@ export async function checkPermission(
 	if (user.role === 'admin') {
 		return true;
 	}
+
+	const cacheKey = makeCacheKey(action, resourceType, namespace, clusterId);
+	const cached = getCached(user.id, cacheKey);
+	if (cached !== undefined) {
+		cacheMetrics.hits++;
+		return cached;
+	}
+	cacheMetrics.misses++;
 
 	const db = getDbSync();
 
@@ -105,7 +178,9 @@ export async function checkPermission(
 		.where(and(...conditions))
 		.get();
 
-	return (matchingPolicies?.count ?? 0) > 0;
+	const result = (matchingPolicies?.count ?? 0) > 0;
+	setCached(user.id, cacheKey, result);
+	return result;
 }
 
 /**
@@ -177,6 +252,7 @@ export async function bindPolicyToUser(userId: string, policyId: string): Promis
 		userId,
 		policyId
 	});
+	invalidateUserPermissionCache(userId);
 }
 
 /**
@@ -187,6 +263,7 @@ export async function unbindPolicyFromUser(userId: string, policyId: string): Pr
 	await db
 		.delete(rbacBindings)
 		.where(and(eq(rbacBindings.userId, userId), eq(rbacBindings.policyId, policyId)));
+	invalidateUserPermissionCache(userId);
 }
 
 /**
@@ -246,6 +323,9 @@ export async function deletePolicy(policyId: string): Promise<void> {
 
 	// Delete policy
 	await db.delete(rbacPolicies).where(eq(rbacPolicies.id, policyId));
+
+	// Invalidate the entire cache since we don't track which users were affected
+	invalidateAllPermissionCache();
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #197

- Add a per-user in-memory cache for `checkPermission()` results with a 5-minute TTL, eliminating repeated DB queries on every API call
- Invalidate per-user cache entries when bindings change (`bindPolicyToUser`, `unbindPolicyFromUser`, `bindUserToDefaultPolicies`, `syncUserPolicyBindings`)
- Clear the full cache on `deletePolicy` (affected users unknown at that point)
- Export `cacheMetrics` (`hits`, `misses`, `invalidations`) for future observability/monitoring

## Test plan

- [ ] Verify repeated `checkPermission()` calls for the same user+action return cached result (no extra DB queries)
- [ ] Bind/unbind a policy from a user and confirm subsequent checks hit the DB (cache was invalidated)
- [ ] Delete a policy and confirm all users' caches are cleared
- [ ] Wait > 5 minutes (or reduce TTL locally) and confirm the cache expires correctly
- [ ] Change a user's role via `syncUserPolicyBindings` and confirm their new permissions are reflected immediately