### PR TITLE
fix(ui): address admin and resource accessibility regressions

### DIFF
--- a/src/lib/components/layout/ClusterSwitcher.svelte
+++ b/src/lib/components/layout/ClusterSwitcher.svelte
@@ -29,7 +29,9 @@
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger
 		class="group flex items-center gap-1.5 rounded-md border border-transparent bg-secondary/50 px-2 py-1 text-xs font-medium transition-all hover:border-border hover:bg-secondary/80 sm:gap-2 sm:px-3 sm:py-1.5"
-		aria-label="Current cluster: {currentCluster === 'in-cluster' ? 'In-cluster' : currentCluster}. Click to switch cluster"
+		aria-label={`Current cluster: ${
+			currentCluster === 'in-cluster' ? 'In-cluster' : currentCluster
+		}. Click to switch cluster`}
 	>
 		<div
 			aria-hidden="true"

--- a/src/lib/components/layout/NotificationBell.svelte
+++ b/src/lib/components/layout/NotificationBell.svelte
@@ -46,6 +46,20 @@
 		eventsStore.markAsRead(id);
 	}
 
+	function isNestedInteractiveTarget(
+		event: MouseEvent | KeyboardEvent,
+		currentTarget: EventTarget | null
+	): boolean {
+		if (!(event.target instanceof Element) || !(currentTarget instanceof Element)) {
+			return false;
+		}
+
+		const interactiveAncestor = event.target.closest(
+			'button, a, input, select, textarea, summary, [role="button"], [role="link"]'
+		);
+		return interactiveAncestor !== null && interactiveAncestor !== currentTarget;
+	}
+
 	function markAllAsRead() {
 		eventsStore.markAllAsRead(showAllClusters ? undefined : currentCluster);
 	}
@@ -119,7 +133,7 @@
 		type="button"
 		class="relative rounded-lg p-2 text-gray-500 transition-colors hover:bg-accent hover:text-gray-700 dark:text-gray-400 dark:hover:bg-accent dark:hover:text-gray-200"
 		onclick={toggleDropdown}
-		aria-label="Notifications{unreadCount > 0 ? `, ${unreadCount} unread` : ''}"
+		aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ''}`}
 		aria-expanded={isOpen}
 		aria-haspopup="dialog"
 	>
@@ -263,8 +277,16 @@
 							class="w-full border-b border-gray-100 px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-accent focus:bg-accent focus:outline-none dark:border-gray-700 dark:hover:bg-accent dark:focus:bg-accent {notification.read
 								? 'opacity-60'
 								: ''}"
-							onclick={() => markAsRead(notification.id)}
+							onclick={(event) => {
+								if (isNestedInteractiveTarget(event, event.currentTarget)) {
+									return;
+								}
+								markAsRead(notification.id);
+							}}
 							onkeydown={(e) => {
+								if (isNestedInteractiveTarget(e, e.currentTarget)) {
+									return;
+								}
 								if (e.key === 'Enter' || e.key === ' ') {
 									markAsRead(notification.id);
 									e.preventDefault();

--- a/src/lib/components/wizards/ResourceWizard.svelte
+++ b/src/lib/components/wizards/ResourceWizard.svelte
@@ -5,7 +5,7 @@
 	import ArrayField from '$lib/components/wizards/ArrayField.svelte';
 	import ReferenceField from '$lib/components/wizards/ReferenceField.svelte';
 	import FieldHelp from '$lib/components/wizards/FieldHelp.svelte';
-	import type { ResourceTemplate } from '$lib/templates';
+	import type { ResourceTemplate, TemplateField } from '$lib/templates';
 	import { cn } from '$lib/utils';
 	import { logger } from '$lib/utils/logger.js';
 	import { Loader2, Check, AlertCircle, Code, ListChecks, ChevronDown } from 'lucide-svelte';
@@ -90,7 +90,7 @@
 				for (let i = 0; i < path.length; i++) {
 					if (!current) break;
 					if (i === path.length - 1) {
-						values[field.name] = current[path[i]];
+						values[field.name] = coerceFieldValue(field, current[path[i]]);
 					} else {
 						current = current[path[i]] as Record<string, unknown>;
 					}
@@ -117,8 +117,13 @@
 			template.fields.forEach((field) => {
 				if (field.virtual) return;
 
-				const value = formValues[field.name];
+				const value = coerceFieldValue(field, formValues[field.name]);
 				const path = field.path.split('.');
+
+				if (field.type === 'number' && value === undefined) {
+					doc.deleteIn(path);
+					return;
+				}
 
 				doc.setIn(path, value);
 			});
@@ -144,7 +149,7 @@
 				for (let i = 0; i < path.length; i++) {
 					if (!current) break;
 					if (i === path.length - 1) {
-						values[field.name] = current[path[i]];
+						values[field.name] = coerceFieldValue(field, current[path[i]]);
 					} else {
 						current = current[path[i]] as Record<string, unknown>;
 					}
@@ -158,6 +163,32 @@
 				yamlError = 'Invalid YAML syntax';
 			}
 		}
+	}
+
+	function coerceFieldValue(field: TemplateField, value: unknown): unknown {
+		if (field.type !== 'number') {
+			return value;
+		}
+
+		if (value === '' || value === null || value === undefined) {
+			return undefined;
+		}
+
+		if (typeof value === 'number') {
+			return Number.isFinite(value) ? value : undefined;
+		}
+
+		if (typeof value === 'string') {
+			const parsedValue = Number(value);
+			return Number.isFinite(parsedValue) ? parsedValue : undefined;
+		}
+
+		return undefined;
+	}
+
+	function setFieldValue(field: TemplateField, value: unknown) {
+		formValues[field.name] = coerceFieldValue(field, value);
+		handleFieldChange(field);
 	}
 
 	async function handleSubmit() {
@@ -191,11 +222,15 @@
 				throw new Error(data.message || 'Failed to create resource');
 			}
 
+			const createdResource = (await response.json()) as {
+				metadata?: { namespace?: string; name?: string };
+			};
+
 			success = true;
 
 			setTimeout(() => {
-				const ns = parsed.metadata?.namespace;
-				const name = parsed.metadata?.name;
+				const ns = createdResource.metadata?.namespace;
+				const name = createdResource.metadata?.name;
 				if (ns && name && K8S_NAME_RE.test(ns) && K8S_NAME_RE.test(name)) {
 					void goto(`/resources/${template.plural}/${ns}/${name}`);
 				} else {
@@ -226,18 +261,18 @@
 		nextValue: string,
 		selection?: { namespace?: string }
 	) {
-		formValues[field.name] = nextValue;
-		handleFieldChange(field);
+		setFieldValue(field, nextValue);
 
 		if (!field.referenceNamespaceField) return;
 		if (selection?.namespace === undefined) return;
 
-		formValues[field.referenceNamespaceField] = selection.namespace;
 		const namespaceField = template.fields.find(
 			(candidate) => candidate.name === field.referenceNamespaceField
 		);
 		if (namespaceField) {
-			handleFieldChange(namespaceField);
+			setFieldValue(namespaceField, selection.namespace);
+		} else {
+			formValues[field.referenceNamespaceField] = selection.namespace;
 		}
 	}
 
@@ -462,10 +497,7 @@
 															<Select.Root
 																type="single"
 																value={formValues[field.name] as string}
-																onValueChange={(v) => {
-																	formValues[field.name] = v;
-																	handleFieldChange(field);
-																}}
+																onValueChange={(v) => setFieldValue(field, v)}
 															>
 																<Select.Trigger
 																	id="field-{field.name}"
@@ -492,8 +524,9 @@
 															<div class="flex items-center gap-2">
 																<input
 																	type="checkbox"
-																	bind:checked={formValues[field.name] as boolean}
-																	onchange={() => handleFieldChange(field)}
+																	checked={Boolean(formValues[field.name])}
+																	onchange={(event) =>
+																		setFieldValue(field, (event.currentTarget as HTMLInputElement).checked)}
 																	class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
 																/>
 																<span class="text-sm text-muted-foreground"
@@ -503,8 +536,9 @@
 														{:else if field.type === 'textarea'}
 															<textarea
 																id="field-{field.name}"
-																bind:value={formValues[field.name] as string}
-																oninput={() => handleFieldChange(field)}
+																value={String(formValues[field.name] ?? '')}
+																oninput={(event) =>
+																	setFieldValue(field, (event.currentTarget as HTMLTextAreaElement).value)}
 																placeholder={field.placeholder || field.description}
 																rows="4"
 																class={cn(
@@ -542,8 +576,11 @@
 															<input
 																id="field-{field.name}"
 																type={field.type === 'number' ? 'number' : 'text'}
-																bind:value={formValues[field.name] as string}
-																oninput={() => handleFieldChange(field)}
+																value={field.type === 'number'
+																	? ((formValues[field.name] as number | undefined) ?? '')
+																	: String(formValues[field.name] ?? '')}
+																oninput={(event) =>
+																	setFieldValue(field, (event.currentTarget as HTMLInputElement).value)}
 																placeholder={field.placeholder || field.description}
 																class={cn(
 																	'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
@@ -587,10 +624,7 @@
 												<Select.Root
 													type="single"
 													value={formValues[field.name] as string}
-													onValueChange={(v) => {
-														formValues[field.name] = v;
-														handleFieldChange(field);
-													}}
+													onValueChange={(v) => setFieldValue(field, v)}
 												>
 													<Select.Trigger
 														id="field-{field.name}"
@@ -611,8 +645,9 @@
 												<div class="flex items-center gap-2">
 													<input
 														type="checkbox"
-														bind:checked={formValues[field.name] as boolean}
-														onchange={() => handleFieldChange(field)}
+														checked={Boolean(formValues[field.name])}
+														onchange={(event) =>
+															setFieldValue(field, (event.currentTarget as HTMLInputElement).checked)}
 														class="size-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
 													/>
 													<span class="text-sm text-muted-foreground"
@@ -622,8 +657,9 @@
 											{:else if field.type === 'textarea'}
 												<textarea
 													id="field-{field.name}"
-													bind:value={formValues[field.name] as string}
-													oninput={() => handleFieldChange(field)}
+													value={String(formValues[field.name] ?? '')}
+													oninput={(event) =>
+														setFieldValue(field, (event.currentTarget as HTMLTextAreaElement).value)}
 													placeholder={field.placeholder || field.description}
 													rows="4"
 													class={cn(
@@ -661,8 +697,11 @@
 												<input
 													id="field-{field.name}"
 													type={field.type === 'number' ? 'number' : 'text'}
-													bind:value={formValues[field.name] as string}
-													oninput={() => handleFieldChange(field)}
+													value={field.type === 'number'
+														? ((formValues[field.name] as number | undefined) ?? '')
+														: String(formValues[field.name] ?? '')}
+													oninput={(event) =>
+														setFieldValue(field, (event.currentTarget as HTMLInputElement).value)}
 													placeholder={field.placeholder || field.description}
 													class={cn(
 														'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',

--- a/src/lib/components/wizards/ResourceWizard.svelte
+++ b/src/lib/components/wizards/ResourceWizard.svelte
@@ -53,11 +53,13 @@
 
 	// Form values derived from parsing the current YAML
 	let formValues = $state<Record<string, unknown>>({});
+	let hasInitializedFormValues = $state(false);
 
 	// Update currentYaml when template changes
 	$effect(() => {
 		currentYaml = template.yaml;
 		yamlError = null;
+		hasInitializedFormValues = false;
 	});
 
 	// Validate YAML in real-time when in YAML mode
@@ -102,17 +104,26 @@
 				}
 			});
 			formValues = values;
+			hasInitializedFormValues = true;
 		} catch (err) {
 			logger.error(err, 'Failed to parse initial YAML');
 			formValues = {};
 			yamlError = 'Failed to parse template YAML';
+			hasInitializedFormValues = true;
 		}
+	});
+
+	$effect(() => {
+		if (mode !== 'wizard' || !currentYaml || !hasInitializedFormValues) return;
+
+		JSON.stringify(formValues);
+		updateYamlFromForm();
 	});
 
 	// Synchronize YAML when form values change (Wizard -> YAML)
 	function updateYamlFromForm() {
 		try {
-			const doc = parseDocument(currentYaml);
+			const doc = parseDocument(currentYaml || template.yaml);
 
 			template.fields.forEach((field) => {
 				if (field.virtual) return;
@@ -186,8 +197,25 @@
 		return undefined;
 	}
 
+	function ensureTemplateField(field: TemplateField): TemplateField {
+		const existingField = template.fields.find((candidate) => candidate.name === field.name);
+		if (existingField) {
+			return existingField;
+		}
+
+		template.fields = [...template.fields, field];
+		return field;
+	}
+
+	function commitFieldValue(field: TemplateField) {
+		const nextValue = coerceFieldValue(field, formValues[field.name]);
+		formValues[field.name] = nextValue;
+		handleFieldChange(field);
+	}
+
 	function setFieldValue(field: TemplateField, value: unknown) {
-		formValues[field.name] = coerceFieldValue(field, value);
+		formValues[field.name] =
+			field.type === 'number' && typeof value === 'string' ? value : coerceFieldValue(field, value);
 		handleFieldChange(field);
 	}
 
@@ -202,15 +230,13 @@
 		logger.warn(
 			`ResourceWizard: template field "${fieldName}" is missing from template.fields; using fallback validation flow`
 		);
-		setFieldValue(
-			{
-				name: fieldName,
-				label: fieldName,
-				path: fieldName,
-				type: 'string'
-			},
-			value
-		);
+		const fallbackField = ensureTemplateField({
+			name: fieldName,
+			label: fieldName,
+			path: fieldName,
+			type: 'string'
+		});
+		setFieldValue(fallbackField, value);
 	}
 
 	async function handleSubmit() {
@@ -230,6 +256,15 @@
 		error = null;
 
 		try {
+			if (mode === 'wizard') {
+				template.fields.forEach((field) => {
+					if (field.type === 'number') {
+						commitFieldValue(field);
+					}
+				});
+				updateYamlFromForm();
+			}
+
 			const parsed = parse(currentYaml) as Record<string, unknown> & {
 				metadata?: { namespace?: string; name?: string };
 			};
@@ -545,6 +580,7 @@
 														{:else if field.type === 'boolean'}
 															<div class="flex items-center gap-2">
 																<input
+																	id="field-{field.name}"
 																	type="checkbox"
 																	checked={Boolean(formValues[field.name])}
 																	onchange={(event) =>
@@ -598,11 +634,14 @@
 															<input
 																id="field-{field.name}"
 																type={field.type === 'number' ? 'number' : 'text'}
-																value={field.type === 'number'
-																	? ((formValues[field.name] as number | undefined) ?? '')
-																	: String(formValues[field.name] ?? '')}
+																value={String(formValues[field.name] ?? '')}
 																oninput={(event) =>
 																	setFieldValue(field, (event.currentTarget as HTMLInputElement).value)}
+																onblur={() => {
+																	if (field.type === 'number') {
+																		commitFieldValue(field);
+																	}
+																}}
 																placeholder={field.placeholder || field.description}
 																class={cn(
 																	'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
@@ -666,6 +705,7 @@
 											{:else if field.type === 'boolean'}
 												<div class="flex items-center gap-2">
 													<input
+														id="field-{field.name}"
 														type="checkbox"
 														checked={Boolean(formValues[field.name])}
 														onchange={(event) =>
@@ -719,11 +759,14 @@
 												<input
 													id="field-{field.name}"
 													type={field.type === 'number' ? 'number' : 'text'}
-													value={field.type === 'number'
-														? ((formValues[field.name] as number | undefined) ?? '')
-														: String(formValues[field.name] ?? '')}
+													value={String(formValues[field.name] ?? '')}
 													oninput={(event) =>
 														setFieldValue(field, (event.currentTarget as HTMLInputElement).value)}
+													onblur={() => {
+														if (field.type === 'number') {
+															commitFieldValue(field);
+														}
+													}}
 													placeholder={field.placeholder || field.description}
 													class={cn(
 														'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',

--- a/src/lib/components/wizards/ResourceWizard.svelte
+++ b/src/lib/components/wizards/ResourceWizard.svelte
@@ -191,6 +191,28 @@
 		handleFieldChange(field);
 	}
 
+	function setFieldValueByName(fieldName: string, value: unknown) {
+		const targetField = template.fields.find((candidate) => candidate.name === fieldName);
+
+		if (targetField) {
+			setFieldValue(targetField, value);
+			return;
+		}
+
+		logger.warn(
+			`ResourceWizard: template field "${fieldName}" is missing from template.fields; using fallback validation flow`
+		);
+		setFieldValue(
+			{
+				name: fieldName,
+				label: fieldName,
+				path: fieldName,
+				type: 'string'
+			},
+			value
+		);
+	}
+
 	async function handleSubmit() {
 		// Check for YAML syntax errors first
 		if (yamlError) {
@@ -272,7 +294,7 @@
 		if (namespaceField) {
 			setFieldValue(namespaceField, selection.namespace);
 		} else {
-			formValues[field.referenceNamespaceField] = selection.namespace;
+			setFieldValueByName(field.referenceNamespaceField, selection.namespace);
 		}
 	}
 

--- a/src/lib/utils/filtering.ts
+++ b/src/lib/utils/filtering.ts
@@ -12,7 +12,7 @@ export interface FilterState {
 	namespace: string;
 	status: ResourceHealth | 'all';
 	labels: string;
-	useRegex?: boolean;
+	useRegex: boolean;
 }
 
 export const defaultFilterState: FilterState = {
@@ -144,7 +144,8 @@ export function hasActiveFilters(filters: FilterState): boolean {
 		filters.search !== '' ||
 		filters.namespace !== '' ||
 		filters.status !== 'all' ||
-		filters.labels !== ''
+		filters.labels !== '' ||
+		filters.useRegex
 	);
 }
 
@@ -158,6 +159,7 @@ export function filtersToSearchParams(filters: FilterState): URLSearchParams {
 	if (filters.namespace) params.set('ns', filters.namespace);
 	if (filters.status !== 'all') params.set('status', filters.status);
 	if (filters.labels) params.set('labels', filters.labels);
+	if (filters.useRegex) params.set('regex', '1');
 
 	return params;
 }
@@ -172,6 +174,7 @@ export function searchParamsToFilters(params: URLSearchParams): FilterState {
 		search: (params.get('q') ?? '').slice(0, MAX_PARAM_LENGTH),
 		namespace: (params.get('ns') ?? '').slice(0, MAX_PARAM_LENGTH),
 		status,
-		labels: (params.get('labels') ?? '').slice(0, MAX_PARAM_LENGTH)
+		labels: (params.get('labels') ?? '').slice(0, MAX_PARAM_LENGTH),
+		useRegex: params.get('regex') === '1'
 	};
 }

--- a/src/lib/utils/focus-trap.ts
+++ b/src/lib/utils/focus-trap.ts
@@ -20,9 +20,13 @@ export function modalFocusTrap(node: HTMLElement) {
 			labelledBy && typeof document !== 'undefined'
 				? (document.getElementById(labelledBy) as HTMLElement | null)
 				: null;
-		const focusTarget = getFocusableElements(node)[0] ?? labelledElement ?? node;
+		const initialFocusSelector = node.getAttribute('data-initial-focus');
+		const initialFocusElement = initialFocusSelector
+			? (node.querySelector<HTMLElement>(initialFocusSelector) ?? null)
+			: null;
+		const focusTarget = initialFocusElement ?? getFocusableElements(node)[0] ?? labelledElement ?? node;
 
-		if (labelledElement && !labelledElement.hasAttribute('tabindex')) {
+		if (focusTarget === labelledElement && labelledElement && !labelledElement.hasAttribute('tabindex')) {
 			labelledElement.tabIndex = -1;
 		}
 
@@ -57,7 +61,17 @@ export function modalFocusTrap(node: HTMLElement) {
 	return {
 		destroy() {
 			node.removeEventListener('keydown', handleKeydown);
-			previousActiveElement?.focus();
+			const livePreviousActiveElement =
+				previousActiveElement?.isConnected &&
+				previousActiveElement.ownerDocument?.contains(previousActiveElement)
+					? previousActiveElement
+					: null;
+			const fallbackFocusTarget =
+				document.activeElement instanceof HTMLElement && document.activeElement.isConnected
+					? document.activeElement
+					: document.body;
+
+			(livePreviousActiveElement ?? fallbackFocusTarget).focus();
 			previousActiveElement = null;
 		}
 	};

--- a/src/lib/utils/focus-trap.ts
+++ b/src/lib/utils/focus-trap.ts
@@ -1,0 +1,64 @@
+export const FOCUSABLE_SELECTOR =
+	'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+		(element) =>
+			!element.hasAttribute('disabled') &&
+			element.getAttribute('aria-hidden') !== 'true' &&
+			element.tabIndex !== -1
+	);
+}
+
+export function modalFocusTrap(node: HTMLElement) {
+	let previousActiveElement: HTMLElement | null =
+		typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
+
+	const focusInitialElement = () => {
+		const labelledBy = node.getAttribute('aria-labelledby');
+		const labelledElement =
+			labelledBy && typeof document !== 'undefined'
+				? (document.getElementById(labelledBy) as HTMLElement | null)
+				: null;
+		const focusTarget = getFocusableElements(node)[0] ?? labelledElement ?? node;
+
+		if (labelledElement && !labelledElement.hasAttribute('tabindex')) {
+			labelledElement.tabIndex = -1;
+		}
+
+		focusTarget.focus();
+	};
+
+	const handleKeydown = (event: KeyboardEvent) => {
+		if (event.key !== 'Tab') return;
+
+		const focusables = getFocusableElements(node);
+		if (focusables.length === 0) {
+			event.preventDefault();
+			node.focus();
+			return;
+		}
+
+		const first = focusables[0];
+		const last = focusables[focusables.length - 1];
+
+		if (event.shiftKey && document.activeElement === first) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && document.activeElement === last) {
+			event.preventDefault();
+			first.focus();
+		}
+	};
+
+	node.addEventListener('keydown', handleKeydown);
+	setTimeout(focusInitialElement, 0);
+
+	return {
+		destroy() {
+			node.removeEventListener('keydown', handleKeydown);
+			previousActiveElement?.focus();
+			previousActiveElement = null;
+		}
+	};
+}

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,8 +1,32 @@
 import type { PageServerLoad } from './$types';
 
+function formatEnvironment(nodeEnv: string | undefined): string | null {
+	if (!nodeEnv) return null;
+
+	switch (nodeEnv.toLowerCase()) {
+		case 'development':
+			return 'Development';
+		case 'production':
+			return 'Production';
+		case 'test':
+			return 'Test';
+		default:
+			return nodeEnv;
+	}
+}
+
 /**
  * Load function for admin settings landing page
  */
 export const load: PageServerLoad = async () => {
-	return {};
+	const inCluster = Boolean(process.env.KUBERNETES_SERVICE_HOST);
+
+	return {
+		systemInfo: {
+			deploymentMode: inCluster ? 'In-cluster' : 'Local',
+			clusterAccess: inCluster ? 'In-cluster Kubernetes API' : 'Local kubeconfig contexts',
+			databaseEngine: 'SQLite',
+			environment: formatEnvironment(process.env.NODE_ENV)
+		}
+	};
 };

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,3 +1,4 @@
+import { env } from '$env/dynamic/private';
 import type { PageServerLoad } from './$types';
 
 function formatEnvironment(nodeEnv: string | undefined): string | null {
@@ -19,14 +20,14 @@ function formatEnvironment(nodeEnv: string | undefined): string | null {
  * Load function for admin settings landing page
  */
 export const load: PageServerLoad = async () => {
-	const inCluster = Boolean(process.env.KUBERNETES_SERVICE_HOST);
+	const inCluster = Boolean(env.KUBERNETES_SERVICE_HOST);
 
 	return {
 		systemInfo: {
 			deploymentMode: inCluster ? 'In-cluster' : 'Local',
 			clusterAccess: inCluster ? 'In-cluster Kubernetes API' : 'Local kubeconfig contexts',
 			databaseEngine: 'SQLite',
-			environment: formatEnvironment(process.env.NODE_ENV)
+			environment: formatEnvironment(env.NODE_ENV)
 		}
 	};
 };

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import { GYRE_VERSION } from '$lib/config/version';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
 
 	const adminFeatures = [
 		{
@@ -52,6 +55,16 @@
 			bg: 'bg-primary/10'
 		}
 	];
+
+	const systemInfoItems = $derived.by(() =>
+		[
+			{ label: 'Version', value: `v${GYRE_VERSION}` },
+			{ label: 'Deployment Mode', value: data.systemInfo.deploymentMode },
+			{ label: 'Cluster Access', value: data.systemInfo.clusterAccess },
+			{ label: 'Database Engine', value: data.systemInfo.databaseEngine },
+			{ label: 'Environment', value: data.systemInfo.environment }
+		].filter((item): item is { label: string; value: string } => Boolean(item.value))
+	);
 </script>
 
 <div class="space-y-6">
@@ -100,22 +113,18 @@
 			<div>
 				<h2 class="text-lg font-bold text-foreground">System Configuration</h2>
 				<p class="mt-1 text-sm text-muted-foreground">
-					Gyre is currently running in a single-cluster mode with local SQLite database. Some
-					settings may be controlled via environment variables.
+					Runtime details are derived from the current server environment and active Gyre
+					configuration.
 				</p>
-				<div class="mt-4 flex gap-4">
-					<div class="flex flex-col">
-						<span class="text-[10px] font-bold tracking-widest text-muted-foreground uppercase"
-							>Version</span
-						>
-						<span class="font-mono text-sm text-foreground">v{GYRE_VERSION}</span>
-					</div>
-					<div class="flex flex-col">
-						<span class="text-[10px] font-bold tracking-widest text-muted-foreground uppercase"
-							>Environment</span
-						>
-						<span class="font-mono text-sm text-foreground">Production</span>
-					</div>
+				<div class="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+					{#each systemInfoItems as item (item.label)}
+						<div class="flex flex-col rounded-xl border border-border/60 bg-background/40 p-4">
+							<span class="text-[10px] font-bold tracking-widest text-muted-foreground uppercase">
+								{item.label}
+							</span>
+							<span class="mt-1 font-mono text-sm text-foreground">{item.value}</span>
+						</div>
+					{/each}
 				</div>
 			</div>
 		</div>

--- a/src/routes/admin/auth-providers/+page.svelte
+++ b/src/routes/admin/auth-providers/+page.svelte
@@ -296,6 +296,7 @@
 			<p class="mt-1 text-sm text-slate-400">Manage OAuth2 and OIDC authentication providers</p>
 		</div>
 		<button
+			type="button"
 			onclick={openCreateModal}
 			class="flex w-full items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-amber-400 sm:w-auto"
 		>
@@ -324,6 +325,7 @@
 				Get started by adding your first authentication provider
 			</p>
 			<button
+				type="button"
 				onclick={openCreateModal}
 				class="mt-4 rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-amber-400"
 			>
@@ -389,9 +391,11 @@
 						<div class="flex items-center gap-2">
 							<!-- Toggle Enabled/Disabled -->
 							<button
+								type="button"
 								onclick={() => toggleEnabled(provider)}
 								class="rounded-lg p-2 transition-colors hover:bg-slate-700"
 								title={provider.enabled ? 'Disable' : 'Enable'}
+								aria-label={`${provider.enabled ? 'Disable' : 'Enable'} provider ${provider.name}`}
 							>
 								{#if provider.enabled}
 									<svg
@@ -426,9 +430,11 @@
 
 							<!-- Edit Button -->
 							<button
+								type="button"
 								onclick={() => openEditModal(provider)}
 								class="rounded-lg p-2 transition-colors hover:bg-slate-700"
 								title="Edit"
+								aria-label={`Edit provider ${provider.name}`}
 							>
 								<svg
 									class="h-5 w-5 text-slate-400"
@@ -447,9 +453,11 @@
 
 							<!-- Delete Button -->
 							<button
+								type="button"
 								onclick={() => openDeleteModal(provider)}
 								class="rounded-lg p-2 transition-colors hover:bg-slate-700"
 								title="Delete"
+								aria-label={`Delete provider ${provider.name}`}
 							>
 								<svg
 									class="h-5 w-5 text-red-400"
@@ -475,13 +483,22 @@
 
 <!-- Create Modal -->
 {#if showCreateModal}
-	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-0 sm:p-4">
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-0 sm:p-4"
+		role="dialog"
+		aria-modal="true"
+		tabindex="-1"
+		aria-labelledby="create-provider-title"
+		onclick={(e) => e.target === e.currentTarget && closeModals()}
+		onkeydown={(e) => e.key === 'Escape' && closeModals()}
+	>
 		<div
 			class="h-full w-full overflow-y-auto border border-slate-700 bg-slate-800 p-6 sm:h-auto sm:max-h-[90vh] sm:max-w-2xl sm:rounded-lg"
 		>
 			<div class="mb-6 flex items-center justify-between">
-				<h2 class="text-xl font-bold text-slate-100">Add SSO Provider</h2>
+				<h2 id="create-provider-title" class="text-xl font-bold text-slate-100">Add SSO Provider</h2>
 				<button
+					type="button"
 					aria-label="Close"
 					onclick={closeModals}
 					class="text-slate-400 hover:text-slate-300"
@@ -732,13 +749,24 @@
 
 <!-- Edit Modal (similar structure to Create) -->
 {#if showEditModal && selectedProvider}
-	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-0 sm:p-4">
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-0 sm:p-4"
+		role="dialog"
+		aria-modal="true"
+		tabindex="-1"
+		aria-labelledby="edit-provider-title"
+		onclick={(e) => e.target === e.currentTarget && closeModals()}
+		onkeydown={(e) => e.key === 'Escape' && closeModals()}
+	>
 		<div
 			class="h-full w-full overflow-y-auto border border-slate-700 bg-slate-800 p-6 sm:h-auto sm:max-h-[90vh] sm:max-w-2xl sm:rounded-lg"
 		>
 			<div class="mb-6 flex items-center justify-between">
-				<h2 class="text-xl font-bold text-slate-100">Edit Provider: {selectedProvider.name}</h2>
+				<h2 id="edit-provider-title" class="text-xl font-bold text-slate-100">
+					Edit Provider: {selectedProvider.name}
+				</h2>
 				<button
+					type="button"
 					aria-label="Close"
 					onclick={closeModals}
 					class="text-slate-400 hover:text-slate-300"
@@ -983,10 +1011,19 @@
 
 <!-- Delete Confirmation Modal -->
 {#if showDeleteModal && selectedProvider}
-	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+		role="dialog"
+		aria-modal="true"
+		tabindex="-1"
+		aria-labelledby="delete-provider-title"
+		aria-describedby="delete-provider-description"
+		onclick={(e) => e.target === e.currentTarget && closeModals()}
+		onkeydown={(e) => e.key === 'Escape' && closeModals()}
+	>
 		<div class="w-full max-w-md rounded-lg border border-slate-700 bg-slate-800 p-6">
-			<h2 class="text-xl font-bold text-slate-100">Delete Provider</h2>
-			<p class="mt-4 text-sm text-slate-300">
+			<h2 id="delete-provider-title" class="text-xl font-bold text-slate-100">Delete Provider</h2>
+			<p id="delete-provider-description" class="mt-4 text-sm text-slate-300">
 				Are you sure you want to delete <strong>{selectedProvider.name}</strong>? This action cannot
 				be undone and will affect all users linked to this provider.
 			</p>
@@ -1001,6 +1038,7 @@
 
 			<div class="mt-6 flex gap-3">
 				<button
+					type="button"
 					onclick={handleDelete}
 					disabled={loading}
 					class="flex-1 rounded-lg bg-red-500 px-4 py-2 font-medium text-white transition-colors hover:bg-red-600 disabled:opacity-50"
@@ -1008,6 +1046,7 @@
 					{loading ? 'Deleting...' : 'Delete'}
 				</button>
 				<button
+					type="button"
 					onclick={closeModals}
 					class="rounded-lg border border-slate-600 px-4 py-2 text-slate-300 transition-colors hover:bg-slate-700"
 				>

--- a/src/routes/admin/auth-providers/+page.svelte
+++ b/src/routes/admin/auth-providers/+page.svelte
@@ -8,6 +8,7 @@
 	import type { PageData } from './$types';
 	import * as Select from '$lib/components/ui/select';
 	import { getCsrfToken } from '$lib/utils/csrf';
+	import { modalFocusTrap } from '$lib/utils/focus-trap';
 	import { logger } from '$lib/utils/logger.js';
 
 	type ProviderType =
@@ -29,9 +30,6 @@
 	let success = $state('');
 	let loading = $state(false);
 	let roleMappingError = $state('');
-
-	const FOCUSABLE_SELECTOR =
-		'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 	$effect(() => {
 		const mapping = formData.roleMapping?.trim();
@@ -124,68 +122,6 @@
 		showEditModal = false;
 		showDeleteModal = false;
 		selectedProvider = null;
-	}
-
-	function getFocusableElements(container: HTMLElement): HTMLElement[] {
-		return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
-			(element) =>
-				!element.hasAttribute('disabled') &&
-				element.getAttribute('aria-hidden') !== 'true' &&
-				element.tabIndex !== -1
-		);
-	}
-
-	function modalFocusTrap(node: HTMLElement) {
-		let previousActiveElement: HTMLElement | null =
-			typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
-
-		const focusInitialElement = () => {
-			const labelledBy = node.getAttribute('aria-labelledby');
-			const labelledElement =
-				labelledBy && typeof document !== 'undefined'
-					? (document.getElementById(labelledBy) as HTMLElement | null)
-					: null;
-			const focusTarget = getFocusableElements(node)[0] ?? labelledElement ?? node;
-
-			if (labelledElement && !labelledElement.hasAttribute('tabindex')) {
-				labelledElement.tabIndex = -1;
-			}
-
-			focusTarget.focus();
-		};
-
-		const handleKeydown = (event: KeyboardEvent) => {
-			if (event.key !== 'Tab') return;
-
-			const focusables = getFocusableElements(node);
-			if (focusables.length === 0) {
-				event.preventDefault();
-				node.focus();
-				return;
-			}
-
-			const first = focusables[0];
-			const last = focusables[focusables.length - 1];
-
-			if (event.shiftKey && document.activeElement === first) {
-				event.preventDefault();
-				last.focus();
-			} else if (!event.shiftKey && document.activeElement === last) {
-				event.preventDefault();
-				first.focus();
-			}
-		};
-
-		node.addEventListener('keydown', handleKeydown);
-		setTimeout(focusInitialElement, 0);
-
-		return {
-			destroy() {
-				node.removeEventListener('keydown', handleKeydown);
-				previousActiveElement?.focus();
-				previousActiveElement = null;
-			}
-		};
 	}
 
 	function normalizeRoleMappingForSave(value: string) {

--- a/src/routes/admin/auth-providers/+page.svelte
+++ b/src/routes/admin/auth-providers/+page.svelte
@@ -30,6 +30,9 @@
 	let loading = $state(false);
 	let roleMappingError = $state('');
 
+	const FOCUSABLE_SELECTOR =
+		'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 	$effect(() => {
 		const mapping = formData.roleMapping?.trim();
 		if (!mapping) {
@@ -121,6 +124,68 @@
 		showEditModal = false;
 		showDeleteModal = false;
 		selectedProvider = null;
+	}
+
+	function getFocusableElements(container: HTMLElement): HTMLElement[] {
+		return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+			(element) =>
+				!element.hasAttribute('disabled') &&
+				element.getAttribute('aria-hidden') !== 'true' &&
+				element.tabIndex !== -1
+		);
+	}
+
+	function modalFocusTrap(node: HTMLElement) {
+		let previousActiveElement: HTMLElement | null =
+			typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
+
+		const focusInitialElement = () => {
+			const labelledBy = node.getAttribute('aria-labelledby');
+			const labelledElement =
+				labelledBy && typeof document !== 'undefined'
+					? (document.getElementById(labelledBy) as HTMLElement | null)
+					: null;
+			const focusTarget = getFocusableElements(node)[0] ?? labelledElement ?? node;
+
+			if (labelledElement && !labelledElement.hasAttribute('tabindex')) {
+				labelledElement.tabIndex = -1;
+			}
+
+			focusTarget.focus();
+		};
+
+		const handleKeydown = (event: KeyboardEvent) => {
+			if (event.key !== 'Tab') return;
+
+			const focusables = getFocusableElements(node);
+			if (focusables.length === 0) {
+				event.preventDefault();
+				node.focus();
+				return;
+			}
+
+			const first = focusables[0];
+			const last = focusables[focusables.length - 1];
+
+			if (event.shiftKey && document.activeElement === first) {
+				event.preventDefault();
+				last.focus();
+			} else if (!event.shiftKey && document.activeElement === last) {
+				event.preventDefault();
+				first.focus();
+			}
+		};
+
+		node.addEventListener('keydown', handleKeydown);
+		setTimeout(focusInitialElement, 0);
+
+		return {
+			destroy() {
+				node.removeEventListener('keydown', handleKeydown);
+				previousActiveElement?.focus();
+				previousActiveElement = null;
+			}
+		};
 	}
 
 	function normalizeRoleMappingForSave(value: string) {
@@ -484,6 +549,7 @@
 <!-- Create Modal -->
 {#if showCreateModal}
 	<div
+		use:modalFocusTrap
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-0 sm:p-4"
 		role="dialog"
 		aria-modal="true"
@@ -750,6 +816,7 @@
 <!-- Edit Modal (similar structure to Create) -->
 {#if showEditModal && selectedProvider}
 	<div
+		use:modalFocusTrap
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-0 sm:p-4"
 		role="dialog"
 		aria-modal="true"
@@ -1012,6 +1079,7 @@
 <!-- Delete Confirmation Modal -->
 {#if showDeleteModal && selectedProvider}
 	<div
+		use:modalFocusTrap
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
 		role="dialog"
 		aria-modal="true"

--- a/src/routes/admin/clusters/+page.svelte
+++ b/src/routes/admin/clusters/+page.svelte
@@ -225,9 +225,9 @@
 					View Diagnostics
 				</Button>
 			</div>
-			{#if form.healthCheck.error}
-				<p class="mt-2 text-sm">{form.healthCheck.error}</p>
-			{/if}
+			<p class="mt-2 text-sm">
+				Connection checks failed. Open diagnostics for the detailed failure reason and checklist.
+			</p>
 		</div>
 	{:else if form?.error}
 		<div class="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-red-400">

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { enhance, applyAction } from '$app/forms';
 	import { invalidateAll, goto } from '$app/navigation';
-	import { page } from '$app/stores';
 	import { getCsrfToken } from '$lib/utils/csrf';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import { UserPlus, AlertTriangle, CheckCircle2, XCircle } from 'lucide-svelte';
@@ -264,10 +263,12 @@
 							<div class="flex justify-end gap-2">
 								{#if user.isLocal}
 									<Button
+										type="button"
 										variant="ghost"
 										size="sm"
 										onclick={() => openResetPasswordModal(user)}
 										title="Reset Password"
+										aria-label={`Reset password for ${user.username}`}
 									>
 										<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 											<path
@@ -279,7 +280,14 @@
 										</svg>
 									</Button>
 								{/if}
-								<Button variant="ghost" size="sm" onclick={() => openEditModal(user)} title="Edit">
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									onclick={() => openEditModal(user)}
+									title="Edit"
+									aria-label={`Edit user ${user.username}`}
+								>
 									<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 										<path
 											stroke-linecap="round"
@@ -291,11 +299,13 @@
 								</Button>
 								{#if user.id !== data.currentUser.id}
 									<Button
+										type="button"
 										variant="ghost"
 										size="sm"
 										onclick={() => openDeleteModal(user)}
 										class="text-red-400 hover:text-red-300"
 										title="Delete"
+										aria-label={`Delete user ${user.username}`}
 									>
 										<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 											<path
@@ -600,10 +610,21 @@
 
 	<!-- Reset Password Modal -->
 	{#if resettingPassword}
-		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+		<div
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+			role="dialog"
+			aria-modal="true"
+			tabindex="-1"
+			aria-labelledby="reset-password-title"
+			aria-describedby={passwordResetSuccess
+				? 'reset-password-success-message reset-password-generated-password reset-password-success-hint'
+				: 'reset-password-description new-password-hint reset-password-warning'}
+			onclick={(e) => e.target === e.currentTarget && closeModals()}
+			onkeydown={(e) => e.key === 'Escape' && closeModals()}
+		>
 			<div class="w-full max-w-md rounded-xl border border-slate-700 bg-slate-800 p-6 shadow-2xl">
-				<h2 class="mb-4 text-xl font-bold text-white">Reset Password</h2>
-				<p class="mb-4 text-slate-400">
+				<h2 id="reset-password-title" class="mb-4 text-xl font-bold text-white">Reset Password</h2>
+				<p id="reset-password-description" class="mb-4 text-slate-400">
 					Generate a new password for <strong class="text-white"
 						>{resettingPassword.username}</strong
 					>
@@ -611,19 +632,24 @@
 
 				{#if passwordResetSuccess}
 				<div class="space-y-4">
-					<div class="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-400">
+					<div
+						id="reset-password-success-message"
+						class="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-400"
+					>
 						<div class="flex items-center gap-2">
 							<CheckCircle2 size={16} />
 							Password reset successfully
 						</div>
 					</div>
-					<div class="rounded bg-slate-900 p-3">
+					<div id="reset-password-generated-password" class="rounded bg-slate-900 p-3">
 						<p class="text-xs text-slate-400">New Password:</p>
 						<p class="font-mono text-sm text-amber-400">{generatedPassword}</p>
-						<p class="mt-1 text-xs text-slate-500">Copy this now - it won't be shown again</p>
+						<p id="reset-password-success-hint" class="mt-1 text-xs text-slate-500">
+							Copy this now - it won't be shown again
+						</p>
 					</div>
 					<div class="flex justify-end pt-2">
-						<Button onclick={closeModals}>Done</Button>
+						<Button type="button" onclick={closeModals}>Done</Button>
 					</div>
 				</div>
 			{:else}
@@ -675,7 +701,7 @@
 						</p>
 					</div>
 
-					<p class="text-xs text-amber-400">
+					<p id="reset-password-warning" class="text-xs text-amber-400">
 						Copy the password before submitting - it will only be shown once after reset.
 					</p>
 

--- a/src/routes/resources/[type]/+page.svelte
+++ b/src/routes/resources/[type]/+page.svelte
@@ -217,6 +217,7 @@
 		filters.namespace = defaultFilterState.namespace;
 		filters.status = defaultFilterState.status;
 		filters.labels = defaultFilterState.labels;
+		filters.useRegex = defaultFilterState.useRegex;
 	}
 
 	function handleSearch() {
@@ -277,11 +278,13 @@
 							? 'bg-primary text-primary-foreground'
 							: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
 						aria-pressed={sortBy === opt.key}
-						aria-label="Sort by {opt.label}: {sortBy === opt.key
-							? sortOrder === 'asc'
-								? 'ascending'
-								: 'descending'
-							: 'not sorted'}"
+						aria-label={`Sort by ${opt.label}: ${
+							sortBy === opt.key
+								? sortOrder === 'asc'
+									? 'ascending'
+									: 'descending'
+								: 'not sorted'
+						}`}
 						onclick={() => applySort(opt.key)}
 					>
 						{opt.label}

--- a/src/tests/filtering.test.ts
+++ b/src/tests/filtering.test.ts
@@ -3,7 +3,8 @@ import { describe, test, expect, mock } from 'bun:test';
 mock.module('$app/environment', () => ({ dev: false }));
 mock.module('$env/dynamic/public', () => ({ env: {} }));
 
-const { searchParamsToFilters, parseLabels } = await import('../lib/utils/filtering.js');
+const { searchParamsToFilters, filtersToSearchParams, parseLabels, defaultFilterState } =
+	await import('../lib/utils/filtering.js');
 
 // ---------------------------------------------------------------------------
 // searchParamsToFilters
@@ -53,6 +54,33 @@ describe('searchParamsToFilters', () => {
 		const params = new URLSearchParams({ labels: 'c'.repeat(600) });
 		const result = searchParamsToFilters(params);
 		expect(result.labels).toHaveLength(500);
+	});
+
+	test('regex=1 enables regex mode', () => {
+		const params = new URLSearchParams({ regex: '1' });
+		const result = searchParamsToFilters(params);
+		expect(result.useRegex).toBe(true);
+	});
+
+	test('missing regex param restores default regex mode', () => {
+		const result = searchParamsToFilters(new URLSearchParams());
+		expect(result.useRegex).toBe(defaultFilterState.useRegex);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// filtersToSearchParams
+// ---------------------------------------------------------------------------
+
+describe('filtersToSearchParams', () => {
+	test('regex mode is persisted as regex=1', () => {
+		const params = filtersToSearchParams({ ...defaultFilterState, useRegex: true });
+		expect(params.get('regex')).toBe('1');
+	});
+
+	test('default regex mode is omitted from params', () => {
+		const params = filtersToSearchParams(defaultFilterState);
+		expect(params.has('regex')).toBe(false);
 	});
 });
 

--- a/src/tests/resource-health.test.ts
+++ b/src/tests/resource-health.test.ts
@@ -255,6 +255,10 @@ describe('hasActiveFilters', () => {
 	test('returns true when labels is set', () => {
 		expect(hasActiveFilters({ ...defaultFilterState, labels: 'app=foo' })).toBe(true);
 	});
+
+	test('returns true when regex mode is enabled', () => {
+		expect(hasActiveFilters({ ...defaultFilterState, useRegex: true })).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -267,7 +271,8 @@ describe('filtersToSearchParams / searchParamsToFilters', () => {
 			search: 'nginx',
 			namespace: 'flux-system',
 			status: 'healthy' as const,
-			labels: 'app=foo'
+			labels: 'app=foo',
+			useRegex: true
 		};
 		const params = filtersToSearchParams(original);
 		const restored = searchParamsToFilters(params);
@@ -275,6 +280,7 @@ describe('filtersToSearchParams / searchParamsToFilters', () => {
 		expect(restored.namespace).toBe(original.namespace);
 		expect(restored.status).toBe(original.status);
 		expect(restored.labels).toBe(original.labels);
+		expect(restored.useRegex).toBe(original.useRegex);
 	});
 
 	test('empty default state produces empty params', () => {
@@ -288,5 +294,6 @@ describe('filtersToSearchParams / searchParamsToFilters', () => {
 		expect(filters.namespace).toBe('');
 		expect(filters.status).toBe('all');
 		expect(filters.labels).toBe('');
+		expect(filters.useRegex).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- fix admin auth-provider and user action accessibility, dialog semantics, and notification interaction behavior
- persist resource regex filter state in the URL, repair resource sort ARIA bindings, and fix wizard numeric handling plus post-create routing
- remove duplicate cluster health failure messaging and replace hardcoded admin landing facts with runtime-derived system info

## Testing
- `bun run format`
- `bun run lint`
- `bun run check`
- `bun run build`
- `bun test` *(fails with pre-existing unrelated baseline failures in crypto, flux-actions, validation, settings, RBAC, rate limiting, and SSO tests; not widened in this issue scope)*

Closes #412.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin system panel now shows deployment, cluster access, DB, and environment
  * Regex search mode is persistent and shareable via URL
  * Modal focus-trap utility added for dialogs with robust focus cycling

* **Bug Fixes**
  * Notification bell ignores clicks/keys from nested interactive controls
  * Resource wizard improves numeric field handling and form↔YAML sync

* **Accessibility**
  * Improved ARIA labels, dialog semantics, and explicit button types across admin pages
  * Cluster selector and sort controls now produce correct accessible labels

* **Tests**
  * Added tests for regex filter URL round-trip and active-filter behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->