### PR TITLE
fix(security): use substring matching for audit log sensitive field redaction

### DIFF
--- a/src/lib/server/audit.ts
+++ b/src/lib/server/audit.ts
@@ -21,7 +21,6 @@ const SENSITIVE_PATTERNS = [
 	'apikey',
 	'api_key',
 	'authorization',
-	'auth',
 	'credential',
 	'privatekey',
 	'private_key',

--- a/src/tests/audit-redaction.test.ts
+++ b/src/tests/audit-redaction.test.ts
@@ -15,8 +15,10 @@ describe('redactSensitiveFields', () => {
 			expect(redactSensitiveFields({ token: 'tok_xyz' })).toEqual({ token: '[REDACTED]' });
 		});
 
-		test('redacts auth', () => {
-			expect(redactSensitiveFields({ auth: 'Bearer xyz' })).toEqual({ auth: '[REDACTED]' });
+		test('redacts authorization', () => {
+			expect(redactSensitiveFields({ authorization: 'Bearer xyz' })).toEqual({
+				authorization: '[REDACTED]'
+			});
 		});
 	});
 
@@ -148,6 +150,23 @@ describe('redactSensitiveFields', () => {
 
 		test('passes through null values unchanged', () => {
 			const input = { username: 'alice', note: null };
+			expect(redactSensitiveFields(input)).toEqual(input);
+		});
+
+		// Regression guard: 'auth' was previously in SENSITIVE_PATTERNS and caused
+		// false positives for common English-word fields. Ensure these are NOT redacted.
+		test('does not redact author', () => {
+			const input = { author: 'alice', title: 'post' };
+			expect(redactSensitiveFields(input)).toEqual(input);
+		});
+
+		test('does not redact authority', () => {
+			const input = { authority: 'example.com', port: 443 };
+			expect(redactSensitiveFields(input)).toEqual(input);
+		});
+
+		test('does not redact authorizedAt', () => {
+			const input = { authorizedAt: '2026-01-01T00:00:00Z', userId: 'u1' };
 			expect(redactSensitiveFields(input)).toEqual(input);
 		});
 	});


### PR DESCRIPTION
## Summary

- Fixes #333
- Replaces the exact-match `SENSITIVE_KEYS` Set in `redactSensitiveFields()` with a `SENSITIVE_PATTERNS` array and substring matching (`key.toLowerCase().includes(pattern)`)
- Catches camelCase variants (`mySecret`, `dbPassword`, `jwtToken`), snake_case variants (`jwt_secret`, `api_password`, `encryption_token`), and any combination
- Deep/recursive redaction of nested objects and arrays was already correct — no changes needed there
- Exports `redactSensitiveFields` to enable direct unit testing

## Test plan

- [x] `bun test src/tests/audit-redaction.test.ts` — 22 new tests covering exact names, camelCase/snake_case variants, case-insensitivity, nested objects, and arrays
- [x] `bun test src/tests/audit-cleanup.test.ts` — existing tests still pass (no regression)
- [x] `bun run format && bun run lint && bun run check` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved sensitive-field redaction in audit logs using case-insensitive substring pattern matching for tokens, passwords, secrets, API keys, authorization, credentials, and encryption/signing keys; reduces reliance on exact key matches while avoiding benign "auth" words.

* **Tests**
  * Added comprehensive tests covering case variations, camel/snake/case-preserved keys, nested objects, arrays, nulls, and regression edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->