### PR TITLE
fix: address SSE implementation issues (#290)

### DIFF
--- a/src/lib/server/events.ts
+++ b/src/lib/server/events.ts
@@ -34,6 +34,7 @@ export interface SSEEvent {
 	message?: string;
 	timestamp: string;
 	serverSessionId?: string;
+	reason?: string;
 }
 
 // Stable identifier for this server process lifetime; changes on restart
@@ -86,7 +87,8 @@ export async function closeAllEventStreams() {
 		broadcast(context, {
 			type: 'SHUTDOWN',
 			clusterId,
-			timestamp: new Date().toISOString()
+			timestamp: new Date().toISOString(),
+			reason: 'server_shutdown'
 		});
 		// Explicitly call stopWorker to guarantee timer cleanup even if a subscriber throws.
 		// It is safe if stopWorker is called twice (idempotent check for null intervals).

--- a/src/lib/stores/events.svelte.ts
+++ b/src/lib/stores/events.svelte.ts
@@ -201,15 +201,18 @@ class RealtimeStore {
 
 		try {
 			this.eventSource = new EventSource(sseUrl);
+			const es = this.eventSource;
 
-			this.eventSource.onopen = () => {
+			es.onopen = () => {
+				if (this.eventSource !== es) return;
 				this.status = 'connected';
 				this.reconnectAttempts = 0;
 				this.notifyStatusChange('connected');
 				logger.info('[SSE] Connected to event stream');
 			};
 
-			this.eventSource.onmessage = (event) => {
+			es.onmessage = (event) => {
+				if (this.eventSource !== es) return;
 				try {
 					const data: ResourceEvent = JSON.parse(event.data);
 					this.handleMessage(data);
@@ -218,8 +221,9 @@ class RealtimeStore {
 				}
 			};
 
-			this.eventSource.onerror = () => {
-				const rs = this.eventSource?.readyState;
+			es.onerror = () => {
+				if (this.eventSource !== es) return;
+				const rs = es.readyState;
 				if (rs === EventSource.CLOSED) {
 					logger.info('[SSE] Connection closed');
 					this.status = 'disconnected';
@@ -229,7 +233,7 @@ class RealtimeStore {
 					this.status = 'error';
 					this.notifyStatusChange('error');
 				}
-				this.eventSource?.close();
+				es.close();
 				this.eventSource = null;
 				this.scheduleReconnect();
 			};

--- a/src/routes/api/v1/events/+server.ts
+++ b/src/routes/api/v1/events/+server.ts
@@ -154,7 +154,8 @@ export const GET: RequestHandler = async ({ request, locals, getClientAddress })
 							type: 'SHUTDOWN',
 							clusterId,
 							message: 'Connection timeout – please reconnect',
-							timestamp: new Date().toISOString()
+							timestamp: new Date().toISOString(),
+							reason: 'connection_timeout'
 						};
 						try {
 							controller.enqueue(encoder.encode(`data: ${JSON.stringify(timeoutEvent)}\n\n`));


### PR DESCRIPTION
## Summary

Fixes the confirmed bugs from issue #290 in the SSE implementation:

- **Double-release in cleanup/cancel** (`+server.ts`): Added an `isCleanedUp` idempotency guard to `cleanup()` so that `release()` (the connection slot counter) is never called more than once, even when abort, `cancel()`, SHUTDOWN, and buffer-overflow paths all fire in close succession.

- **Reconnection blocked during server shutdown in dev mode** (`events.svelte.ts`): `scheduleReconnect()` now mirrors the DEV mode bypass already present in `connect()` — when `isServerShutdown` is true in dev, the flag is cleared and reconnection proceeds normally. This enables automatic recovery after HMR server restarts.

- **`onerror` doesn't distinguish error from clean close** (`events.svelte.ts`): The `onerror` handler now checks `EventSource.readyState` to distinguish a clean server-side close (`CLOSED`) from a genuine connection error, logging at `info` vs `warn` respectively.

- **No user notification when max reconnect attempts reached** (`events.svelte.ts`): When the reconnect limit is exhausted, `status` is explicitly set to `'error'` and `notifyStatusChange` is called so the UI can surface the permanent failure.

## Non-issues confirmed

- **ReconnectDelay never reset**: `reconnectDelay` is an immutable field; the delay resets via `reconnectAttempts = 0` in `onopen`. No change needed.
- **State updated even if poll failed**: All state updates in `events.ts` are guarded by `if (resourceList && resourceList.items)`. No change needed.

## Test plan

- [x] `bun run format` — passes
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run check` — 0 svelte-check errors
- [x] `bun test src/tests/events.test.ts` — 12/12 pass

Closes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event payloads can include an optional shutdown/reason field surfaced in logs and status updates.
  * Timeout shutdowns now convey a specific connection-timeout reason.

* **Bug Fixes**
  * Distinguish clean server shutdowns from connection errors with appropriate logging and status transitions.
  * Improved reconnection behavior in development vs. production.
  * Prevent duplicate cleanup runs during connection teardown.
  * Ensure error status is set and notified when max reconnect attempts are exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->