### PR TITLE
fix: remove cluster-context coupling from settings and preferences

### DIFF
--- a/src/lib/server/backup.ts
+++ b/src/lib/server/backup.ts
@@ -285,16 +285,24 @@ export function getDecryptedBackupBuffer(filename: string): Buffer | null {
 	if (!filePath) return null;
 
 	const data = readFileSync(filePath);
+	return getDecryptedBackupBufferFromBuffer(filename, data);
+}
 
-	if (filename.endsWith('.db.enc')) {
-		const key = getBackupEncryptionKey();
-		if (!key) {
-			throw new BackupError('BACKUP_ENCRYPTION_KEY is not set; cannot decrypt this backup.', 500);
-		}
-		return decryptBackup(data, key);
+/**
+ * Convert an uploaded or in-memory backup payload to a plain SQLite buffer.
+ * If the filename ends with .db.enc, the payload is decrypted first.
+ */
+export function getDecryptedBackupBufferFromBuffer(filename: string, data: Buffer): Buffer {
+	if (!filename.endsWith('.db.enc')) {
+		return data;
 	}
 
-	return data;
+	const key = getBackupEncryptionKey();
+	if (!key) {
+		throw new BackupError('BACKUP_ENCRYPTION_KEY is not set; cannot decrypt this backup.', 500);
+	}
+
+	return decryptBackup(data, key);
 }
 
 /**
@@ -526,3 +534,6 @@ function pruneOldBackups(): void {
 // — Test-only exports (underscore-prefixed, not part of the public API) —
 export { encryptBackup as _encryptBackup, decryptBackup as _decryptBackup };
 export { getBackupEncryptionKey as _getBackupEncryptionKey };
+export function _resetBackupEncryptionKeyCache(): void {
+	cachedEncryptionKey = undefined;
+}

--- a/src/routes/admin/backups/+page.svelte
+++ b/src/routes/admin/backups/+page.svelte
@@ -227,7 +227,7 @@
 				<input
 					bind:this={restoreInput}
 					type="file"
-					accept=".db,.sqlite,.sqlite3"
+					accept=".db,.db.enc"
 					class="hidden"
 					onchange={handleFileSelect}
 				/>
@@ -406,7 +406,8 @@
 			<h3 class="font-semibold text-purple-900 dark:text-purple-100">Restore from Backup</h3>
 			<p class="mt-2 text-sm text-purple-800 dark:text-purple-200">
 				Upload a previously downloaded backup file to restore the database. A safety backup is
-				always created before restoring. The file must be a valid Gyre SQLite database.
+				always created before restoring. Accepted formats: <code class="font-mono">.db</code>
+				(unencrypted) and <code class="font-mono">.db.enc</code> (AES-256-GCM encrypted).
 			</p>
 		</div>
 

--- a/src/routes/api/v1/admin/backups/restore/+server.ts
+++ b/src/routes/api/v1/admin/backups/restore/+server.ts
@@ -32,12 +32,10 @@ export const _metadata = {
 				content: {
 					'multipart/form-data': {
 						schema: z.object({
-							file: z
-								.any()
-								.openapi({
-									description: 'SQLite database backup file (.db or .db.enc)',
-									format: 'binary'
-								})
+							file: z.any().openapi({
+								description: 'SQLite database backup file (.db or .db.enc)',
+								format: 'binary'
+							})
 						})
 					}
 				}
@@ -147,12 +145,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 	} catch (err) {
 		if (err instanceof BackupError) {
 			logger.error(err, 'Backup restore error:');
-			const code =
-				err.status === 400
-					? 'BadRequest'
-					: err.status === 404
-						? 'NotFound'
-						: 'InternalServerError';
+			const code = err.status === 400 ? 'BadRequest' : 'InternalServerError';
 			const message = code !== 'InternalServerError' ? err.message : 'Failed to restore backup';
 			throw error(err.status, { message, code });
 		}

--- a/src/routes/api/v1/admin/backups/restore/+server.ts
+++ b/src/routes/api/v1/admin/backups/restore/+server.ts
@@ -7,7 +7,11 @@ import { logger } from '$lib/server/logger.js';
 import { json, error } from '@sveltejs/kit';
 import { z, errorSchema } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
-import { restoreFromBuffer } from '$lib/server/backup';
+import {
+	restoreFromBuffer,
+	getDecryptedBackupBufferFromBuffer,
+	BackupError
+} from '$lib/server/backup';
 import { logAudit } from '$lib/server/audit';
 import { requirePermission } from '$lib/server/rbac';
 import { REQUEST_LIMITS, formatSize } from '$lib/server/request-limits';
@@ -30,7 +34,10 @@ export const _metadata = {
 						schema: z.object({
 							file: z
 								.any()
-								.openapi({ description: 'SQLite database backup file (.db)', format: 'binary' })
+								.openapi({
+									description: 'SQLite database backup file (.db or .db.enc)',
+									format: 'binary'
+								})
 						})
 					}
 				}
@@ -118,8 +125,9 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
 		const arrayBuffer = await file.arrayBuffer();
 		const buffer = Buffer.from(arrayBuffer);
+		const restoreBuffer = getDecryptedBackupBufferFromBuffer(file.name, buffer);
 
-		const result = await restoreFromBuffer(buffer);
+		const result = await restoreFromBuffer(restoreBuffer);
 
 		await logAudit(locals.user, 'backup:restore', {
 			resourceType: 'DatabaseBackup',
@@ -137,6 +145,17 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 			backup: result
 		});
 	} catch (err) {
+		if (err instanceof BackupError) {
+			logger.error(err, 'Backup restore error:');
+			const code =
+				err.status === 400
+					? 'BadRequest'
+					: err.status === 404
+						? 'NotFound'
+						: 'InternalServerError';
+			const message = code !== 'InternalServerError' ? err.message : 'Failed to restore backup';
+			throw error(err.status, { message, code });
+		}
 		const status =
 			err !== null && typeof err === 'object' && 'status' in err
 				? (err as { status: unknown }).status

--- a/src/routes/api/v1/admin/settings/+server.ts
+++ b/src/routes/api/v1/admin/settings/+server.ts
@@ -41,7 +41,6 @@ export const _metadata = {
 					}
 				}
 			},
-			400: { description: 'Missing cluster context' },
 			401: { description: 'Unauthorized' },
 			403: { description: 'Admin access required' }
 		}
@@ -73,7 +72,7 @@ export const _metadata = {
 					}
 				}
 			},
-			400: { description: 'Invalid request or missing cluster context' },
+			400: { description: 'Invalid request body' },
 			401: { description: 'Unauthorized' },
 			403: { description: 'Admin access required' }
 		}
@@ -88,10 +87,6 @@ export const GET: RequestHandler = async ({ locals }) => {
 	// Check authentication
 	if (!locals.user) {
 		throw error(401, { message: 'Unauthorized' });
-	}
-
-	if (!locals.cluster) {
-		throw error(400, { message: 'Missing cluster context' });
 	}
 
 	// Enforce RBAC (checkPermission short-circuits for admin role)
@@ -147,10 +142,6 @@ export const PATCH: RequestHandler = async ({ locals, request, setHeaders }) => 
 	// Check authentication
 	if (!locals.user) {
 		throw error(401, { message: 'Unauthorized' });
-	}
-
-	if (!locals.cluster) {
-		throw error(400, { message: 'Missing cluster context' });
 	}
 
 	checkRateLimit({ setHeaders }, `admin:${locals.user.id}`, 20, 60 * 1000);

--- a/src/routes/api/v1/user/preferences/+server.ts
+++ b/src/routes/api/v1/user/preferences/+server.ts
@@ -6,7 +6,6 @@ import { users } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 import type { UserPreferences } from '$lib/types/user';
-import { requirePermission } from '$lib/server/rbac';
 import { checkRateLimit } from '$lib/server/rate-limiter';
 import { logAudit } from '$lib/server/audit';
 
@@ -61,7 +60,7 @@ export const _metadata = {
 				}
 			},
 			400: {
-				description: 'Bad request (missing cluster context, invalid JSON, or validation failure)',
+				description: 'Bad request (invalid JSON or validation failure)',
 				content: { 'application/json': { schema: errorSchema } }
 			},
 			401: {
@@ -80,13 +79,6 @@ export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
 	if (!locals.user) {
 		throw error(401, { message: 'Unauthorized', code: 'Unauthorized' });
 	}
-
-	if (!locals.cluster) {
-		throw error(400, { message: 'Missing cluster context', code: 'BadRequest' });
-	}
-
-	// Ensure the user has at least 'read' permission on the cluster to manage their own notifications
-	await requirePermission(locals.user, 'read', undefined, undefined, locals.cluster);
 
 	checkRateLimit({ setHeaders }, `preferences:${locals.user.id}`, 30, 60 * 1000);
 
@@ -144,7 +136,7 @@ export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
 
 		await logAudit(locals.user, 'preferences:update', {
 			resourceType: 'UserPreferences',
-			clusterId: locals.cluster,
+			...(locals.cluster ? { clusterId: locals.cluster } : {}),
 			details: { updatedFields: Object.keys(newPreferences) }
 		});
 

--- a/src/routes/settings/notifications/+page.svelte
+++ b/src/routes/settings/notifications/+page.svelte
@@ -27,14 +27,30 @@
 	];
 
 	let loading = $state(false);
+	let isDirty = $state(false);
 
-	// Local state for form initialized from store
+	// Local state for form synced from store when the form is clean
 	let enabled = $state(preferences.notifications.enabled ?? true);
 	let selectedResourceTypes = $state(preferences.notifications.resourceTypes ?? []);
 	let selectedEventTypes = $state<('success' | 'failure' | 'warning' | 'info' | 'error')[]>(
 		preferences.notifications.events ?? ['success', 'failure', 'warning', 'info', 'error']
 	);
 	let namespaceInput = $state(preferences.notifications.namespaces?.join(', ') ?? '');
+
+	$effect(() => {
+		if (!isDirty) {
+			enabled = preferences.notifications.enabled ?? true;
+			selectedResourceTypes = preferences.notifications.resourceTypes ?? [];
+			selectedEventTypes = preferences.notifications.events ?? [
+				'success',
+				'failure',
+				'warning',
+				'info',
+				'error'
+			];
+			namespaceInput = preferences.notifications.namespaces?.join(', ') ?? '';
+		}
+	});
 
 	async function savePreferences() {
 		loading = true;
@@ -60,6 +76,7 @@
 			if (!res.ok) throw new Error('Failed to save');
 
 			preferences.setNotifications(newPrefs);
+			isDirty = false;
 			toast.success('Notification settings saved successfully');
 		} catch (err) {
 			logger.error(err);
@@ -70,6 +87,7 @@
 	}
 
 	function toggleResourceType(type: string) {
+		isDirty = true;
 		if (selectedResourceTypes.includes(type)) {
 			selectedResourceTypes = selectedResourceTypes.filter((t) => t !== type);
 		} else {
@@ -78,6 +96,7 @@
 	}
 
 	function toggleEventType(type: 'success' | 'failure' | 'warning' | 'info' | 'error') {
+		isDirty = true;
 		if (selectedEventTypes.includes(type)) {
 			selectedEventTypes = selectedEventTypes.filter((t) => t !== type);
 		} else {
@@ -102,7 +121,11 @@
 				<p class="text-sm text-muted-foreground">Enable or disable real-time notifications</p>
 			</div>
 			<div class="flex items-center">
-				<Checkbox id="notifications-enabled" bind:checked={enabled} />
+				<Checkbox
+					id="notifications-enabled"
+					bind:checked={enabled}
+					onchange={() => (isDirty = true)}
+				/>
 			</div>
 		</div>
 
@@ -157,6 +180,7 @@
 					<Input
 						placeholder="e.g. flux-system, production, monitoring"
 						bind:value={namespaceInput}
+						oninput={() => (isDirty = true)}
 						class="max-w-md"
 					/>
 				</div>

--- a/src/tests/backup-encryption.test.ts
+++ b/src/tests/backup-encryption.test.ts
@@ -214,9 +214,9 @@ describe('Backup Encryption Module', () => {
 
 		test('throws BackupError for encrypted uploads when the key is unset', () => {
 			delete process.env.BACKUP_ENCRYPTION_KEY;
-			expect(() =>
-				getDecryptedBackupBufferFromBuffer('upload.db.enc', Buffer.alloc(64))
-			).toThrow(BackupError);
+			expect(() => getDecryptedBackupBufferFromBuffer('upload.db.enc', Buffer.alloc(64))).toThrow(
+				BackupError
+			);
 		});
 	});
 });

--- a/src/tests/backup-encryption.test.ts
+++ b/src/tests/backup-encryption.test.ts
@@ -5,7 +5,9 @@ import {
 	_encryptBackup,
 	_decryptBackup,
 	_getBackupEncryptionKey,
+	_resetBackupEncryptionKeyCache,
 	getDecryptedBackupBuffer,
+	getDecryptedBackupBufferFromBuffer,
 	BackupError
 } from '../lib/server/backup';
 
@@ -24,6 +26,7 @@ describe('Backup Encryption Module', () => {
 		} else {
 			delete process.env.BACKUP_ENCRYPTION_KEY;
 		}
+		_resetBackupEncryptionKeyCache();
 	});
 
 	describe('_encryptBackup / _decryptBackup round-trip', () => {
@@ -189,6 +192,31 @@ describe('Backup Encryption Module', () => {
 				existsSpy.mockRestore();
 				readSpy.mockRestore();
 			}
+		});
+	});
+
+	describe('getDecryptedBackupBufferFromBuffer', () => {
+		const validKeyHex = 'c'.repeat(64);
+
+		test('returns plaintext unchanged for unencrypted .db uploads', () => {
+			const plaintext = Buffer.from('SQLite format 3\0test');
+			expect(getDecryptedBackupBufferFromBuffer('upload.db', plaintext)).toEqual(plaintext);
+		});
+
+		test('decrypts encrypted .db.enc upload payloads', () => {
+			process.env.BACKUP_ENCRYPTION_KEY = validKeyHex;
+
+			const plaintext = Buffer.from('SQLite format 3\0test');
+			const encrypted = _encryptBackup(plaintext, Buffer.from(validKeyHex, 'hex'));
+
+			expect(getDecryptedBackupBufferFromBuffer('upload.db.enc', encrypted)).toEqual(plaintext);
+		});
+
+		test('throws BackupError for encrypted uploads when the key is unset', () => {
+			delete process.env.BACKUP_ENCRYPTION_KEY;
+			expect(() =>
+				getDecryptedBackupBufferFromBuffer('upload.db.enc', Buffer.alloc(64))
+			).toThrow(BackupError);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- remove spurious cluster-context gating from the admin settings API
- allow user preferences to save without cluster-scoped permission coupling and make audit cluster logging optional
- align the backup restore picker and copy with backend-accepted file extensions
- re-sync the notification settings form from store updates while the form is not dirty

## Verification
- `bun run check`
- `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for encrypted backup uploads (.db.enc) with server-side decryption and clearer restore error responses.

* **Bug Fixes**
  * Notification settings form now prevents unsaved edits from being overwritten by automatic updates.
  * Backup restore file picker now only accepts .db and .db.enc and shows updated guidance.

* **Improvements**
  * Relaxed validation/requirements on some settings endpoints for more consistent request handling.

* **Tests**
  * Added tests for backup decryption behaviors and encryption key cache reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->