### PR TITLE
fix(security): pin GitHub Actions to commit hashes and fix CI issues

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Cleanup untagged images
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
         with:
           image-names: gyre
           cut-off: 7d
@@ -26,7 +26,7 @@ jobs:
           timestamp-to-use: created_at
 
       - name: Cleanup old PR images
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
         with:
           image-names: gyre
           cut-off: 7d
@@ -35,21 +35,6 @@ jobs:
           image-tags: 'pr-*'
           tag-selection: tagged
           keep-n-most-recent: 5
-          timestamp-to-use: created_at
-
-      # Cleans up legacy SHA-tagged releases (e.g. v0.1.0-abc1234) that
-      # accumulated before SHA tag generation was removed from build.yml.
-      # This step can be removed once all pre-existing SHA tags have expired.
-      - name: Cleanup legacy SHA-tagged releases
-        uses: snok/container-retention-policy@v3.0.1
-        with:
-          image-names: gyre
-          cut-off: 14d
-          account: user
-          token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: 'v*-*'
-          tag-selection: tagged
-          keep-n-most-recent: 0
           timestamp-to-use: created_at
 
       - name: Cleanup summary
@@ -62,7 +47,6 @@ jobs:
           echo "|------|------------------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| **Untagged images** | 7 days | Automatically removed |" >> $GITHUB_STEP_SUMMARY
           echo "| **PR tags** (\`pr-*\`) | 7 days | Keep 5 most recent |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Legacy SHA tags** (\`v*-*\`) | 14 days | Transitional — remove step once expired |" >> $GITHUB_STEP_SUMMARY
           echo "| **Release tags** (\`v*.*.*\`) | Forever | Not matched by cleanup rules |" >> $GITHUB_STEP_SUMMARY
           echo "| **latest / main / develop** | Forever | Not matched by cleanup rules |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended,security-and-quality
@@ -54,10 +54,10 @@ jobs:
               - documentation/build
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
         with:
           category: '/language:${{ matrix.language }}'
           upload: true

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
           npm run build
 
       - name: Upload build artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: documentation/build
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,7 +38,7 @@ jobs:
         id: bun-lock-hash
         run: |
           if [ -f bun.lock ]; then
-            echo "hash=$(shasum bun.lock | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+            echo "hash=$(sha256sum bun.lock | awk '{print $1}')" >> $GITHUB_OUTPUT
             echo "lockfile_exists=true" >> $GITHUB_OUTPUT
           else
             echo "lockfile_exists=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -27,9 +27,9 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@f0accbfd55e3332a28f721b8202b1016cecf90d5 # v5
         with:
-          version: 'latest'
+          version: 'v3.20.1'
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -86,7 +86,7 @@ jobs:
           EOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           name: Release ${{ steps.tag.outputs.tag_name }}
           body_path: release_notes.md


### PR DESCRIPTION
## Summary

Resolves #389 — addresses all four security issues identified in the GitHub Actions / CI/CD audit:

- **Pin all actions to immutable commit SHAs** across `codeql.yml`, `docs-deploy.yml`, `release.yml`, and `cleanup-ghcr.yml`. Version tags like `@v4` can be force-pushed to point at arbitrary code; commit hashes cannot.
- **Replace `shasum` with `sha256sum`** in `lint.yaml` cache step. `shasum` is macOS/BSD-specific; `sha256sum` is the correct GNU coreutils command on Linux runners.
- **Pin Helm to `v3.20.1`** instead of `'latest'` in `release.yml`. Prevents non-deterministic builds and unintentional Helm 4 major-version upgrade.
- **Remove the legacy SHA-tag cleanup step** from `cleanup-ghcr.yml`. The step's own comment said to remove it once tags expired (14-day TTL). Keeping it posed a risk: the `v*-*` glob with `keep-n-most-recent: 0` would also match pre-release semver tags like `v1.0.0-rc.1`.

## Test plan

- [x] Verify no bare `@vN` refs remain: `grep -rn "uses:" .github/workflows/ | grep -E "@v[0-9]" | grep -v "#"`
- [x] Confirm `cleanup-ghcr.yml` no longer contains `v*-*` or `keep-n-most-recent: 0`
- [x] Confirm `release.yml` Helm step shows `version: 'v3.20.1'`
- [x] Confirm `lint.yaml` cache step uses `sha256sum`
- [x] CI passes on this PR (lint, type-check, build workflows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use pinned commit SHAs for improved security and reproducibility.
  * Removed unused container cleanup step.
  * Stabilized Helm version in release workflow.
  * Improved lockfile hash calculation in lint workflow.

**Note:** These are internal infrastructure updates with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->