### PR TITLE
fix(command-palette): consolidate keydown listener cleanup into onMount return

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, onDestroy, tick } from 'svelte';
+	import { onMount, tick } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import * as Dialog from '$lib/components/ui/dialog';
@@ -183,11 +183,11 @@
 	onMount(() => {
 		window.addEventListener('keydown', handleKeydown);
 		const unsubscribe = commandPaletteOpen.subscribe((v) => { if (v && !open) open = true; });
-		return unsubscribe;
-	});
 
-	onDestroy(() => {
-		if (typeof window !== 'undefined') window.removeEventListener('keydown', handleKeydown);
+		return () => {
+			window.removeEventListener('keydown', handleKeydown);
+			unsubscribe();
+		};
 	});
 
 	// Precompute item id → flat index once per groupedItems change (O(n) total vs O(n²) per render)


### PR DESCRIPTION
## Summary

- Moves `window.removeEventListener('keydown', handleKeydown)` from `onDestroy` into the cleanup function returned by `onMount`
- Moves the store `unsubscribe()` call into the same cleanup function
- Removes the `onDestroy` call entirely
- Removes the now-unused `onDestroy` import from svelte

## Why

During HMR, Svelte only guarantees the `onMount` return path fires — `onDestroy` can be skipped. This left the `keydown` listener permanently attached to `window` across hot-reloads.

## Test plan

- [ ] Open the app in dev mode, open the command palette, trigger HMR (edit any file), confirm `Ctrl+K` / `Cmd+K` still works and no duplicate handlers fire
- [ ] Verify normal mount/unmount cycle still cleans up correctly

Closes #340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal lifecycle management for optimal performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->