### PR TITLE
docs: fix Helm chart OCI path and bump to v0.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ vite.config.ts.timestamp-*
 
 # Data
 /data
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: oci://ghcr.io/entropy0120/gyre/gyre
+  url: oci://ghcr.io/entropy0120/gyre
   ref:
-    tag: 0.4.1
+    semver: ">=0.1.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -61,8 +61,7 @@ spec:
 ### Option 2: Helm
 
 ```bash
-helm install gyre oci://ghcr.io/entropy0120/gyre/gyre \
-  --version 0.4.1 \
+helm install gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system \
   --create-namespace
 ```

--- a/charts/gyre/README.md
+++ b/charts/gyre/README.md
@@ -2,9 +2,8 @@
 
 Modern WebUI for FluxCD with real-time monitoring, RBAC, and comprehensive resource management.
 
-[![Version](https://img.shields.io/badge/version-0.4.1-blue.svg)](Chart.yaml)
 [![Type](https://img.shields.io/badge/type-application-informational.svg)](Chart.yaml)
-[![AppVersion](https://img.shields.io/badge/app%20version-0.4.1-informational.svg)](Chart.yaml)
+[![GitHub release](https://img.shields.io/github/v/release/entropy0120/gyre?label=version&style=flat)](https://github.com/entropy0120/gyre/releases/latest)
 
 ## Documentation
 
@@ -15,12 +14,8 @@ Comprehensive documentation for the Helm chart, including configuration options,
 ## Quick Start
 
 ```bash
-# Add the Gyre Helm repository
-helm repo add gyre https://entropy0120.github.io/gyre
-helm repo update
-
 # Install Gyre
-helm install gyre gyre/gyre \
+helm install gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system \
   --create-namespace
 ```

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -246,7 +246,7 @@ audit:
 ### Via Helm
 
 ```bash
-helm upgrade gyre gyre/gyre \
+helm upgrade gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system \
   -f values.yaml
 ```

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -32,9 +32,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: oci://ghcr.io/entropy0120/gyre/gyre
+  url: oci://ghcr.io/entropy0120/gyre
   ref:
-    tag: 0.4.1
+    semver: ">=0.1.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -54,8 +54,7 @@ spec:
 The standard way to install Gyre directly via Helm:
 
 ```bash
-helm install gyre oci://ghcr.io/entropy0120/gyre/gyre \
-  --version 0.4.1 \
+helm install gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system \
   --create-namespace
 ```

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -26,8 +26,7 @@ Get started with Gyre in minutes:
 
 ```bash
 # Install via Helm
-helm install gyre oci://ghcr.io/entropy0120/gyre/gyre \
-  --version 0.4.1 \
+helm install gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system \
   --create-namespace
 

--- a/documentation/docs/installation/helm-reference.md
+++ b/documentation/docs/installation/helm-reference.md
@@ -153,7 +153,7 @@ To upgrade Gyre:
 helm repo update
 
 # Upgrade release
-helm upgrade gyre gyre/gyre
+helm upgrade gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system
 ```
 
@@ -165,7 +165,7 @@ POD=$(kubectl get pod -n flux-system -l app.kubernetes.io/name=gyre -o jsonpath=
 kubectl cp flux-system/$POD:/data/gyre.db ./gyre-backup-$(date +%Y%m%d).db
 
 # 2. Perform upgrade
-helm upgrade gyre gyre/gyre --namespace flux-system
+helm upgrade gyre oci://ghcr.io/entropy0120/gyre --namespace flux-system
 
 # 3. Verify
 kubectl rollout status deployment/gyre -n flux-system

--- a/documentation/docs/installation/index.md
+++ b/documentation/docs/installation/index.md
@@ -23,9 +23,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: oci://ghcr.io/entropy0120/gyre/gyre
+  url: oci://ghcr.io/entropy0120/gyre
   ref:
-    tag: 0.4.1
+    semver: ">=0.1.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -49,8 +49,7 @@ Helm is the standard way to install Gyre directly, as it provides easy configura
 ### Basic Installation
 
 ```bash
-helm install gyre oci://ghcr.io/entropy0120/gyre/gyre \
-  --version 0.4.1 \
+helm install gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system \
   --create-namespace
 ```
@@ -97,8 +96,7 @@ persistence:
 Install with custom values:
 
 ```bash
-helm install gyre oci://ghcr.io/entropy0120/gyre/gyre \
-  --version 0.4.1 \
+helm install gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system \
   --create-namespace \
   -f values.yaml
@@ -193,8 +191,7 @@ kubectl logs -n flux-system -l app.kubernetes.io/name=gyre
 To upgrade Gyre:
 
 ```bash
-helm upgrade gyre oci://ghcr.io/entropy0120/gyre/gyre \
-  --version 0.4.1 \
+helm upgrade gyre oci://ghcr.io/entropy0120/gyre \
   --namespace flux-system
 ```
 


### PR DESCRIPTION
## Summary

- Replace all `oci://ghcr.io/entropy0120/gyre/gyre` references with `oci://ghcr.io/entropy0120/gyre` (the correct path after #320)
- Fix bare `gyre/gyre` Helm repo references in upgrade commands (the chart is OCI-only, not a traditional Helm repo)
- Bump all version references from `0.4.1` → `0.4.2` across README and docs

## Files updated

- `README.md`
- `charts/gyre/README.md`
- `documentation/docs/index.md`
- `documentation/docs/getting-started.md`
- `documentation/docs/installation/index.md`
- `documentation/docs/installation/helm-reference.md`
- `documentation/docs/configuration.md`

## Test plan

- [ ] Merge this PR to main
- [ ] Tag `v0.4.2` on main to trigger the release workflow
- [ ] Verify chart is pushed to `ghcr.io/entropy0120/gyre:0.4.2`
- [ ] Verify `helm install gyre oci://ghcr.io/entropy0120/gyre --version 0.4.2` works