### PR TITLE
feat(security): add browser security headers #267

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -81,7 +81,7 @@ function setSecurityHeaders(response: Response): void {
 			"style-src 'self' 'unsafe-inline'",
 			"img-src 'self' data: blob:",
 			"font-src 'self' data:",
-			"connect-src 'self' ws: wss:",
+			"connect-src 'self'",
 			"frame-ancestors 'none'",
 			"object-src 'none'",
 			"base-uri 'self'"


### PR DESCRIPTION
## Summary

- Adds `setSecurityHeaders()` helper in `src/hooks.server.ts` called from `recordResponse`, so all responses (including error paths) get the headers
- **Content-Security-Policy**: `default-src 'self'` with `unsafe-inline` for scripts/styles (SvelteKit SSR hydration requirement); blocks remote script injection and `object-src`/`base-uri`
- **X-Frame-Options**: `DENY` (plus `frame-ancestors 'none'` in CSP for modern browser support)
- **X-Content-Type-Options**: `nosniff`
- **Referrer-Policy**: `strict-origin-when-cross-origin`
- **HSTS**: `max-age=31536000; includeSubDomains` — production only (dev runs over HTTP)

## Test plan

- [x] `curl -I http://localhost:5173/` — should see `X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`, `Referrer-Policy` (no `Strict-Transport-Security` in dev)
- [x] Production build — `Strict-Transport-Security` header should appear
- [x] Existing auth, CSRF, and rate-limiting behaviour unaffected (all responses pass through `recordResponse`)
- [x] `bun run format && bun run lint && bun run check` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added HTTP security headers to protect against clickjacking, content-type sniffing, and referrer information leakage.
  * Enabled Strict Transport Security in production to ensure secure HTTPS connections.
  * Security headers are now applied consistently to all responses generated by the request handling flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->