### PR TITLE
refactor(types): extract inline types to centralized type definitions

### DIFF
--- a/src/lib/server/kubernetes/events.ts
+++ b/src/lib/server/kubernetes/events.ts
@@ -1,23 +1,8 @@
 import { getKubeConfig, handleK8sError } from './client';
 import * as k8s from '@kubernetes/client-node';
+import type { K8sEvent } from '$lib/types/events';
 
-export interface K8sEvent {
-	type: 'Normal' | 'Warning';
-	reason: string;
-	message: string;
-	count: number;
-	firstTimestamp: string | null;
-	lastTimestamp: string | null;
-	involvedObject: {
-		kind: string;
-		name: string;
-		namespace: string;
-		uid: string;
-	};
-	source: {
-		component: string;
-	};
-}
+export type { K8sEvent };
 
 /**
  * Fetch events related to a specific Kubernetes resource

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -1,0 +1,22 @@
+export interface K8sInvolvedObject {
+	kind: string;
+	name: string;
+	namespace: string;
+	uid: string;
+	apiVersion?: string;
+	resourceVersion?: string;
+	fieldPath?: string;
+}
+
+export interface K8sEvent {
+	type: 'Normal' | 'Warning';
+	reason: string;
+	message: string;
+	count: number;
+	firstTimestamp: string | null;
+	lastTimestamp: string | null;
+	involvedObject: K8sInvolvedObject;
+	source: {
+		component: string;
+	};
+}

--- a/src/lib/types/reconciliation.ts
+++ b/src/lib/types/reconciliation.ts
@@ -1,0 +1,13 @@
+export interface ReconciliationEntry {
+	id: string;
+	revision: string | null;
+	status: 'success' | 'failure' | 'unknown';
+	readyStatus: string | null;
+	readyReason: string | null;
+	readyMessage: string | null;
+	reconcileCompletedAt: string;
+	durationMs: number | null;
+	triggerType: 'automatic' | 'manual' | 'webhook' | 'rollback';
+	errorMessage: string | null;
+	specSnapshot: string | null;
+}

--- a/src/lib/types/resource.ts
+++ b/src/lib/types/resource.ts
@@ -1,25 +1,5 @@
-export interface K8sInvolvedObject {
-	kind: string;
-	name: string;
-	namespace: string;
-	uid: string;
-	apiVersion?: string;
-	resourceVersion?: string;
-	fieldPath?: string;
-}
-
-export interface K8sEvent {
-	type: 'Normal' | 'Warning';
-	reason: string;
-	message: string;
-	count: number;
-	firstTimestamp: string | null;
-	lastTimestamp: string | null;
-	involvedObject: K8sInvolvedObject;
-	source: {
-		component: string;
-	};
-}
+export type { K8sInvolvedObject, K8sEvent } from './events';
+export type { ReconciliationEntry } from './reconciliation';
 
 export interface ResourceDiff {
 	kind: string;
@@ -34,18 +14,4 @@ export interface DiffResponse {
 	diffs: ResourceDiff[];
 	timestamp?: number;
 	revision?: string | null;
-}
-
-export interface ReconciliationEntry {
-	id: string;
-	revision: string | null;
-	status: 'success' | 'failure' | 'unknown';
-	readyStatus: string | null;
-	readyReason: string | null;
-	readyMessage: string | null;
-	reconcileCompletedAt: string;
-	durationMs: number | null;
-	triggerType: 'automatic' | 'manual' | 'webhook' | 'rollback';
-	errorMessage: string | null;
-	specSnapshot: string | null;
 }

--- a/src/routes/admin/clusters/+page.svelte
+++ b/src/routes/admin/clusters/+page.svelte
@@ -4,6 +4,7 @@
 	import Button from '$lib/components/ui/button/button.svelte';
 	import SearchBar from '$lib/components/ui/search/SearchBar.svelte';
 	import Pagination from '$lib/components/ui/pagination/Pagination.svelte';
+	import type { HealthCheckResult, ClusterHealthCheck } from '$lib/server/clusters';
 
 	interface Cluster {
 		id: string;
@@ -15,23 +16,6 @@
 		lastConnectedAt: Date | null;
 		lastError: string | null;
 		createdAt: Date;
-	}
-
-	interface HealthCheckResult {
-		name: string;
-		passed: boolean;
-		message: string;
-		details?: string;
-		duration?: number;
-	}
-
-	interface ClusterHealthCheck {
-		connected: boolean;
-		clusterName: string;
-		kubernetesVersion?: string;
-		checks: HealthCheckResult[];
-		error?: string;
-		timestamp: string;
 	}
 
 	let { data, form } = $props<{


### PR DESCRIPTION
## Summary

- Created `$lib/types/events.ts` with `K8sInvolvedObject` and `K8sEvent` interfaces
- Created `$lib/types/reconciliation.ts` with `ReconciliationEntry` interface
- Refactored `$lib/types/resource.ts` to re-export from the new files, maintaining backward compatibility for existing imports
- Removed duplicate `K8sEvent` definition from `src/lib/server/kubernetes/events.ts`, now imports the shared type from `$lib/types/events`
- Replaced inline `HealthCheckResult`/`ClusterHealthCheck` in admin clusters page with imports from `$lib/server/clusters` where they already existed

Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated and reorganized internal type definitions for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->