### PR TITLE
fix(flux): validate resource type in logs endpoint

### DIFF
--- a/src/routes/api/v1/flux/[type]/[namespace]/[name]/logs/+server.ts
+++ b/src/routes/api/v1/flux/[type]/[namespace]/[name]/logs/+server.ts
@@ -14,7 +14,7 @@ export const _metadata = {
 		tags: ['Flux'],
 		request: {
 			params: z.object({
-				type: z.string().openapi({ example: 'GitRepository' }),
+				type: z.string().openapi({ example: 'gitrepositories' }),
 				namespace: z.string().openapi({ example: 'flux-system' }),
 				name: z.string().openapi({ example: 'my-repo' })
 			})


### PR DESCRIPTION
## Summary

- Add `getResourceTypeByPlural()` validation to the Flux logs endpoint
- Return `400 Invalid resource type` on unknown type values, matching all other Flux endpoints
- Remove unsafe `type as FluxResourceType` casts — `resolvedType` is now properly typed

Resolves #332

## Test plan

- [x] Pass an invalid type (e.g. `bogustype`) to the logs endpoint → expect `400 Invalid resource type: bogustype`
- [x] Pass a valid plural type (e.g. `gitrepositories`) → endpoint proceeds as normal
- [x] `bun run check` passes with no type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logs API now validates the resource type parameter and returns a clear 400 error for invalid types.
  * Authorization and log retrieval reliably use the validated resource type, preventing mismatches and reducing unexpected errors when fetching logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->