### PR TITLE
feat(ux): add fuzzy search result highlighting in CommandPalette

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -190,15 +190,17 @@
 		if (typeof window !== 'undefined') window.removeEventListener('keydown', handleKeydown);
 	});
 
-	// Flat index for a grouped item
-	function flatIndex(category: string, idxInGroup: number): number {
-		let offset = 0;
-		for (const [cat, results] of groupedItems) {
-			if (cat === category) return offset + idxInGroup;
-			offset += results.length;
+	// Precompute item id → flat index once per groupedItems change (O(n) total vs O(n²) per render)
+	const flatIndexMap = $derived.by(() => {
+		const map = new Map<string, number>();
+		let idx = 0;
+		for (const [, results] of groupedItems) {
+			for (const result of results) {
+				map.set(result.item.id, idx++);
+			}
 		}
-		return offset + idxInGroup;
-	}
+		return map;
+	});
 </script>
 
 <Dialog.Dialog bind:open onOpenChange={handleOpenChange}>
@@ -232,7 +234,7 @@
 						</div>
 						{#each results as result, i (result.item.id)}
 							{@const item = result.item}
-							{@const idx = flatIndex(category, i)}
+							{@const idx = flatIndexMap.get(result.item.id) ?? 0}
 							{@const isSelected = selectedIndex === idx}
 							<button
 								type="button"


### PR DESCRIPTION
## Summary

- Enables `includeMatches: true` in the Fuse.js config to capture match index metadata
- Introduces `highlightText()` helper that splits text into highlighted/plain segments based on Fuse match indices
- Renders `<mark>` spans for matched characters in both label and description fields
- Adds visual distinction: **amber** for keyword (exact substring) matches, **sky blue** for fuzzy (non-contiguous) matches

Closes #208

## Test plan

- [x] Open the command palette (Ctrl+K / ⌘K)
- [x] Type a partial word like `dash` — "Dashboard" label should show `dash` in amber
- [x] Type a fuzzy query like `dshbd` — matching characters should appear in sky blue
- [x] Verify description text also highlights matched characters
- [x] Confirm keyboard navigation (↑↓ Enter) still works correctly
- [x] Confirm no results case still shows "No results found."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now display highlighted matching text in labels and descriptions to improve visibility of relevant matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->