### PR TITLE
fix(events): resolve notification state mismatch and reliability issues

### DIFF
--- a/src/lib/server/events.ts
+++ b/src/lib/server/events.ts
@@ -257,6 +257,8 @@ async function poll(context: ClusterContext) {
 					context.clusterId === 'in-cluster' ? undefined : context.clusterId
 				);
 
+				if (!context.isActive) return;
+
 				resourcePollsTotal.labels(context.clusterId, resourceType, 'success').inc();
 
 				if (resourceList && resourceList.items) {
@@ -341,6 +343,8 @@ async function poll(context: ClusterContext) {
 									// Don't fail event broadcast if history capture fails
 								}
 
+								if (!context.isActive) return;
+
 								broadcast(context, {
 									type: 'ADDED',
 									clusterId: context.clusterId,
@@ -400,6 +404,8 @@ async function poll(context: ClusterContext) {
 										);
 										// Don't fail event broadcast if history capture fails
 									}
+
+									if (!context.isActive) return;
 
 									broadcast(context, {
 										type: 'MODIFIED',

--- a/src/lib/stores/events.svelte.ts
+++ b/src/lib/stores/events.svelte.ts
@@ -159,8 +159,8 @@ class RealtimeStore {
 			if (err instanceof DOMException && err.name === 'QuotaExceededError') {
 				try {
 					const reduced = this.notifications.slice(0, Math.floor(MAX_NOTIFICATIONS / 2));
-					localStorage.setItem(NOTIFICATIONS_STORAGE_KEY, JSON.stringify(reduced));
 					localStorage.removeItem(NOTIFICATION_STATE_STORAGE_KEY);
+					localStorage.setItem(NOTIFICATIONS_STORAGE_KEY, JSON.stringify(reduced));
 					logger.warn('[Storage] localStorage quota exceeded, saved reduced notification set');
 				} catch {
 					localStorage.removeItem(NOTIFICATIONS_STORAGE_KEY);


### PR DESCRIPTION
## Summary

Fixes all issues reported in #283 across `src/lib/server/events.ts` and `src/lib/stores/events.svelte.ts`.

- **Client-server state mismatch (Medium):** Removed the extra `type` field from the client's `currentState` JSON — it wasn't present in the server's `notificationState`, breaking client-side deduplication for `MODIFIED` events.
- **Recovery notifications suppressed (Medium):** Decoupled `becameHealthy` from `revisionChanged` in `shouldNotify`. Resources that self-heal (`False → True`) without deploying a new revision now correctly trigger a notification.
- **No localStorage quota fallback (Medium):** `saveToStorage` now catches `QuotaExceededError` specifically, retries with half the notification count (dropping state cache to free space), and as a last resort clears both storage keys rather than silently losing data.
- **Incomplete transient state handling (Low):** `isTransientState` now covers `null`/`undefined`/empty `readyStatus` in addition to `'Unknown'`, preventing spurious notifications when conditions haven't been populated yet.
- **Potential memory leak (Low):** `stopWorker` explicitly clears `lastStates`, `lastNotificationStates`, and `resourceFirstSeen` Maps after removing Prometheus gauge labels, preventing accumulation if a cluster context is stopped externally.

## Test plan

- [x] `bun run check` — 0 errors, 0 warnings ✅
- [x] `bun run lint` — 0 errors, 0 warnings ✅
- [x] `bun run format` — no diff ✅
- [x] Manual: trigger a resource failure → confirm warning notification appears
- [x] Manual: recover resource without revision change → confirm recovery notification fires
- [x] Manual: confirm no duplicate notifications on repeated polls with no state change

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Full per-cluster state reset on shutdown to avoid stale caches
  * Poll loop now exits promptly when polling is stopped to prevent spurious events
  * Broader detection of transient ready states (treat missing/empty as transient)
  * Notifications now fire when a resource becomes healthy even without a revision change
  * Storage quota fallback that persists a reduced notification set and clears state when needed
  * Improved duplicate detection for modified events to avoid type-based mismatches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->