### PR TITLE
fix(stores): add safe localStorage wrappers to prevent unhandled errors

### DIFF
--- a/src/lib/stores/preferences.svelte.ts
+++ b/src/lib/stores/preferences.svelte.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import type { UserPreferences } from '$lib/types/user';
 import type { ViewPreferences } from '$lib/types/view';
+import { safeGetItem, safeSetItem, safeRemoveItem } from '$lib/utils/storage';
 
 type CodeFormat = 'yaml' | 'json';
 
@@ -46,7 +47,7 @@ function createPreferencesStore() {
 	let _viewPrefs = $state<ViewPreferences>(
 		(() => {
 			if (browser) {
-				const stored = localStorage.getItem('gyre:preferences');
+				const stored = safeGetItem('gyre:preferences');
 				if (stored) {
 					try {
 						return sanitizeViewPrefs(JSON.parse(stored));
@@ -61,7 +62,7 @@ function createPreferencesStore() {
 
 	// --- Code Editor Format ---
 	let _format = $state<CodeFormat>(
-		(browser && (localStorage.getItem('gyre_code_format') as CodeFormat)) || 'yaml'
+		(browser && (safeGetItem('gyre_code_format') as CodeFormat)) || 'yaml'
 	);
 
 	// --- Notifications ---
@@ -75,7 +76,7 @@ function createPreferencesStore() {
 	// Helper to persist view preferences
 	function saveViewPrefs() {
 		if (browser) {
-			localStorage.setItem('gyre:preferences', JSON.stringify(_viewPrefs));
+			safeSetItem('gyre:preferences', JSON.stringify(_viewPrefs));
 		}
 	}
 
@@ -129,7 +130,7 @@ function createPreferencesStore() {
 		resetViewPrefs() {
 			_viewPrefs = { ...DEFAULT_VIEW_PREFERENCES };
 			if (browser) {
-				localStorage.removeItem('gyre:preferences');
+				safeRemoveItem('gyre:preferences');
 			}
 		},
 
@@ -140,7 +141,7 @@ function createPreferencesStore() {
 		setFormat(newFormat: CodeFormat) {
 			_format = newFormat;
 			if (browser) {
-				localStorage.setItem('gyre_code_format', newFormat);
+				safeSetItem('gyre_code_format', newFormat);
 			}
 		},
 		toggleFormat() {

--- a/src/lib/stores/sidebar.ts
+++ b/src/lib/stores/sidebar.ts
@@ -1,9 +1,10 @@
 import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
+import { safeGetItem, safeSetItem } from '$lib/utils/storage';
 
 function createSidebarStore() {
 	// Load from localStorage if in browser
-	const stored = browser ? localStorage.getItem('gyre:sidebar-open') : null;
+	const stored = browser ? safeGetItem('gyre:sidebar-open') : null;
 	const initial = stored !== null ? stored === 'true' : true; // Default to open
 
 	const { subscribe, set, update } = writable<boolean>(initial);
@@ -12,7 +13,7 @@ function createSidebarStore() {
 		subscribe,
 		set: (value: boolean) => {
 			if (browser) {
-				localStorage.setItem('gyre:sidebar-open', value.toString());
+				safeSetItem('gyre:sidebar-open', value.toString());
 			}
 			set(value);
 		},
@@ -20,20 +21,20 @@ function createSidebarStore() {
 			update((open) => {
 				const newValue = !open;
 				if (browser) {
-					localStorage.setItem('gyre:sidebar-open', newValue.toString());
+					safeSetItem('gyre:sidebar-open', newValue.toString());
 				}
 				return newValue;
 			});
 		},
 		open: () => {
 			if (browser) {
-				localStorage.setItem('gyre:sidebar-open', 'true');
+				safeSetItem('gyre:sidebar-open', 'true');
 			}
 			set(true);
 		},
 		close: () => {
 			if (browser) {
-				localStorage.setItem('gyre:sidebar-open', 'false');
+				safeSetItem('gyre:sidebar-open', 'false');
 			}
 			set(false);
 		}

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { safeGetItem, safeSetItem } from '$lib/utils/storage';
 
 export type Theme = 'light' | 'dark' | 'system';
 
@@ -17,7 +18,7 @@ function getSystemTheme(): 'light' | 'dark' {
 
 function getStoredTheme(): Theme {
 	if (!browser) return DEFAULT_THEME;
-	const stored = localStorage.getItem(STORAGE_KEY);
+	const stored = safeGetItem(STORAGE_KEY);
 	if (stored === 'light' || stored === 'dark' || stored === 'system') {
 		return stored;
 	}
@@ -81,7 +82,7 @@ function createThemeStore() {
 			applyTheme(store.resolvedTheme);
 
 			if (browser) {
-				localStorage.setItem(STORAGE_KEY, newTheme);
+				safeSetItem(STORAGE_KEY, newTheme);
 			}
 		},
 		toggle() {

--- a/src/lib/utils/storage.ts
+++ b/src/lib/utils/storage.ts
@@ -1,0 +1,33 @@
+import { logger } from '$lib/utils/logger.js';
+
+/**
+ * Safe localStorage wrappers that catch storage errors (quota exceeded,
+ * private-browsing restrictions, etc.) and log them instead of throwing.
+ *
+ * Callers are responsible for browser-environment guards before calling these.
+ */
+
+export function safeGetItem(key: string): string | null {
+	try {
+		return localStorage.getItem(key);
+	} catch (err) {
+		logger.warn(err, `[Storage] Failed to read key "${key}"`);
+		return null;
+	}
+}
+
+export function safeSetItem(key: string, value: string): void {
+	try {
+		localStorage.setItem(key, value);
+	} catch (err) {
+		logger.warn(err, `[Storage] Failed to write key "${key}"`);
+	}
+}
+
+export function safeRemoveItem(key: string): void {
+	try {
+		localStorage.removeItem(key);
+	} catch (err) {
+		logger.warn(err, `[Storage] Failed to remove key "${key}"`);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #339 — inconsistent localStorage error handling across Svelte stores.

- Introduces `src/lib/utils/storage.ts` with three safe wrappers (`safeGetItem`, `safeSetItem`, `safeRemoveItem`) that catch all storage errors and log via `logger.warn`, matching the existing pattern in `events.svelte.ts`
- Updates `sidebar.ts`, `theme.svelte.ts`, and `preferences.svelte.ts` to use these wrappers instead of calling `localStorage` directly

## Test plan

- [x] Run `bun run check` — 0 errors/warnings (verified)
- [x] Run `bun run lint` — 0 errors/warnings (verified)
- [x] Open app in private/incognito window — sidebar, theme, and preferences should load with defaults instead of throwing unhandled exceptions
- [x] Verify console shows `[WARN]` messages (not thrown errors) when storage is restricted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced storage operation reliability across preferences, theme, and sidebar features with added error handling and logging for localStorage access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->