### PR TITLE
fix(audit): add audit logging for user preference updates (GH #336)

### DIFF
--- a/src/routes/api/v1/user/preferences/+server.ts
+++ b/src/routes/api/v1/user/preferences/+server.ts
@@ -8,6 +8,7 @@ import type { RequestHandler } from './$types';
 import type { UserPreferences } from '$lib/types/user';
 import { requirePermission } from '$lib/server/rbac';
 import { checkRateLimit } from '$lib/server/rate-limiter';
+import { logAudit } from '$lib/server/audit';
 
 const preferencesSchema = z.object({
 	theme: z.enum(['light', 'dark', 'system']).optional(),
@@ -137,12 +138,15 @@ export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
 		};
 
 		await db
-
 			.update(users)
-
 			.set({ preferences: mergedPreferences })
-
 			.where(eq(users.id, locals.user.id));
+
+		await logAudit(locals.user, 'preferences:update', {
+			resourceType: 'UserPreferences',
+			clusterId: locals.cluster,
+			details: { updatedFields: Object.keys(newPreferences) }
+		});
 
 		return json({ success: true, preferences: mergedPreferences });
 	} catch (err) {


### PR DESCRIPTION
## Summary

- Adds `logAudit()` call to the user preferences endpoint for successful updates
- Follows the same pattern used by other mutating endpoints (backups, cluster config, RBAC, user management)
- Closes the audit gap identified in GH issue #336

## Changes

- Modified `src/routes/api/v1/user/preferences/+server.ts`:
  - Added import for `logAudit` from `$lib/server/audit`
  - Added audit logging after successful preference update with action `preferences:update`

## Testing

- Format: `bun run format` ✓
- Lint: `bun run lint` ✓
- Typecheck: `bun run check` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced audit tracking for user preference updates to maintain records of configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->