### PR TITLE
fix: prevent duplicate X-RateLimit headers crashing login endpoint

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -147,7 +147,9 @@ export const handle: Handle = async ({ event, resolve }) => {
 			path === '/api/v1/flux/health';
 		if (!isStaticAsset && !isHealthEndpoint) {
 			const ip = event.getClientAddress();
-			const globalLimit = tryCheckRateLimit(event, `global:${ip}`, 300, 60 * 1000);
+			// Pass a no-op setHeaders so the global limiter doesn't set X-RateLimit-* on the event —
+			// endpoint-specific limiters own those headers and SvelteKit throws if they're set twice.
+			const globalLimit = tryCheckRateLimit({ setHeaders: () => {} }, `global:${ip}`, 300, 60 * 1000);
 			if (globalLimit.limited) {
 				return recordResponse(
 					new Response(JSON.stringify({ error: 'Too Many Requests' }), {


### PR DESCRIPTION
Global rate limiter in hooks.server.ts was calling tryCheckRateLimit(event, ...) which set X-RateLimit-* headers on the event. The login endpoint then called checkRateLimit() which tried to set the same headers again, causing SvelteKit to throw 'header is already set'.

Pass a no-op setHeaders to the global limiter — it's a defense measure and clients should see the per-endpoint limits, not the global 300/min one.