### PR TITLE
fix: address misc issues and tech debt (#392)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '25.8.1'
+          node-version: '22'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/src/lib/components/ui/Icon.svelte
+++ b/src/lib/components/ui/Icon.svelte
@@ -176,7 +176,7 @@
 		'file-edit': FileEdit,
 		'alert-triangle': AlertTriangle,
 		'help-circle': HelpCircle,
-		'rerotate-ccw': RotateCcw,
+		'rotate-ccw': RotateCcw,
 		'circle-off': CircleOff,
 		history: History,
 		'hard-drive': HardDrive,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,0 @@
-// Project-wide library entrypoint
-export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	},
-	"exclude": ["src/tests"]
+	"exclude": ["src/tests"] // Tests use bun-specific globals; they have their own tsconfig at src/tests/tsconfig.json
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
## Summary

- **Typo fix**: `'rerotate-ccw'` → `'rotate-ccw'` in `Icon.svelte` icon map (the icon was silently unmapped)
- **Remove dead file**: deleted `src/lib/index.ts` which contained only `export {}` — SvelteKit resolves `$lib` to the `src/lib/` directory directly, no barrel file needed
- **Document tsconfig exclusion**: added inline comment to `tsconfig.json` clarifying that `src/tests` is intentionally excluded because tests have their own `src/tests/tsconfig.json` with `bun-types`
- **LTS Node version**: changed `node-version: '25.8.1'` → `'22'` in lint CI workflow — Node 25 is a "Current" (non-LTS) release and may not be available on GitHub runners

## Test plan

- [x] `bun run format` — passes (270 files, no changes needed)
- [x] `bun run lint` — 0 errors, 0 new warnings (pre-existing warning in `request-limits.ts` unrelated to this PR)
- [x] `bun run check` — 0 errors, 0 warnings
- [x] Verify `rotate-ccw` icon renders correctly in the UI (was previously broken due to typo)

Closes #392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rotation icon mapping to display correctly.

* **Chores**
  * Updated Node.js version in CI workflow configuration.
  * Updated TypeScript configuration comments for test setup clarity.
  * Removed unused module export declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->