### PR TITLE
feat(audit-logs): add server-side pagination and sorting

### DIFF
--- a/src/lib/server/audit.ts
+++ b/src/lib/server/audit.ts
@@ -161,7 +161,7 @@ export async function logClusterChange(
 	});
 }
 
-export type AuditLogSortBy = 'date' | 'action' | 'user';
+export type AuditLogSortBy = 'date' | 'action';
 export type AuditLogSortOrder = 'asc' | 'desc';
 
 /**

--- a/src/routes/admin/audit-logs/+page.server.ts
+++ b/src/routes/admin/audit-logs/+page.server.ts
@@ -17,7 +17,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 50;
 	const offset = Number.isFinite(offsetParam) && offsetParam >= 0 ? offsetParam : 0;
 
-	const validSortBy: AuditLogSortBy[] = ['date', 'action', 'user'];
+	const validSortBy: AuditLogSortBy[] = ['date', 'action'];
 	const sortBy: AuditLogSortBy = validSortBy.includes(rawSortBy as AuditLogSortBy)
 		? (rawSortBy as AuditLogSortBy)
 		: 'date';
@@ -27,14 +27,14 @@ export const load: PageServerLoad = async ({ url }) => {
 		? (rawSortOrder as AuditLogSortOrder)
 		: 'desc';
 
-	let success: boolean | undefined;
-	if (rawSuccess === 'true') success = true;
-	else if (rawSuccess === 'false') success = false;
+	const successFilter = rawSuccess === 'true' ? 'true' : rawSuccess === 'false' ? 'false' : 'all';
+	const success: boolean | undefined =
+		successFilter === 'true' ? true : successFilter === 'false' ? false : undefined;
 
 	const action = url.searchParams.get('action') || undefined;
 	const userId = url.searchParams.get('userId') || undefined;
 
-	const { logs, total } = await getAuditLogsPaginated({
+	const { logs: rawLogs, total } = await getAuditLogsPaginated({
 		userId,
 		action,
 		success,
@@ -43,6 +43,23 @@ export const load: PageServerLoad = async ({ url }) => {
 		sortBy,
 		sortOrder
 	});
+
+	const lastValidOffset = total > 0 ? Math.floor((total - 1) / limit) * limit : 0;
+	let effectiveOffset = offset;
+	let logs = rawLogs;
+	if (offset > lastValidOffset) {
+		effectiveOffset = lastValidOffset;
+		const clamped = await getAuditLogsPaginated({
+			userId,
+			action,
+			success,
+			limit,
+			offset: effectiveOffset,
+			sortBy,
+			sortOrder
+		});
+		logs = clamped.logs;
+	}
 
 	return {
 		logs: logs.map((log) => {
@@ -63,9 +80,9 @@ export const load: PageServerLoad = async ({ url }) => {
 		}),
 		total,
 		limit,
-		offset,
+		offset: effectiveOffset,
 		sortBy,
 		sortOrder,
-		successFilter: rawSuccess ?? 'all'
+		successFilter
 	};
 };

--- a/src/routes/admin/audit-logs/+page.svelte
+++ b/src/routes/admin/audit-logs/+page.svelte
@@ -45,7 +45,7 @@
 			total: number;
 			limit: number;
 			offset: number;
-			sortBy: 'date' | 'action' | 'user';
+			sortBy: 'date' | 'action';
 			sortOrder: 'asc' | 'desc';
 			successFilter: string;
 		};
@@ -119,7 +119,7 @@
 		navigate({ offset: newOffset });
 	}
 
-	function setSort(col: 'date' | 'action' | 'user') {
+	function setSort(col: 'date' | 'action') {
 		const newOrder =
 			data.sortBy === col ? (data.sortOrder === 'desc' ? 'asc' : 'desc') : 'desc';
 		navigate({ sortBy: col, sortOrder: newOrder, offset: 0 });
@@ -136,14 +136,7 @@
 	let currentPage = $derived(Math.floor(data.offset / data.limit) + 1);
 	let totalPages = $derived(Math.ceil(data.total / data.limit));
 
-	function SortIcon(col: 'date' | 'action' | 'user') {
-		if (data.sortBy !== col) return ArrowUpDown;
-		return data.sortOrder === 'asc' ? ArrowUp : ArrowDown;
-	}
 
-	const dateSortIcon = $derived(SortIcon('date'));
-	const userSortIcon = $derived(SortIcon('user'));
-	const actionSortIcon = $derived(SortIcon('action'));
 </script>
 
 <div class="space-y-6">
@@ -198,28 +191,32 @@
 						<th class="px-4 py-3 font-medium text-slate-400">
 							<button
 								onclick={() => setSort('date')}
-								class="flex items-center gap-1 hover:text-white transition-colors"
+								class="flex items-center gap-1 transition-colors hover:text-white"
 							>
 								Time
-								<dateSortIcon size={13}></dateSortIcon>
+								{#if data.sortBy === 'date' && data.sortOrder === 'asc'}
+									<ArrowUp size={13} />
+								{:else if data.sortBy === 'date' && data.sortOrder === 'desc'}
+									<ArrowDown size={13} />
+								{:else}
+									<ArrowUpDown size={13} />
+								{/if}
 							</button>
 						</th>
-						<th class="px-4 py-3 font-medium text-slate-400">
-							<button
-								onclick={() => setSort('user')}
-								class="flex items-center gap-1 hover:text-white transition-colors"
-							>
-								User
-								<userSortIcon size={13}></userSortIcon>
-							</button>
-						</th>
+						<th class="px-4 py-3 font-medium text-slate-400">User</th>
 						<th class="px-4 py-3 font-medium text-slate-400">
 							<button
 								onclick={() => setSort('action')}
-								class="flex items-center gap-1 hover:text-white transition-colors"
+								class="flex items-center gap-1 transition-colors hover:text-white"
 							>
 								Action
-								<actionSortIcon size={13}></actionSortIcon>
+								{#if data.sortBy === 'action' && data.sortOrder === 'asc'}
+									<ArrowUp size={13} />
+								{:else if data.sortBy === 'action' && data.sortOrder === 'desc'}
+									<ArrowDown size={13} />
+								{:else}
+									<ArrowUpDown size={13} />
+								{/if}
 							</button>
 						</th>
 						<th class="px-4 py-3 font-medium text-slate-400">Resource</th>


### PR DESCRIPTION
## Summary

- Add \`getAuditLogsPaginated()\` to \`audit.ts\` supporting \`limit\`, \`offset\`, \`sortBy\` (\`date\`/\`action\`), \`sortOrder\` (\`asc\`/\`desc\`), and \`success\` filter; returns total count via a parallel \`COUNT(*)\` query
- Update \`+page.server.ts\` to parse all pagination/sort/filter params from URL and pass metadata (\`total\`, \`limit\`, \`offset\`, \`sortBy\`, \`sortOrder\`, \`successFilter\`) to the page; invalid \`success\` params are sanitised to \`'all'\`; out-of-range offsets are clamped to the last valid page
- Update \`+page.svelte\` with:
  - Clickable column sort headers (Time, Action) with sort direction indicators — User column is a plain header (sorting by username requires a JOIN and isn't needed given the existing userId filter)
  - Server-side status filter (All / Successful / Failed) via URL param
  - Rows-per-page selector (25 / 50 / 100 / 200)
  - First / Prev / Next / Last pagination controls with disabled states
  - Summary line showing "Showing X–Y of Z logs"
  - Local search retained as a fast client-side substring filter across the current page

## Test plan

- [x] Navigate to \`/admin/audit-logs\` — default 50 rows, sorted by date desc
- [x] Click "Time" and "Action" headers to toggle sort direction; verify icon updates (↑ / ↓ / ↕)
- [x] Verify "User" column header is not clickable
- [x] Use the filter icon to switch between All / Successful / Failed; verify \`?success=foo\` or \`?success=\` is treated as All
- [x] Change rows per page and verify the correct number of rows loads
- [x] Use Prev / Next / First / Last buttons and verify offset updates correctly
- [x] Navigate to an out-of-range offset directly via URL — verify it redirects to the last valid page
- [x] Type in the search box to filter the current page client-side
- [x] Verify URL query params update on every interaction (bookmarkable state)

Closes #213