### PR TITLE
fix(ci): fix OCI registry path, remove SHA tags, clean up stale workflow rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,6 @@ jobs:
             type=ref,event=branch
             # Immutable version tag (e.g., 0.1.0)
             type=semver,pattern={{version}}
-            # Version with short SHA for traceability (e.g., v0.1.0-abc1234)
-            type=raw,value={{tag}}-{{sha}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             # PR tags (for pull requests)
             type=ref,event=pr
           flavor: |

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -37,18 +37,10 @@ jobs:
           keep-n-most-recent: 5
           timestamp-to-use: created_at
 
-      - name: Cleanup old branch images
-        uses: snok/container-retention-policy@v3.0.1
-        with:
-          image-names: gyre
-          cut-off: 4w
-          account: user
-          token: ${{ secrets.PAT }}
-          image-tags: 'feat/* fix/* chore/* docs/* refactor/* ci/*'
-          tag-selection: tagged
-          timestamp-to-use: created_at
-
-      - name: Cleanup old SHA-tagged releases
+      # Cleans up legacy SHA-tagged releases (e.g. v0.1.0-abc1234) that
+      # accumulated before SHA tag generation was removed from build.yml.
+      # This step can be removed once all pre-existing SHA tags have expired.
+      - name: Cleanup legacy SHA-tagged releases
         uses: snok/container-retention-policy@v3.0.1
         with:
           image-names: gyre
@@ -57,7 +49,7 @@ jobs:
           token: ${{ secrets.PAT }}
           image-tags: 'v*-*'
           tag-selection: tagged
-          keep-n-most-recent: 3
+          keep-n-most-recent: 0
           timestamp-to-use: created_at
 
       - name: Cleanup summary
@@ -70,8 +62,7 @@ jobs:
           echo "|------|------------------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| **Untagged images** | 7 days | Automatically removed |" >> $GITHUB_STEP_SUMMARY
           echo "| **PR tags** (\`pr-*\`) | 7 days | Keep 5 most recent |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Branch tags** (\`feat/* fix/*\` etc.) | 4 weeks | Feature branch images |" >> $GITHUB_STEP_SUMMARY
-          echo "| **SHA-tagged releases** (\`v*-*\`) | 14 days | Keep 3 most recent |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Legacy SHA tags** (\`v*-*\`) | 14 days | Transitional — remove step once expired |" >> $GITHUB_STEP_SUMMARY
           echo "| **Release tags** (\`v*.*.*\`) | Forever | Not matched by cleanup rules |" >> $GITHUB_STEP_SUMMARY
           echo "| **latest / main / develop** | Forever | Not matched by cleanup rules |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Package and push Helm chart to OCI
         run: |
           helm package charts/gyre --version ${{ steps.tag.outputs.version }} --app-version ${{ steps.tag.outputs.version }}
-          helm push gyre-${{ steps.tag.outputs.version }}.tgz oci://ghcr.io/entropy0120/gyre
+          helm push gyre-${{ steps.tag.outputs.version }}.tgz oci://ghcr.io/entropy0120
 
       - name: Generate Release Notes
         id: notes
@@ -58,7 +58,7 @@ jobs:
 
           **Using Helm:**
           ```bash
-          helm install gyre oci://ghcr.io/entropy0120/gyre/gyre \
+          helm install gyre oci://ghcr.io/entropy0120/gyre \
             --version ${{ steps.tag.outputs.version }} \
             --namespace flux-system \
             --create-namespace
@@ -72,7 +72,7 @@ jobs:
 
           ### 📋 What's Included
 
-          - **Multi-arch Docker images** (amd64, arm64)
+          - **Docker image** (linux/amd64)
           - **Production-ready Helm chart**
           - **Comprehensive RBAC configuration**
           - **Auto-generated admin credentials**

--- a/charts/gyre/Chart.yaml
+++ b/charts/gyre/Chart.yaml
@@ -2,8 +2,10 @@ apiVersion: v2
 name: gyre
 description: Modern WebUI for FluxCD with real-time monitoring and multi-cluster management
 type: application
-version: 0.4.1
-appVersion: "0.4.1"
+# Overridden at release time by CI: helm package --version <tag> --app-version <tag>
+# Do not edit manually.
+version: 0.0.0
+appVersion: "0.0.0"
 icon: https://raw.githubusercontent.com/entropy0120/gyre/main/static/favicon.svg
 keywords:
   - flux


### PR DESCRIPTION
Closes #319

## Summary

- **Helm chart OCI path**: `release.yml` was pushing to `oci://ghcr.io/entropy0120/gyre`, landing the chart at the sub-package `ghcr.io/entropy0120/gyre/gyre`. Changed to `oci://ghcr.io/entropy0120` so the chart is at `ghcr.io/entropy0120/gyre` alongside the Docker image.
- **SHA tag removal**: `build.yml` was generating `v0.1.0-abc1234` SHA tags that shared a digest with the semver `0.1.0` tag, causing the cleanup tool to skip them forever (confirmed in run logs). Removed — semver + provenance attestation is sufficient.
- **Dead cleanup rules**: The branch-tag cleanup step (`feat/* fix/*`) never matched anything since the build workflow doesn't create branch-named images. Removed.
- **Release notes**: Fixed incorrect multi-arch claim (arm64 not built); updated Helm install command to match new OCI path.
- **Chart.yaml**: Replaced hardcoded `0.4.1` with `0.0.0` placeholder + comment; CI already overrides at package time.

## Test plan

- [x] Verify next release pushes Helm chart to `ghcr.io/entropy0120/gyre` (not `.../gyre/gyre`)
- [x] Verify no `v*-*` SHA tags appear after a tag push
- [x] Verify cleanup workflow still runs and processes untagged + PR images