### PR TITLE
fix(security): explicitly disable sourcemaps in production build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig(({ mode }) => {
 			}
 		},
 		build: {
+			sourcemap: false, // never emit .map files in production — avoids exposing source paths and pre-minified logic
 			reportCompressedSize: true,
 			rolldownOptions: {
 				output: {


### PR DESCRIPTION
## Summary

Closes #338

- Adds `sourcemap: false` to the `build` section of `vite.config.ts`
- Makes the security intent explicit rather than relying on Vite's default behavior
- Prevents any future Vite/SvelteKit upgrade from accidentally re-enabling client-side source maps

## What was happening

`tsconfig.json` has `"sourceMap": true` and `vite.config.ts` had no explicit `build.sourcemap` setting. While Vite already defaults to `false` for production client-side maps, the absence of an explicit setting meant the configuration was relying on implicit behavior that could change across upgrades.

## Verification

After `bun run build`:

```
find build/client -name '*.map' | wc -l
# → 0  (no client-side source maps served to browsers)
```

Note: `build/server/*.map` files are the adapter-node's internal SSR bundling artifacts and are not served over HTTP in a standard deployment.

## Checks

- [x] `bun run format` — no changes
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run check` — 0 errors, 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Production builds no longer generate source maps, resulting in smaller bundle sizes and improved deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->