### PR TITLE
feat(logs): add level filter and regex search to logs tab

### DIFF
--- a/src/lib/components/resources/tabs/LogsTab.svelte
+++ b/src/lib/components/resources/tabs/LogsTab.svelte
@@ -27,24 +27,26 @@
 	let searchQuery = $state('');
 	let levelFilter = $state<string>('ALL');
 	let useRegex = $state(false);
-	let regexError = $state<string | null>(null);
-	let compiledRegex = $state<RegExp | null>(null);
 
 	const LEVEL_OPTIONS = ['ALL', 'DEBUG', 'INFO', 'WARN', 'ERROR'] as const;
 
-	// Compile regex separately so filteredFormattedLogs stays a pure derived (no state writes)
-	$effect(() => {
-		if (!useRegex || !searchQuery) {
-			regexError = null;
-			compiledRegex = null;
-			return;
-		}
+	// Derive regex and error synchronously so filtering is always consistent
+	const compiledRegex = $derived.by<RegExp | null>(() => {
+		if (!useRegex || !searchQuery) return null;
 		try {
-			compiledRegex = new RegExp(searchQuery, 'i');
-			regexError = null;
+			return new RegExp(searchQuery, 'i');
 		} catch {
-			compiledRegex = null;
-			regexError = 'Invalid regular expression';
+			return null;
+		}
+	});
+
+	const regexError = $derived.by<string | null>(() => {
+		if (!useRegex || !searchQuery) return null;
+		try {
+			new RegExp(searchQuery, 'i');
+			return null;
+		} catch {
+			return 'Invalid regular expression';
 		}
 	});
 
@@ -63,9 +65,11 @@
 		if (searchQuery) {
 			if (useRegex) {
 				if (compiledRegex) {
-					result = result.filter((line) => compiledRegex!.test(line.msg) || compiledRegex!.test(line.level));
+					result = result.filter(
+						(line) => compiledRegex.test(line.msg) || compiledRegex.test(line.level)
+					);
 				}
-				// if compiledRegex is null, regex is invalid — return unfiltered-by-text result
+				// compiledRegex is null when pattern is invalid — leave result unfiltered by text
 			} else {
 				const q = searchQuery.toLowerCase();
 				result = result.filter(


### PR DESCRIPTION
## Summary

Closes #200

- Add **level filter** buttons (ALL / DEBUG / INFO / WARN / ERROR) with color-coded active states that compose with text/regex search
- Add **regex search** toggle — validates the pattern live and shows an inline error on invalid regex
- Filter controls are hidden when "Raw JSON" mode is active (they have no effect there)

> Note: Diff export and Reconcile Now were already implemented in earlier commits; this PR adds the remaining two items from the issue (level filter + regex search).

## Test plan

- [x] Open a resource detail page → Logs tab
- [x] Verify level filter buttons appear below the header row
- [x] Click ERROR — only ERROR/FATAL lines shown
- [x] Click WARN — only WARN/WARNING lines shown; click ALL to reset
- [x] Type text in search box — filters within the active level selection
- [ ] Enable Regex checkbox — placeholder changes, invalid pattern shows red border + error message, valid pattern filters correctly
- [x] Toggle "Raw JSON" — filter controls hide; toggle back — controls reappear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log level filtering (ALL, DEBUG, INFO, WARN, ERROR).
  * Regex search toggle for advanced filtering with optional regex mode.
  * Raw JSON logs view and manual refresh control.
  * Color-coded log level buttons for quick scanning.

* **Improvements**
  * Inline regex validation with error messaging and safe-fallback behavior.
  * Dynamic search placeholder and improved accessibility and ARIA support for log controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->