### PR TITLE
fix(auth): resolve four security vulnerabilities (#383)

### DIFF
--- a/drizzle/0009_require_password_change.sql
+++ b/drizzle/0009_require_password_change.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN requires_password_change INTEGER NOT NULL DEFAULT 0;

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -32,8 +32,11 @@ function warnIfWeakAdminPassword(password: string): void {
 	}
 }
 
-// Store generated password temporarily for first-time setup display
-let generatedAdminPassword: string | null = null;
+// Pre-computed dummy hash for constant-time comparisons (prevents timing-based enumeration)
+const DUMMY_HASH: Promise<string> = bcrypt.hash('__dummy_password_for_timing__', SALT_ROUNDS);
+
+// Tracks whether a setup token file has been written and not yet consumed
+let pendingSetupCleanup = false;
 
 // Path to the local-dev setup token file; cleared after first successful login
 let setupTokenFilePath: string | null = null;
@@ -47,16 +50,16 @@ export function setSetupTokenFile(filePath: string): void {
 }
 
 export function cleanupSetupTokenFile(): void {
-	if (generatedAdminPassword === null || setupTokenFilePath === null) return;
+	if (!pendingSetupCleanup || setupTokenFilePath === null) return;
 	const filePath = setupTokenFilePath;
 	try {
 		unlinkSync(filePath);
 		setupTokenFilePath = null;
-		generatedAdminPassword = null;
+		pendingSetupCleanup = false;
 	} catch (err) {
 		if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
 			setupTokenFilePath = null;
-			generatedAdminPassword = null;
+			pendingSetupCleanup = false;
 		} else {
 			logger.error(
 				{ err, filePath },
@@ -127,10 +130,11 @@ export function generateStrongPassword(): string {
 }
 
 /**
- * Get the generated admin password (for initial setup display)
+ * @deprecated The generated admin password is no longer stored in memory.
+ * It is returned directly from createDefaultAdminIfNeeded() and written to a restricted temp file.
  */
 export function getGeneratedAdminPassword(): string | null {
-	return generatedAdminPassword;
+	return null;
 }
 
 // Password hashing
@@ -189,6 +193,11 @@ export function isInClusterAdmin(user: User): boolean {
 	return normalizeUsername(user.username) === 'admin' && isInClusterMode();
 }
 
+export async function clearRequiresPasswordChange(userId: string): Promise<void> {
+	const db = await getDb();
+	await db.update(users).set({ requiresPasswordChange: false }).where(eq(users.id, userId));
+}
+
 // Internal helper: fetch the credential hash directly by userId, skipping the
 // user-row re-fetch and in-cluster-admin re-check. Callers must have already
 // handled the in-cluster-admin case before calling this.
@@ -207,6 +216,8 @@ export async function verifyManagedUserPassword(user: User, password: string): P
 
 	const credentialPasswordHash = await getCredentialHashDirect(user.id);
 	if (!credentialPasswordHash) {
+		// Run dummy verification to prevent timing-based enumeration of SSO vs credential accounts
+		await verifyPassword(password, await DUMMY_HASH);
 		return false;
 	}
 
@@ -583,7 +594,7 @@ export async function loadOrCreateInClusterAdmin(): Promise<string | null> {
 		// Use ADMIN_PASSWORD from env if provided, otherwise generate a strong one
 		const password = process.env.ADMIN_PASSWORD || generateStrongPassword();
 		if (process.env.ADMIN_PASSWORD) warnIfWeakAdminPassword(process.env.ADMIN_PASSWORD);
-		generatedAdminPassword = password;
+		pendingSetupCleanup = true;
 
 		// Hash for storage
 		inClusterAdminPasswordHash = await hashPassword(password);
@@ -683,7 +694,8 @@ export async function createDefaultAdminIfNeeded(): Promise<{
 				name: 'admin',
 				role: 'admin',
 				email: 'admin@gyre.local',
-				active: true
+				active: true,
+				requiresPasswordChange: true
 			};
 			db.transaction((tx) => {
 				tx.insert(users).values(newUser).run();
@@ -707,7 +719,7 @@ export async function createDefaultAdminIfNeeded(): Promise<{
 	// Local development mode: Use env var or generate password
 	const password = process.env.ADMIN_PASSWORD || generateStrongPassword();
 	if (process.env.ADMIN_PASSWORD) warnIfWeakAdminPassword(process.env.ADMIN_PASSWORD);
-	generatedAdminPassword = password;
+	pendingSetupCleanup = true;
 
 	const db = getDbSync();
 	const passwordHash = await hashPassword(password);
@@ -717,7 +729,8 @@ export async function createDefaultAdminIfNeeded(): Promise<{
 		name: 'admin',
 		role: 'admin',
 		email: 'admin@gyre.local',
-		active: true
+		active: true,
+		requiresPasswordChange: true
 	};
 	db.transaction((tx) => {
 		tx.insert(users).values(newUser).run();

--- a/src/lib/server/auth/better-auth.ts
+++ b/src/lib/server/auth/better-auth.ts
@@ -4,6 +4,7 @@ import { parseSetCookieHeader } from 'better-auth/cookies';
 import { makeSignature } from 'better-auth/crypto';
 import { username } from 'better-auth/plugins/username';
 import type { Cookies } from '@sveltejs/kit';
+import { randomBytes } from 'node:crypto';
 import { logger } from '$lib/server/logger.js';
 import { getDb, getDbSync, schema } from '$lib/server/db';
 import { DEFAULT_COOKIE_OPTIONS, IS_PROD } from '$lib/server/config';
@@ -127,6 +128,17 @@ function createBetterAuth() {
 
 let authInstance: ReturnType<typeof createBetterAuth> | null = null;
 
+let _ephemeralSecret: string | null = null;
+function getEphemeralSecret(): string {
+	if (!_ephemeralSecret) {
+		_ephemeralSecret = randomBytes(32).toString('hex');
+		logger.warn(
+			'[Auth] No BETTER_AUTH_SECRET or AUTH_ENCRYPTION_KEY configured — using an ephemeral random secret. All sessions will be invalidated on restart. Set BETTER_AUTH_SECRET to persist sessions.'
+		);
+	}
+	return _ephemeralSecret;
+}
+
 function getBetterAuthSecret(): string {
 	const configuredSecret = process.env.BETTER_AUTH_SECRET ?? process.env.AUTH_ENCRYPTION_KEY;
 
@@ -138,7 +150,7 @@ function getBetterAuthSecret(): string {
 		throw new Error('Better Auth requires BETTER_AUTH_SECRET or AUTH_ENCRYPTION_KEY in production');
 	}
 
-	return 'gyre-dev-auth-secret';
+	return getEphemeralSecret();
 }
 
 export function getBetterAuth() {

--- a/src/lib/server/db/migrate.ts
+++ b/src/lib/server/db/migrate.ts
@@ -111,7 +111,8 @@ export function initDatabase(): void {
 		sql`ALTER TABLE users ADD COLUMN preferences TEXT`,
 		sql`ALTER TABLE users ADD COLUMN name TEXT NOT NULL DEFAULT ''`,
 		sql`ALTER TABLE users ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 0`,
-		sql`ALTER TABLE users ADD COLUMN image TEXT`
+		sql`ALTER TABLE users ADD COLUMN image TEXT`,
+		sql`ALTER TABLE users ADD COLUMN requires_password_change INTEGER NOT NULL DEFAULT 0`
 	]) {
 		try {
 			db.run(ddl);

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -22,6 +22,9 @@ export const users = sqliteTable('users', {
 		.default('viewer'),
 	active: integer('active', { mode: 'boolean' }).notNull().default(true),
 	isLocal: integer('is_local', { mode: 'boolean' }).notNull().default(true), // true = local auth (password), false = SSO-only
+	requiresPasswordChange: integer('requires_password_change', { mode: 'boolean' })
+		.notNull()
+		.default(false),
 	createdAt: integer('created_at', { mode: 'timestamp' })
 		.notNull()
 		.default(sql`(unixepoch())`),

--- a/src/routes/api/v1/auth/change-password/+server.ts
+++ b/src/routes/api/v1/auth/change-password/+server.ts
@@ -4,6 +4,7 @@ import { z } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
 import {
 	addPasswordHistory,
+	clearRequiresPasswordChange,
 	getCredentialAccount,
 	getCredentialPasswordHash,
 	isInClusterAdmin,
@@ -207,6 +208,8 @@ export const POST: RequestHandler = async ({ request, locals, setHeaders, cookie
 			ipAddress: locals.session?.ipAddress || undefined,
 			details: { userId: user.id }
 		});
+
+		await clearRequiresPasswordChange(user.id);
 
 		return json({
 			success: true,

--- a/src/routes/api/v1/auth/login/+server.ts
+++ b/src/routes/api/v1/auth/login/+server.ts
@@ -47,7 +47,8 @@ export const _metadata = {
 								id: z.string(),
 								username: z.string(),
 								email: z.string().nullable(),
-								role: z.string()
+								role: z.string(),
+								requiresPasswordChange: z.boolean()
 							})
 						})
 					}
@@ -190,7 +191,8 @@ export const POST: RequestHandler = async (event) => {
 				id: user.id,
 				username: user.username,
 				email: user.email,
-				role: user.role
+				role: user.role,
+				requiresPasswordChange: user.requiresPasswordChange
 			}
 		});
 	} catch (err) {

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -79,7 +79,7 @@
 
 			toast.success('Login successful! Redirecting...');
 
-			if (password === 'admin' && result.user?.role === 'admin') {
+			if (result.user?.requiresPasswordChange) {
 				window.location.href = '/change-password?first=true';
 			} else {
 				const returnTo = page.url.searchParams.get('returnTo');


### PR DESCRIPTION
## Summary

Fixes #383 — four authentication security vulnerabilities.

- **Client-side password comparison removed**: replaced `if (password === 'admin')` in the login page with a server-provided `requiresPasswordChange` boolean in the login API response. Set `true` on admin creation, cleared `false` after successful password change.

- **Timing attack mitigated**: `verifyManagedUserPassword` previously returned `false` immediately (no bcrypt) for SSO-only users, enabling timing-based enumeration of account types. Now performs a dummy `bcrypt.compare` against a pre-computed `DUMMY_HASH` — same pattern the login route already uses.

- **Hardcoded dev secret replaced**: `getBetterAuthSecret()` no longer falls back to the known constant `'gyre-dev-auth-secret'`. Generates a cryptographically random 32-byte ephemeral secret per process instance with a warning log instead.

- **Plaintext password removed from module scope**: `generatedAdminPassword: string | null` replaced by `pendingSetupCleanup: boolean`. The password is returned directly from `createDefaultAdminIfNeeded()` and written to a 0600 temp file — never stored as a module-level variable.

## Changes

| File | Change |
|------|--------|
| `src/lib/server/db/schema.ts` | Add `requiresPasswordChange` boolean column |
| `src/lib/server/db/migrate.ts` | Idempotent `ALTER TABLE` for existing DBs |
| `drizzle/0009_require_password_change.sql` | Migration for fresh installs |
| `src/lib/server/auth.ts` | All four fixes |
| `src/lib/server/auth/better-auth.ts` | Ephemeral random secret |
| `src/routes/api/v1/auth/login/+server.ts` | Expose `requiresPasswordChange` in response |
| `src/routes/login/+page.svelte` | Use server flag instead of client-side comparison |
| `src/routes/api/v1/auth/change-password/+server.ts` | Clear flag after successful password change |

## Test plan

- [x] Fresh install: log in as admin → redirects to `/change-password?first=true`
- [x] After changing password: subsequent login does not redirect
- [x] Existing DB upgrade: `requires_password_change` column added idempotently; existing users get `false`
- [x] Dev mode without `BETTER_AUTH_SECRET`: warning logged, sessions still work
- [x] `bun run format && bun run lint && bun run check` all pass ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password change requirement tracking for user accounts. Users required to change their password are now automatically redirected to the password change page upon login.

* **Bug Fixes**
  * Improved login flow logic to dynamically determine password change requirements instead of using hardcoded checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->