### PR TITLE
fix(security): enforce strict backup filename pattern on all endpoints

### DIFF
--- a/src/lib/server/backup.ts
+++ b/src/lib/server/backup.ts
@@ -33,6 +33,14 @@ if (databaseUrl.includes('..')) {
 	throw new Error(`Invalid DATABASE_URL: path traversal detected: ${databaseUrl}`);
 }
 
+/**
+ * Canonical backup filename pattern.
+ * Matches exactly the format produced by createBackup():
+ *   gyre-backup-YYYY-MM-DDThh-mm-ss-mmmZ.db[.enc]
+ */
+export const BACKUP_FILENAME_RE =
+	/^gyre-backup-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.db(\.enc)?$/;
+
 const ENCRYPTION_ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16; // 128-bit IV
 const AUTH_TAG_LENGTH = 16; // 128-bit GCM auth tag
@@ -262,8 +270,7 @@ export function listBackups(): BackupMetadata[] {
  */
 export function getBackupPath(filename: string): string | null {
 	const sanitized = basename(filename);
-	if (!sanitized.startsWith('gyre-backup-')) return null;
-	if (!sanitized.endsWith('.db') && !sanitized.endsWith('.db.enc')) return null;
+	if (!BACKUP_FILENAME_RE.test(sanitized)) return null;
 
 	const filePath = join(backupDir, sanitized);
 	if (!existsSync(filePath)) return null;

--- a/src/routes/api/v1/admin/backups/+server.ts
+++ b/src/routes/api/v1/admin/backups/+server.ts
@@ -11,7 +11,7 @@ import { logger } from '$lib/server/logger.js';
 import { json, error } from '@sveltejs/kit';
 import { z, errorSchema } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
-import { createBackup, listBackups, deleteBackup } from '$lib/server/backup';
+import { createBackup, listBackups, deleteBackup, BACKUP_FILENAME_RE } from '$lib/server/backup';
 
 const backupSchema = z.object({
 	filename: z.string().openapi({ example: 'gyre-backup-2024-01-15T10-30-00.db' }),
@@ -208,7 +208,6 @@ export const DELETE: RequestHandler = async ({ locals, url, setHeaders }) => {
 		throw error(400, { message: 'Missing filename parameter', code: 'BadRequest' });
 	}
 
-	const BACKUP_FILENAME_RE = /^gyre-backup-[\dT\-:.]+Z?\.db(\.enc)?$/;
 	if (!BACKUP_FILENAME_RE.test(filename)) {
 		throw error(400, { message: 'Invalid backup filename', code: 'BadRequest' });
 	}

--- a/src/routes/api/v1/admin/backups/download/+server.ts
+++ b/src/routes/api/v1/admin/backups/download/+server.ts
@@ -15,7 +15,12 @@ import { logger } from '$lib/server/logger.js';
 import { error } from '@sveltejs/kit';
 import { z, errorSchema } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
-import { getDecryptedBackupBuffer, getBackupPath, BackupError } from '$lib/server/backup';
+import {
+	getDecryptedBackupBuffer,
+	getBackupPath,
+	BackupError,
+	BACKUP_FILENAME_RE
+} from '$lib/server/backup';
 import { logAudit } from '$lib/server/audit';
 import { checkPermission } from '$lib/server/rbac';
 import { createReadStream, statSync } from 'node:fs';
@@ -47,7 +52,7 @@ export const _metadata = {
 				content: { 'application/x-sqlite3': { schema: z.any() } }
 			},
 			400: {
-				description: 'Missing filename parameter',
+				description: 'Missing or invalid filename parameter',
 				content: { 'application/json': { schema: errorSchema } }
 			},
 			401: {
@@ -77,9 +82,14 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 
 	const clusterId = locals.cluster || 'in-cluster';
 
-	const filename = url.searchParams.get('filename');
-	if (!filename) {
+	const rawFilename = url.searchParams.get('filename');
+	if (!rawFilename) {
 		throw error(400, { message: 'Missing filename parameter', code: 'BadRequest' });
+	}
+
+	const filename = basename(rawFilename);
+	if (!BACKUP_FILENAME_RE.test(filename)) {
+		throw error(400, { message: 'Invalid backup filename', code: 'BadRequest' });
 	}
 
 	try {
@@ -96,7 +106,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 
 		await logAudit(locals.user, 'backup:download', {
 			resourceType: 'DatabaseBackup',
-			resourceName: basename(filename)
+			resourceName: filename
 		});
 
 		if (filename.endsWith('.db.enc')) {
@@ -106,7 +116,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 				throw error(404, { message: 'Backup not found', code: 'NotFound' });
 			}
 
-			const safeFilename = basename(filename).replace(/\.enc$/, '');
+			const safeFilename = filename.replace(/\.enc$/, '');
 			const encodedFilename = encodeURIComponent(safeFilename);
 			return new Response(buffer as unknown as BodyInit, {
 				status: 200,


### PR DESCRIPTION
Closes #331

## Summary

- **Export `BACKUP_FILENAME_RE`** from `src/lib/server/backup.ts` as the single canonical regex matching exactly the format `createBackup()` produces: `gyre-backup-YYYY-MM-DDThh-mm-ss-mmmZ.db[.enc]`
- **Tighten `getBackupPath()`** to use `BACKUP_FILENAME_RE` instead of the two weak `startsWith`/`endsWith` checks — makes the library itself safe regardless of call site
- **DELETE handler**: import and use the shared constant; drop the local overly-permissive copy (`[\dT\-:.]+Z?`)
- **Download handler**: apply `basename()` + `BACKUP_FILENAME_RE` before the permission check, so crafted filenames get a clean 400 before any filesystem access

## Test plan

- [ ] `DELETE ?filename=gyre-backup-2024-01-15T10-30-00-000Z.db` → 200 (valid)
- [ ] `DELETE ?filename=gyre-backup-...Z.db` → 400 (rejected by strict regex)
- [ ] `DELETE ?filename=../../etc/passwd` → 400 (rejected)
- [ ] `GET /download?filename=gyre-backup-2024-01-15T10-30-00-000Z.db` → 200 (valid)
- [ ] `GET /download?filename=gyre.db` → 400 (rejected — no pattern match)
- [ ] `GET /download?filename=gyre-backup-EVILFILE.db` → 400 (rejected)
- [ ] `bun run format && bun run lint && bun run check` all pass ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Backup filename validation now uses consistent, stricter patterns across all backup operations for improved reliability and system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->