### PR TITLE
fix(security): resolve path traversal bugs in db and backups (#329)

### DIFF
--- a/src/lib/server/backup.ts
+++ b/src/lib/server/backup.ts
@@ -28,10 +28,13 @@ const isInCluster = !!process.env.KUBERNETES_SERVICE_HOST;
 const databaseUrl = process.env.DATABASE_URL || (isInCluster ? '/data/gyre.db' : './data/gyre.db');
 const backupDir = process.env.BACKUP_DIR || (isInCluster ? '/data/backups' : './data/backups');
 
-// Validate DATABASE_URL does not contain path traversal
-if (databaseUrl.includes('..')) {
-	throw new Error(`Invalid DATABASE_URL: path traversal detected: ${databaseUrl}`);
+// Validate paths do not contain path traversal
+import { validateSafePath } from "./utils/path.js";
+validateSafePath(databaseUrl);
+if (process.env.BACKUP_DIR) {
+	validateSafePath(process.env.BACKUP_DIR);
 }
+
 
 const ENCRYPTION_ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16; // 128-bit IV

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -10,13 +10,10 @@ import * as schema from './schema.js';
 // - Production (in-cluster): /data/gyre.db (PersistentVolume mount)
 // - Local development: ./data/gyre.db (relative to project root)
 const isInCluster = !!process.env.KUBERNETES_SERVICE_HOST;
-const databaseUrl = process.env.DATABASE_URL || (isInCluster ? '/data/gyre.db' : './data/gyre.db');
+const databaseUrl = process.env.DATABASE_URL || (isInCluster ? "/data/gyre.db" : "./data/gyre.db");
+import { validateSafePath } from "../utils/path.js";
 if (process.env.DATABASE_URL) {
-	const normalized = normalize(databaseUrl);
-	const segments = normalized.split(/[\\/]/);
-	if (segments.some((seg) => seg === '..')) {
-		throw new Error('DATABASE_URL must not contain path traversal sequences (..)');
-	}
+	validateSafePath(process.env.DATABASE_URL);
 }
 logger.info(`[DB] Database location: ${databaseUrl}`);
 

--- a/src/lib/server/utils/path.ts
+++ b/src/lib/server/utils/path.ts
@@ -1,0 +1,25 @@
+import { resolve } from 'node:path';
+
+/**
+ * Validates that a path does not contain raw traversal sequences.
+ * This should be checked BEFORE normalization.
+ */
+export function validateSafePath(inputPath: string): void {
+	if (inputPath.includes('..')) {
+		throw new Error(`Path traversal detected: ${inputPath}`);
+	}
+}
+
+/**
+ * Validates that a path is safe from traversal and ultimately resolves 
+ * within the expected directory tree.
+ */
+export function validateSafePathPrefix(inputPath: string, expectedPrefix: string): void {
+	validateSafePath(inputPath);
+	const resolvedPath = resolve(inputPath);
+	const resolvedPrefix = resolve(expectedPrefix);
+	
+	if (!resolvedPath.startsWith(resolvedPrefix)) {
+		throw new Error(`Path breaks out of expected directory bounds: ${inputPath}`);
+	}
+}


### PR DESCRIPTION
Fixes #329

1. The environment DATABASE_URL was passed through path.normalize() before the traversal check. Since normalize('/data/../etc/passwd') resolves to /etc/passwd, the condition checking for traversal segments never fired, allowing an attacker to escape the data directory constraint.
2. The backup directory path was blindly trusted from the environment, allowing backups to be written anywhere the node process has permissions to (e.g. BACKUP_DIR=/data/../../../tmp).

Fixes applied:
- Added validateSafePath utility which explicitly runs traversal checks against raw string inputs *before* any path normalizations occur.
- Standardized DATABASE_URL string checks across db/index.ts and backup.ts.
- Introduced validation for BACKUP_DIR using the unified utility function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved filesystem path security by implementing centralized validation for database and backup directory configurations. The validation now consistently prevents path traversal attacks that could allow unauthorized access to files outside intended directories. This strengthens the application's overall security posture and protects critical data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->