### PR TITLE
fix: address template and configuration bugs

### DIFF
--- a/src/lib/server/kubernetes/errors.ts
+++ b/src/lib/server/kubernetes/errors.ts
@@ -75,7 +75,10 @@ export function sanitizeK8sErrorMessage(message: string): string {
 			// Redact full URLs (scheme://host[:port]/path?query#fragment)
 			.replace(/https?:\/\/[^\s]+/g, '[REDACTED URL]')
 			// Redact IPv4 addresses
-			.replace(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/g, '[REDACTED IP]')
+			.replace(
+				/\b(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])){3}\b/g,
+				'[REDACTED IP]'
+			)
 			// Redact IPv6 addresses (simplified pattern)
 			.replace(/\[?[0-9a-fA-F:]+:[0-9a-fA-F:]+\]?/g, '[REDACTED IP]')
 			// Redact possible sensitive tokens in messages

--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -52,7 +52,7 @@ export interface TemplateSection {
 }
 
 const CEL_VALIDATION = {
-	pattern: '^[a-zA-Z0-9_.()\\[\\]"\' !&|=<>+\\-*/%?:,\\n\\r\\t ]{1,500}$',
+	pattern: '^[a-zA-Z0-9_.()\\[\\]"\' !&|=<>+\\-*/%:, ]{1,500}$',
 	message:
 		'CEL expression must use only alphanumeric characters, operators, and field accessors. Max 500 characters.'
 };
@@ -266,7 +266,7 @@ spec:
 				'The interval at which to check the upstream repository for changes. Flux supports: 1h30m, 5m, 30s, etc.',
 			docsUrl: 'https://fluxcd.io/flux/components/source/gitrepositories/#interval',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message:
 					'Duration must use time units like: 1m (minutes), 30s (seconds), 1h (hours), or combined like 1h30m'
 			}
@@ -352,7 +352,7 @@ spec:
 			placeholder: '60s',
 			description: 'Timeout for Git operations',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		},
@@ -551,7 +551,7 @@ spec:
 			}
 		},
 		{
-			name: 'url',
+			name: 'url_oci',
 			label: 'Repository URL',
 			path: 'spec.url',
 			type: 'string',
@@ -579,7 +579,7 @@ spec:
 			placeholder: '5m',
 			description: 'How often to check for new chart versions',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message:
 					'Duration must use time units like: 1m (minutes), 30s (seconds), 1h (hours), or combined like 1h30m'
 			}
@@ -662,7 +662,7 @@ spec:
 			placeholder: '60s',
 			description: 'Timeout for index download operations',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		}
@@ -830,7 +830,7 @@ spec:
 			placeholder: '5m',
 			description: 'How often to reconcile the Kustomization',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message:
 					'Duration must use time units like: 1m (minutes), 30s (seconds), 1h (hours), or combined like 1h30m'
 			}
@@ -976,7 +976,7 @@ spec:
 			placeholder: '5m',
 			description: 'Timeout for health checks and operations',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		},
@@ -1018,7 +1018,7 @@ spec:
 			placeholder: '1m',
 			description: 'How often to retry after a failure',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		},
@@ -1392,7 +1392,7 @@ spec:
 			placeholder: '5m',
 			description: 'How often to reconcile the release',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message:
 					'Duration must use time units like: 1m (minutes), 30s (seconds), 1h (hours), or combined like 1h30m'
 			}
@@ -1609,7 +1609,7 @@ spec:
 			placeholder: '5m',
 			description: 'Timeout for Helm operations',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		},
@@ -1871,7 +1871,7 @@ spec:
 			placeholder: '5m',
 			description: 'How often to check for new chart versions',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message:
 					'Duration must use time units like: 1m (minutes), 30s (seconds), 1h (hours), or combined like 1h30m'
 			}
@@ -2106,7 +2106,7 @@ spec:
 			placeholder: '5m',
 			description: 'How often to check for changes',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message:
 					'Duration must use time units like: 1m (minutes), 30s (seconds), 1h (hours), or combined like 1h30m'
 			}
@@ -2179,7 +2179,7 @@ spec:
 			placeholder: '60s',
 			description: 'Timeout for bucket operations',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		},
@@ -2395,7 +2395,7 @@ spec:
 			placeholder: '5m',
 			description: 'How often to check for changes',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message:
 					'Duration must use time units like: 1m (minutes), 30s (seconds), 1h (hours), or combined like 1h30m'
 			}
@@ -2450,7 +2450,7 @@ spec:
 			placeholder: '60s',
 			description: 'Timeout for OCI operations',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		},
@@ -2876,7 +2876,7 @@ spec:
 			placeholder: '30s',
 			description: 'Timeout for sending notifications',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		},
@@ -3072,7 +3072,7 @@ spec:
 			placeholder: '10m',
 			description: 'Reconciliation interval',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message: 'Duration must be in Flux format (e.g., 60s, 1m30s, 5m)'
 			}
 		},
@@ -3198,7 +3198,7 @@ spec:
 			default: '5m',
 			description: 'How often to scan for new images',
 			validation: {
-				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))+$',
+				pattern: '^([0-9]+(\\.[0-9]+)?(s|m|h))*$',
 				message:
 					'Duration must use time units like: 1m (minutes), 30s (seconds), 1h (hours), or combined like 1h30m'
 			}


### PR DESCRIPTION
## Summary

Fixes #391 — four bugs in template field definitions and error message sanitization:

- **Duplicate field names**: Renamed OCI HelmRepository URL field `name` from `url` to `url_oci`. Both fields still write to `spec.url` via `path`; only the form state key (`field.name`) changed. Prevents silent `formValues` key collision in `ResourceWizard`.
- **Duration regex**: Changed outer quantifier from `+` to `*` in all 17 duration validation patterns. Fields are `required: true` so empty strings are blocked before pattern evaluation.
- **CEL regex**: Removed `\n`, `\r`, `\t`, and `?` from the allowed character class. CEL expressions are single-line and `?` is not a valid CEL operator.
- **IPv4 validation**: Replaced `\d{1,3}` per-octet matching with proper 0–255 range validation (`25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9]`) and added `\b` word boundaries to prevent partial matches.

## Test plan

- [x] Open the HelmRepository wizard, switch between Default and OCI types — both URL fields should show/validate independently
- [x] Enter a valid Flux duration like `1h30m` in any interval field — should pass validation
- [x] Enter `999.999.999.999` in a field — confirm it is NOT matched as a valid IP in error messages
- [x] Enter a multi-line CEL expression or one containing `?` — confirm it fails CEL validation
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — 0 errors (pre-existing warning in unrelated file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved IPv4 redaction in error messages to accurately mask only valid IP addresses, preventing over-redaction.
* Relaxed validation constraints for Flux duration field configurations to accept a broader range of valid formats.
* Refined CEL expression validation rules for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->