### PR TITLE
fix(security): add missing X-Permitted-Cross-Domain-Policies header

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -77,6 +77,7 @@ function isPublicRoute(path: string): boolean {
 function setSecurityHeaders(response: Response): void {
 	response.headers.set('X-Content-Type-Options', 'nosniff');
 	response.headers.set('X-Frame-Options', 'DENY');
+	response.headers.set('X-Permitted-Cross-Domain-Policies', 'none');
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 	response.headers.set(
 		'Content-Security-Policy',


### PR DESCRIPTION
## Summary

- Adds `X-Permitted-Cross-Domain-Policies: none` to the `setSecurityHeaders()` function in `src/hooks.server.ts`
- Completes the standard security header suite flagged by OWASP ZAP, Mozilla Observatory, and Security Headers scanners
- Placed alongside `X-Frame-Options` for logical grouping of "denial" headers

Closes #343

## Test plan

- [x] `bun run format` — no changes
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run check` — 0 errors, 0 warnings
- [x] Verify `X-Permitted-Cross-Domain-Policies: none` appears in response headers when running dev server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security headers to restrict cross-domain policies, strengthening protection against potential security threats and improving overall application safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->