### PR TITLE
feat(ux): replace native confirm() with ConfirmDialog for rollback

### DIFF
--- a/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
+++ b/src/routes/resources/[type]/[namespace]/[name]/+page.svelte
@@ -290,7 +290,8 @@
 
 	async function confirmRollback() {
 		if (!pendingRollback) return;
-		const { historyId, revision } = pendingRollback;
+		const myPending = pendingRollback;
+		const { historyId, revision } = myPending;
 		const displayRevision = revision ? revision.slice(0, 8) : historyId.slice(0, 8);
 		try {
 			const res = await fetch(resolve(`/api/flux/${data.resourceType}/${data.namespace}/${data.name}/rollback`), {
@@ -312,7 +313,9 @@
 		} catch (err) {
 			toast.error(`Error: ${err instanceof Error ? err.message : 'Unknown error'}`);
 		} finally {
-			pendingRollback = null;
+			if (pendingRollback === myPending) {
+				pendingRollback = null;
+			}
 		}
 	}
 
@@ -374,6 +377,8 @@
 		timeline = [];
 		historyLoading = false;
 		historyFetched = false;
+		rollbackConfirmOpen = false;
+		pendingRollback = null;
 	});
 
 	// Consolidated effect for tab data fetching


### PR DESCRIPTION
## Summary

Closes #199

When reviewing issue #199, I found that tab state persistence (URL `?tab=` param), loading skeletons (Events, Logs, History, Diff tabs), and toast notifications were already implemented. The only remaining item was the native browser `confirm()` dialog used in the rollback flow.

- Replaces blocking `confirm()` call in `handleRollback` with the existing `ConfirmDialog` component (AlertDialog-based, destructive variant)
- Splits rollback into two phases: `handleRollback` opens the dialog, `confirmRollback` performs the actual API call
- Clears `pendingRollback` in a `finally` block to prevent stale state

## Test plan

- [x] Navigate to a Kustomization resource with history entries
- [x] Click "Rollback" on a history entry — confirm the `ConfirmDialog` modal opens (not a browser dialog)
- [x] Click "Cancel" — dialog closes, no rollback occurs
- [x] Click "Rollback" in the dialog — rollback is initiated, toast shown on success/failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rollback operations now display a dedicated confirmation dialog with rollback details instead of a browser prompt, providing a clearer and more consistent confirmation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->