### PR TITLE
fix(auth): harden authz boundaries and secure production metrics defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,10 +101,10 @@ ENV NODE_ENV=production \
   KUBECONFIG=/app/.kube/config
 
 # Health check
-# /metrics is a lightweight public endpoint that responds regardless of K8s connectivity.
-# Avoids false-negative unhealthy status when no kubeconfig is mounted yet.
+# /api/v1/health is an app-process readiness endpoint with no K8s dependency.
+# Avoids false-negative unhealthy status when cluster connectivity is unavailable.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3000/metrics', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+  CMD node -e "require('http').get('http://localhost:3000/api/v1/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
 # Start the application
 # Node.js 18+ handles signals properly, no init system needed

--- a/charts/gyre/values.yaml
+++ b/charts/gyre/values.yaml
@@ -101,7 +101,7 @@ resources:
 
 livenessProbe:
   httpGet:
-    path: /api/v1/flux/health
+    path: /api/v1/health
     port: 3000
   initialDelaySeconds: 30
   periodSeconds: 30
@@ -110,7 +110,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /api/v1/flux/health
+    path: /api/v1/health
     port: 3000
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/src/lib/server/config/constants.ts
+++ b/src/lib/server/config/constants.ts
@@ -96,8 +96,8 @@ export const HEARTBEAT_INTERVAL_MS = parseEnvInt('GYRE_HEARTBEAT_INTERVAL_MS', 3
 
 /**
  * Bearer token for Prometheus metrics scraping.
- * If set, requests to /metrics must supply `Authorization: Bearer <token>`.
- * If unset, /metrics is public.
+ * In production, /metrics requires either this bearer token or an authenticated admin session.
+ * In non-production, /metrics is public unless this token is configured.
  * env: GYRE_METRICS_TOKEN
  */
 export const GYRE_METRICS_TOKEN: string | undefined = process.env.GYRE_METRICS_TOKEN || undefined;

--- a/src/lib/server/settings.ts
+++ b/src/lib/server/settings.ts
@@ -17,12 +17,23 @@ export const SETTINGS_KEYS = {
 } as const;
 
 // Default values
-const DEFAULTS: Record<string, string> = {
+const STATIC_DEFAULTS: Record<string, string> = {
 	[SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED]: 'true',
-	[SETTINGS_KEYS.AUTH_ALLOW_SIGNUP]: 'true',
 	[SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST]: '[]',
 	[SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS]: '90'
 };
+
+function isProductionMode(): boolean {
+	return process.env.NODE_ENV === 'production';
+}
+
+function getDefaultValue(key: string): string {
+	if (key === SETTINGS_KEYS.AUTH_ALLOW_SIGNUP) {
+		return isProductionMode() ? 'false' : 'true';
+	}
+
+	return STATIC_DEFAULTS[key] ?? '';
+}
 
 // Environment variable overrides (take precedence over DB)
 const ENV_OVERRIDES: Record<string, string> = {
@@ -64,7 +75,7 @@ export async function getSetting(key: string): Promise<string> {
 		where: eq(appSettings.key, key)
 	});
 
-	const value = setting?.value ?? DEFAULTS[key] ?? '';
+	const value = setting?.value ?? getDefaultValue(key);
 
 	// Update cache
 	cache.set(key, { value, timestamp: Date.now() });
@@ -186,9 +197,9 @@ export function isSettingOverriddenByEnv(key: string): boolean {
 export async function seedAuthSettings(): Promise<void> {
 	const db = await getDb();
 
-	for (const [key, defaultValue] of Object.entries(DEFAULTS)) {
+	for (const key of Object.keys(ENV_OVERRIDES)) {
 		const envVar = ENV_OVERRIDES[key];
-		const value = (envVar && process.env[envVar]) || defaultValue;
+		const value = (envVar && process.env[envVar]) || getDefaultValue(key);
 
 		await db
 			.insert(appSettings)

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,0 +1,6 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+	return json({ status: 'ok' });
+};

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,5 +1,26 @@
 import { json } from '@sveltejs/kit';
+import { z } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
+
+export const _metadata = {
+	GET: {
+		summary: 'Application health check',
+		description: 'Lightweight process health endpoint with no Kubernetes dependency.',
+		tags: ['System'],
+		responses: {
+			200: {
+				description: 'Application is healthy',
+				content: {
+					'application/json': {
+						schema: z.object({
+							status: z.literal('ok')
+						})
+					}
+				}
+			}
+		}
+	}
+};
 
 export const GET: RequestHandler = async () => {
 	return json({ status: 'ok' });

--- a/src/routes/api/v1/admin/auth-providers/+server.ts
+++ b/src/routes/api/v1/admin/auth-providers/+server.ts
@@ -89,6 +89,8 @@ import { encryptSecret } from '$lib/server/auth/crypto';
 import { validateProviderConfig } from '$lib/server/auth/oauth';
 import { randomBytes } from 'node:crypto';
 import { checkRateLimit } from '$lib/server/rate-limiter';
+import { checkPermission } from '$lib/server/rbac.js';
+import { logAudit } from '$lib/server/audit';
 
 /**
  * Generate a unique provider ID
@@ -102,9 +104,20 @@ function generateProviderId(): string {
  * List all auth providers (admin only)
  */
 export const GET: RequestHandler = async ({ locals }) => {
-	// Check authentication (hook enforces admin role for /api/v1/admin/* routes)
+	// Check authentication
 	if (!locals.user) {
 		throw error(401, { message: 'Unauthorized' });
+	}
+
+	const hasPermission = await checkPermission(
+		locals.user,
+		'admin',
+		'AuthProvider',
+		undefined,
+		locals.cluster
+	);
+	if (!hasPermission) {
+		throw error(403, { message: 'Admin access required' });
 	}
 
 	try {
@@ -132,9 +145,20 @@ export const GET: RequestHandler = async ({ locals }) => {
  * Create a new auth provider (admin only)
  */
 export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
-	// Check authentication (hook enforces admin role for /api/v1/admin/* routes)
+	// Check authentication
 	if (!locals.user) {
 		throw error(401, { message: 'Unauthorized' });
+	}
+
+	const hasPermission = await checkPermission(
+		locals.user,
+		'admin',
+		'AuthProvider',
+		undefined,
+		locals.cluster
+	);
+	if (!hasPermission) {
+		throw error(403, { message: 'Admin access required' });
 	}
 
 	checkRateLimit({ setHeaders }, `admin:${locals.user.id}`, 20, 60 * 1000);
@@ -216,6 +240,15 @@ export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
 		// Insert into database
 		const db = await getDb();
 		await db.insert(authProviders).values(newProvider);
+		await logAudit(locals.user, 'auth-provider:create', {
+			resourceType: 'AuthProvider',
+			resourceName: newProvider.name,
+			details: {
+				providerId: newProvider.id,
+				providerType: newProvider.type,
+				enabled: newProvider.enabled
+			}
+		});
 
 		logger.info(`Created new auth provider: ${name} (${type})`);
 

--- a/src/routes/api/v1/admin/auth-providers/[id]/+server.ts
+++ b/src/routes/api/v1/admin/auth-providers/[id]/+server.ts
@@ -190,29 +190,25 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 		}
 
 		const body = await request.json();
-		const changedKeys = Object.keys(body).filter((key) => key !== 'clientSecret');
-
-		// Build update object (only include provided fields)
-		const updates: Record<string, unknown> = {
-			updatedAt: new Date()
-		};
+		// Build applied update object (only include known, provided fields)
+		const appliedUpdate: Record<string, unknown> = {};
 
 		// Update fields if provided
-		if (body.name !== undefined) updates.name = body.name;
-		if (body.type !== undefined) updates.type = body.type;
-		if (body.enabled !== undefined) updates.enabled = body.enabled;
-		if (body.clientId !== undefined) updates.clientId = body.clientId;
-		if (body.issuerUrl !== undefined) updates.issuerUrl = body.issuerUrl;
-		if (body.authorizationUrl !== undefined) updates.authorizationUrl = body.authorizationUrl;
-		if (body.tokenUrl !== undefined) updates.tokenUrl = body.tokenUrl;
-		if (body.userInfoUrl !== undefined) updates.userInfoUrl = body.userInfoUrl;
-		if (body.jwksUrl !== undefined) updates.jwksUrl = body.jwksUrl;
-		if (body.autoProvision !== undefined) updates.autoProvision = body.autoProvision;
-		if (body.defaultRole !== undefined) updates.defaultRole = body.defaultRole;
+		if (body.name !== undefined) appliedUpdate.name = body.name;
+		if (body.type !== undefined) appliedUpdate.type = body.type;
+		if (body.enabled !== undefined) appliedUpdate.enabled = body.enabled;
+		if (body.clientId !== undefined) appliedUpdate.clientId = body.clientId;
+		if (body.issuerUrl !== undefined) appliedUpdate.issuerUrl = body.issuerUrl;
+		if (body.authorizationUrl !== undefined) appliedUpdate.authorizationUrl = body.authorizationUrl;
+		if (body.tokenUrl !== undefined) appliedUpdate.tokenUrl = body.tokenUrl;
+		if (body.userInfoUrl !== undefined) appliedUpdate.userInfoUrl = body.userInfoUrl;
+		if (body.jwksUrl !== undefined) appliedUpdate.jwksUrl = body.jwksUrl;
+		if (body.autoProvision !== undefined) appliedUpdate.autoProvision = body.autoProvision;
+		if (body.defaultRole !== undefined) appliedUpdate.defaultRole = body.defaultRole;
 		if (body.roleMapping !== undefined) {
 			try {
 				const parsedRoleMapping = parseRoleMappingInput(body.roleMapping);
-				updates.roleMapping = parsedRoleMapping ? JSON.stringify(parsedRoleMapping) : null;
+				appliedUpdate.roleMapping = parsedRoleMapping ? JSON.stringify(parsedRoleMapping) : null;
 			} catch (parseError) {
 				throw error(400, {
 					message:
@@ -222,26 +218,28 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 				});
 			}
 		}
-		if (body.roleClaim !== undefined) updates.roleClaim = body.roleClaim;
-		if (body.usernameClaim !== undefined) updates.usernameClaim = body.usernameClaim;
-		if (body.emailClaim !== undefined) updates.emailClaim = body.emailClaim;
-		if (body.usePkce !== undefined) updates.usePkce = body.usePkce;
-		if (body.scopes !== undefined) updates.scopes = body.scopes;
+		if (body.roleClaim !== undefined) appliedUpdate.roleClaim = body.roleClaim;
+		if (body.usernameClaim !== undefined) appliedUpdate.usernameClaim = body.usernameClaim;
+		if (body.emailClaim !== undefined) appliedUpdate.emailClaim = body.emailClaim;
+		if (body.usePkce !== undefined) appliedUpdate.usePkce = body.usePkce;
+		if (body.scopes !== undefined) appliedUpdate.scopes = body.scopes;
 
 		// Handle client secret separately (needs encryption)
-		if (body.clientSecret) {
-			updates.clientSecretEncrypted = encryptSecret(body.clientSecret);
+		if (typeof body.clientSecret === 'string' && body.clientSecret.trim().length > 0) {
+			appliedUpdate.clientSecretEncrypted = encryptSecret(body.clientSecret);
 		}
+		const changedKeys = Object.keys(appliedUpdate).filter((key) => key !== 'clientSecretEncrypted');
+		const updatePayload: Record<string, unknown> = { ...appliedUpdate, updatedAt: new Date() };
 
 		// Validate updated configuration
-		const updatedConfig = { ...existingProvider, ...updates };
+		const updatedConfig = { ...existingProvider, ...updatePayload };
 		const validation = validateProviderConfig(updatedConfig);
 		if (!validation.valid) {
 			throw error(400, { message: validation.errors.join(', ') });
 		}
 
 		// Update in database
-		await db.update(authProviders).set(updates).where(eq(authProviders.id, params.id));
+		await db.update(authProviders).set(updatePayload).where(eq(authProviders.id, params.id));
 
 		logger.info({ providerId: params.id }, 'Updated auth provider');
 
@@ -255,7 +253,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 			details: {
 				providerId: params.id,
 				changedKeys,
-				clientSecretUpdated: body.clientSecret !== undefined
+				clientSecretUpdated: !!appliedUpdate.clientSecretEncrypted
 			}
 		});
 

--- a/src/routes/api/v1/admin/auth-providers/[id]/+server.ts
+++ b/src/routes/api/v1/admin/auth-providers/[id]/+server.ts
@@ -17,6 +17,7 @@ import { encryptSecret } from '$lib/server/auth/crypto';
 import { validateProviderConfig } from '$lib/server/auth/oauth';
 import { eq } from 'drizzle-orm';
 import { checkPermission } from '$lib/server/rbac.js';
+import { logAudit } from '$lib/server/audit';
 
 export const _metadata = {
 	GET: {
@@ -189,6 +190,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 		}
 
 		const body = await request.json();
+		const changedKeys = Object.keys(body).filter((key) => key !== 'clientSecret');
 
 		// Build update object (only include provided fields)
 		const updates: Record<string, unknown> = {
@@ -247,6 +249,15 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 		const updatedProvider = await db.query.authProviders.findFirst({
 			where: eq(authProviders.id, params.id)
 		});
+		await logAudit(locals.user, 'auth-provider:update', {
+			resourceType: 'AuthProvider',
+			resourceName: updatedProvider?.name ?? existingProvider.name,
+			details: {
+				providerId: params.id,
+				changedKeys,
+				clientSecretUpdated: body.clientSecret !== undefined
+			}
+		});
 
 		return json({
 			success: true,
@@ -295,6 +306,14 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 		await db.transaction((tx) => {
 			tx.delete(accounts).where(eq(accounts.providerId, params.id)).run();
 			tx.delete(authProviders).where(eq(authProviders.id, params.id)).run();
+		});
+		await logAudit(locals.user, 'auth-provider:delete', {
+			resourceType: 'AuthProvider',
+			resourceName: provider.name,
+			details: {
+				providerId: params.id,
+				providerType: provider.type
+			}
 		});
 
 		logger.info({ providerId: params.id, providerName: provider.name }, 'Deleted auth provider');

--- a/src/routes/api/v1/admin/k8s/clear-client-pool/+server.ts
+++ b/src/routes/api/v1/admin/k8s/clear-client-pool/+server.ts
@@ -3,6 +3,7 @@ import { z } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
 import { clearClientPool } from '$lib/server/kubernetes/client.js';
 import { checkPermission } from '$lib/server/rbac.js';
+import { logAudit } from '$lib/server/audit';
 
 export const _metadata = {
 	POST: {
@@ -45,5 +46,12 @@ export const POST: RequestHandler = async ({ locals }) => {
 	}
 
 	clearClientPool();
+	await logAudit(locals.user, 'k8s-client-pool:clear', {
+		resourceType: 'KubernetesClientPool',
+		resourceName: 'global',
+		details: {
+			clusterId: locals.cluster ?? null
+		}
+	});
 	return json({ message: 'Connection pool cleared' });
 };

--- a/src/routes/api/v1/admin/k8s/clear-client-pool/+server.ts
+++ b/src/routes/api/v1/admin/k8s/clear-client-pool/+server.ts
@@ -49,9 +49,8 @@ export const POST: RequestHandler = async ({ locals }) => {
 	await logAudit(locals.user, 'k8s-client-pool:clear', {
 		resourceType: 'KubernetesClientPool',
 		resourceName: 'global',
-		details: {
-			clusterId: locals.cluster ?? null
-		}
+		clusterId: locals.cluster ?? null,
+		details: {}
 	});
 	return json({ message: 'Connection pool cleared' });
 };

--- a/src/routes/api/v1/admin/k8s/clear-client-pool/+server.ts
+++ b/src/routes/api/v1/admin/k8s/clear-client-pool/+server.ts
@@ -49,7 +49,7 @@ export const POST: RequestHandler = async ({ locals }) => {
 	await logAudit(locals.user, 'k8s-client-pool:clear', {
 		resourceType: 'KubernetesClientPool',
 		resourceName: 'global',
-		clusterId: locals.cluster ?? null,
+		clusterId: locals.cluster,
 		details: {}
 	});
 	return json({ message: 'Connection pool cleared' });

--- a/src/routes/api/v1/admin/settings/+server.ts
+++ b/src/routes/api/v1/admin/settings/+server.ts
@@ -16,6 +16,7 @@ import {
 	isSettingOverriddenByEnv
 } from '$lib/server/settings';
 import { checkPermission } from '$lib/server/rbac';
+import { logAudit } from '$lib/server/audit';
 
 export const _metadata = {
 	GET: {
@@ -170,17 +171,21 @@ export const PATCH: RequestHandler = async ({ locals, request, setHeaders }) => 
 		if (!body || typeof body !== 'object') {
 			throw error(400, { message: 'Invalid request body' });
 		}
+		const changedKeys: string[] = [];
+		const requestedKeys = Object.keys(body);
 
 		// Update settings
 		if (typeof body.localLoginEnabled === 'boolean') {
 			if (!isSettingOverriddenByEnv(SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED)) {
 				await setSetting(SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED, String(body.localLoginEnabled));
+				changedKeys.push(SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED);
 			}
 		}
 
 		if (typeof body.allowSignup === 'boolean') {
 			if (!isSettingOverriddenByEnv(SETTINGS_KEYS.AUTH_ALLOW_SIGNUP)) {
 				await setSetting(SETTINGS_KEYS.AUTH_ALLOW_SIGNUP, String(body.allowSignup));
+				changedKeys.push(SETTINGS_KEYS.AUTH_ALLOW_SIGNUP);
 			}
 		}
 
@@ -194,6 +199,7 @@ export const PATCH: RequestHandler = async ({ locals, request, setHeaders }) => 
 
 				const uniqueDomains = [...new Set(domains)];
 				await setSetting(SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST, JSON.stringify(uniqueDomains));
+				changedKeys.push(SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST);
 			}
 		}
 
@@ -210,6 +216,7 @@ export const PATCH: RequestHandler = async ({ locals, request, setHeaders }) => 
 				}
 
 				await setSetting(SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS, String(retention));
+				changedKeys.push(SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS);
 			}
 		}
 
@@ -218,6 +225,13 @@ export const PATCH: RequestHandler = async ({ locals, request, setHeaders }) => 
 			getAuthSettings(),
 			getAuditLogRetentionDays()
 		]);
+		await logAudit(locals.user, 'settings:update', {
+			resourceType: 'AppSettings',
+			details: {
+				requestedKeys,
+				changedKeys
+			}
+		});
 		return json({
 			settings: {
 				localLoginEnabled: {

--- a/src/routes/api/v1/flux/[resourceType]/+server.ts
+++ b/src/routes/api/v1/flux/[resourceType]/+server.ts
@@ -15,7 +15,7 @@ import {
 	type FluxResourceType
 } from '$lib/server/kubernetes/flux/resources.js';
 import { handleApiError } from '$lib/server/kubernetes/errors.js';
-import { checkPermission } from '$lib/server/rbac.js';
+import { checkClusterWideReadPermission, checkPermission } from '$lib/server/rbac.js';
 import { validateK8sNamespace, validateFluxResourceSpec } from '$lib/server/validation';
 import { VALID_SORT_BY, VALID_SORT_ORDER } from '$lib/config/sorting';
 
@@ -33,7 +33,8 @@ const createFluxResourceBodySchema = z.looseObject({
 export const _metadata = {
 	GET: {
 		summary: 'List FluxCD resources',
-		description: 'Retrieve a paginated, sortable list of resources of a specific type.',
+		description:
+			'Retrieve a paginated, sortable list of resources of a specific type. Requires explicit cluster-wide read permission.',
 		tags: ['Flux'],
 		request: {
 			params: z.object({
@@ -162,14 +163,8 @@ export const GET: RequestHandler = async ({ params, locals, setHeaders, request,
 
 	const listOptions: ListOptions = queryResult.data;
 
-	// Check permission (all namespaces)
-	const hasPermission = await checkPermission(
-		locals.user,
-		'read',
-		resolvedType,
-		undefined,
-		locals.cluster
-	);
+	// Check permission (all namespaces requires explicit cluster-wide policy)
+	const hasPermission = await checkClusterWideReadPermission(locals.user, locals.cluster);
 
 	if (!hasPermission) {
 		throw error(403, { message: 'Permission denied' });

--- a/src/routes/api/v1/health/+server.ts
+++ b/src/routes/api/v1/health/+server.ts
@@ -1,0 +1,27 @@
+import { json } from '@sveltejs/kit';
+import { z } from '$lib/server/openapi';
+import type { RequestHandler } from './$types';
+
+export const _metadata = {
+	GET: {
+		summary: 'Application health check',
+		description: 'Lightweight process health endpoint with no Kubernetes dependency.',
+		tags: ['System'],
+		responses: {
+			200: {
+				description: 'Application is healthy',
+				content: {
+					'application/json': {
+						schema: z.object({
+							status: z.literal('ok')
+						})
+					}
+				}
+			}
+		}
+	}
+};
+
+export const GET: RequestHandler = async () => {
+	return json({ status: 'ok' });
+};

--- a/src/routes/metrics/+server.ts
+++ b/src/routes/metrics/+server.ts
@@ -1,13 +1,40 @@
 import { register } from '$lib/server/metrics';
 import { GYRE_METRICS_TOKEN } from '$lib/server/config/constants';
 import { checkRateLimit } from '$lib/server/rate-limiter';
+import { checkPermission } from '$lib/server/rbac.js';
+import { IS_PROD } from '$lib/server/config';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ request, setHeaders, getClientAddress }) => {
+export const GET: RequestHandler = async ({ request, setHeaders, getClientAddress, locals }) => {
 	checkRateLimit({ setHeaders }, `metrics:${getClientAddress()}`, 120, 60 * 1000);
 
-	if (GYRE_METRICS_TOKEN) {
-		const authHeader = request.headers.get('authorization') ?? '';
+	const authHeader = request.headers.get('authorization') ?? '';
+	const hasValidBearerToken = !!GYRE_METRICS_TOKEN && authHeader === `Bearer ${GYRE_METRICS_TOKEN}`;
+
+	if (IS_PROD) {
+		if (!hasValidBearerToken) {
+			if (!locals.user) {
+				return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+					status: 401,
+					headers: { 'Content-Type': 'application/json' }
+				});
+			}
+
+			const hasAdminPermission = await checkPermission(
+				locals.user,
+				'admin',
+				undefined,
+				undefined,
+				locals.cluster
+			);
+			if (!hasAdminPermission) {
+				return new Response(JSON.stringify({ error: 'Forbidden' }), {
+					status: 403,
+					headers: { 'Content-Type': 'application/json' }
+				});
+			}
+		}
+	} else if (GYRE_METRICS_TOKEN) {
 		if (authHeader !== `Bearer ${GYRE_METRICS_TOKEN}`) {
 			return new Response(JSON.stringify({ error: 'Unauthorized' }), {
 				status: 401,

--- a/src/tests/admin-auth-providers-guard.test.ts
+++ b/src/tests/admin-auth-providers-guard.test.ts
@@ -40,9 +40,10 @@ beforeEach(() => {
 
 describe('admin auth providers explicit in-handler guard', () => {
 	test('GET rejects authenticated non-admin users with 403', async () => {
+		const locals = { user: createUser('editor'), cluster: 'cluster-a' };
 		await expect(
 			providersGET({
-				locals: { user: createUser('editor'), cluster: 'cluster-a' }
+				locals
 			} as Parameters<typeof providersGET>[0])
 		).rejects.toMatchObject({
 			status: 403,
@@ -52,12 +53,14 @@ describe('admin auth providers explicit in-handler guard', () => {
 		expect(permissionChecks).toHaveLength(1);
 		expect(permissionChecks[0][1]).toBe('admin');
 		expect(permissionChecks[0][2]).toBe('AuthProvider');
+		expect(permissionChecks[0][4]).toBe(locals.cluster);
 	});
 
 	test('POST rejects authenticated non-admin users with 403 before mutation', async () => {
+		const locals = { user: createUser('editor'), cluster: 'cluster-a' };
 		await expect(
 			providersPOST({
-				locals: { user: createUser('editor'), cluster: 'cluster-a' },
+				locals,
 				setHeaders: () => {},
 				request: new Request('http://localhost/api/v1/admin/auth-providers', {
 					method: 'POST',
@@ -73,5 +76,6 @@ describe('admin auth providers explicit in-handler guard', () => {
 		expect(permissionChecks).toHaveLength(1);
 		expect(permissionChecks[0][1]).toBe('admin');
 		expect(permissionChecks[0][2]).toBe('AuthProvider');
+		expect(permissionChecks[0][4]).toBe(locals.cluster);
 	});
 });

--- a/src/tests/admin-auth-providers-guard.test.ts
+++ b/src/tests/admin-auth-providers-guard.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { User } from '../lib/server/db/schema.js';
+
+const permissionChecks: unknown[][] = [];
+
+mock.module('$lib/server/rbac.js', () => ({
+	checkPermission: async (...args: unknown[]) => {
+		permissionChecks.push(args);
+		return false;
+	}
+}));
+
+import {
+	GET as providersGET,
+	POST as providersPOST
+} from '../routes/api/v1/admin/auth-providers/+server.js';
+
+function createUser(role: User['role'] = 'editor'): User {
+	const now = new Date();
+	return {
+		id: 'user-1',
+		username: 'editor',
+		email: null,
+		name: 'Editor',
+		emailVerified: false,
+		image: null,
+		role,
+		active: true,
+		isLocal: true,
+		requiresPasswordChange: false,
+		createdAt: now,
+		updatedAt: now,
+		preferences: null
+	};
+}
+
+beforeEach(() => {
+	permissionChecks.length = 0;
+});
+
+describe('admin auth providers explicit in-handler guard', () => {
+	test('GET rejects authenticated non-admin users with 403', async () => {
+		await expect(
+			providersGET({
+				locals: { user: createUser('editor'), cluster: 'cluster-a' }
+			} as Parameters<typeof providersGET>[0])
+		).rejects.toMatchObject({
+			status: 403,
+			body: { message: 'Admin access required' }
+		});
+
+		expect(permissionChecks).toHaveLength(1);
+		expect(permissionChecks[0][1]).toBe('admin');
+		expect(permissionChecks[0][2]).toBe('AuthProvider');
+	});
+
+	test('POST rejects authenticated non-admin users with 403 before mutation', async () => {
+		await expect(
+			providersPOST({
+				locals: { user: createUser('editor'), cluster: 'cluster-a' },
+				setHeaders: () => {},
+				request: new Request('http://localhost/api/v1/admin/auth-providers', {
+					method: 'POST',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({})
+				})
+			} as Parameters<typeof providersPOST>[0])
+		).rejects.toMatchObject({
+			status: 403,
+			body: { message: 'Admin access required' }
+		});
+
+		expect(permissionChecks).toHaveLength(1);
+		expect(permissionChecks[0][1]).toBe('admin');
+		expect(permissionChecks[0][2]).toBe('AuthProvider');
+	});
+});

--- a/src/tests/admin-security-audit-events.test.ts
+++ b/src/tests/admin-security-audit-events.test.ts
@@ -323,5 +323,6 @@ describe('admin mutation audit events', () => {
 		expect(clearPoolCalls).toBe(1);
 		expect(auditCalls).toHaveLength(1);
 		expect(auditCalls[0][1]).toBe('k8s-client-pool:clear');
+		expect(auditCalls[0][2]?.clusterId).toBe('cluster-a');
 	});
 });

--- a/src/tests/admin-security-audit-events.test.ts
+++ b/src/tests/admin-security-audit-events.test.ts
@@ -1,0 +1,327 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { User } from '../lib/server/db/schema.js';
+
+const auditCalls: Array<[User | null, string, Record<string, unknown> | undefined]> = [];
+const settingWrites: Array<[string, string]> = [];
+
+let permissionAllowed = true;
+let clearPoolCalls = 0;
+
+const dbState: {
+	insertedProviders: Array<Record<string, unknown>>;
+	findFirstQueue: Array<Record<string, unknown> | null>;
+	updates: Array<Record<string, unknown>>;
+	deleteRuns: number;
+} = {
+	insertedProviders: [],
+	findFirstQueue: [],
+	updates: [],
+	deleteRuns: 0
+};
+
+mock.module('$lib/server/audit', () => ({
+	logAudit: async (user: User | null, action: string, options?: Record<string, unknown>) => {
+		auditCalls.push([user, action, options]);
+	}
+}));
+
+mock.module('$lib/server/rbac.js', () => ({
+	checkPermission: async () => permissionAllowed
+}));
+
+mock.module('$lib/server/rbac', () => ({
+	checkPermission: async () => permissionAllowed
+}));
+
+mock.module('$lib/server/rate-limiter', () => ({
+	checkRateLimit: () => {}
+}));
+
+mock.module('$lib/server/db', () => ({
+	getDb: async () => ({
+		query: {
+			authProviders: {
+				findFirst: async () => {
+					if (dbState.findFirstQueue.length > 0) {
+						return dbState.findFirstQueue.shift() ?? null;
+					}
+					return dbState.insertedProviders[0] ?? null;
+				}
+			}
+		},
+		insert: () => ({
+			values: async (value: Record<string, unknown>) => {
+				dbState.insertedProviders.push({ ...value });
+			}
+		}),
+		update: () => ({
+			set: (updates: Record<string, unknown>) => ({
+				where: async () => {
+					dbState.updates.push({ ...updates });
+					if (dbState.insertedProviders[0]) {
+						dbState.insertedProviders[0] = {
+							...dbState.insertedProviders[0],
+							...updates
+						};
+					}
+				}
+			})
+		}),
+		transaction: async (
+			fn: (tx: {
+				delete: () => {
+					where: () => {
+						run: () => void;
+					};
+				};
+			}) => void
+		) => {
+			fn({
+				delete: () => ({
+					where: () => ({
+						run: () => {
+							dbState.deleteRuns += 1;
+						}
+					})
+				})
+			});
+		}
+	})
+}));
+
+mock.module('$lib/auth/role-mapping', () => ({
+	parseRoleMappingInput: (input: unknown) => {
+		if (!input) return null;
+		if (typeof input === 'object') return input;
+		throw new Error('invalid role mapping');
+	}
+}));
+
+mock.module('$lib/server/auth/role-mapping', () => ({
+	parseRoleMappingSafe: (value: unknown) => {
+		if (!value) return null;
+		if (typeof value === 'string') {
+			try {
+				return JSON.parse(value);
+			} catch {
+				return null;
+			}
+		}
+		return value;
+	}
+}));
+
+mock.module('$lib/server/auth/oauth', () => ({
+	validateProviderConfig: () => ({ valid: true, errors: [] })
+}));
+
+mock.module('$lib/server/auth/crypto', () => ({
+	encryptSecret: (value: string) => `enc:${value}`
+}));
+
+mock.module('$lib/server/settings', () => ({
+	SETTINGS_KEYS: {
+		AUTH_LOCAL_LOGIN_ENABLED: 'auth.localLoginEnabled',
+		AUTH_ALLOW_SIGNUP: 'auth.allowSignup',
+		AUTH_DOMAIN_ALLOWLIST: 'auth.domainAllowlist',
+		AUDIT_LOG_RETENTION_DAYS: 'audit.retentionDays'
+	},
+	setSetting: async (key: string, value: string) => {
+		settingWrites.push([key, value]);
+	},
+	isSettingOverriddenByEnv: () => false,
+	getAuthSettings: async () => ({
+		localLoginEnabled: true,
+		allowSignup: false,
+		domainAllowlist: ['example.com']
+	}),
+	getAuditLogRetentionDays: async () => 90
+}));
+
+mock.module('$lib/server/kubernetes/client.js', () => ({
+	clearClientPool: () => {
+		clearPoolCalls += 1;
+	}
+}));
+
+import { POST as createAuthProvider } from '../routes/api/v1/admin/auth-providers/+server.js';
+import {
+	PATCH as updateAuthProvider,
+	DELETE as deleteAuthProvider
+} from '../routes/api/v1/admin/auth-providers/[id]/+server.js';
+import { PATCH as patchSettings } from '../routes/api/v1/admin/settings/+server.js';
+import { POST as clearClientPool } from '../routes/api/v1/admin/k8s/clear-client-pool/+server.js';
+
+function createUser(role: User['role'] = 'admin'): User {
+	const now = new Date();
+	return {
+		id: 'admin-1',
+		username: 'admin',
+		email: null,
+		name: 'Admin',
+		emailVerified: false,
+		image: null,
+		role,
+		active: true,
+		isLocal: true,
+		requiresPasswordChange: false,
+		createdAt: now,
+		updatedAt: now,
+		preferences: null
+	};
+}
+
+beforeEach(() => {
+	auditCalls.length = 0;
+	settingWrites.length = 0;
+	permissionAllowed = true;
+	clearPoolCalls = 0;
+	dbState.insertedProviders.length = 0;
+	dbState.findFirstQueue.length = 0;
+	dbState.updates.length = 0;
+	dbState.deleteRuns = 0;
+});
+
+describe('admin mutation audit events', () => {
+	test('logs auth-provider:create on provider creation', async () => {
+		const response = await createAuthProvider({
+			locals: { user: createUser(), cluster: 'cluster-a' },
+			setHeaders: () => {},
+			request: new Request('http://localhost/api/v1/admin/auth-providers', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					name: 'Corp SSO',
+					type: 'oidc',
+					clientId: 'client-id',
+					clientSecret: 'client-secret'
+				})
+			})
+		} as Parameters<typeof createAuthProvider>[0]);
+
+		expect(response.status).toBe(200);
+		expect(auditCalls).toHaveLength(1);
+		expect(auditCalls[0][1]).toBe('auth-provider:create');
+		expect(auditCalls[0][2]?.resourceType).toBe('AuthProvider');
+	});
+
+	test('logs auth-provider:update on provider patch', async () => {
+		dbState.findFirstQueue.push(
+			{
+				id: 'provider-1',
+				name: 'Old Name',
+				type: 'oidc',
+				enabled: true,
+				clientId: 'client-id',
+				clientSecretEncrypted: 'enc:old',
+				issuerUrl: null,
+				authorizationUrl: null,
+				tokenUrl: null,
+				userInfoUrl: null,
+				jwksUrl: null,
+				autoProvision: true,
+				defaultRole: 'viewer',
+				roleMapping: null,
+				roleClaim: 'groups',
+				usernameClaim: 'preferred_username',
+				emailClaim: 'email',
+				usePkce: true,
+				scopes: 'openid profile email'
+			},
+			{
+				id: 'provider-1',
+				name: 'New Name',
+				type: 'oidc',
+				enabled: true,
+				clientId: 'client-id',
+				clientSecretEncrypted: 'enc:new',
+				issuerUrl: null,
+				authorizationUrl: null,
+				tokenUrl: null,
+				userInfoUrl: null,
+				jwksUrl: null,
+				autoProvision: true,
+				defaultRole: 'viewer',
+				roleMapping: null,
+				roleClaim: 'groups',
+				usernameClaim: 'preferred_username',
+				emailClaim: 'email',
+				usePkce: true,
+				scopes: 'openid profile email'
+			}
+		);
+
+		const response = await updateAuthProvider({
+			params: { id: 'provider-1' },
+			locals: { user: createUser(), cluster: 'cluster-a' },
+			request: new Request('http://localhost/api/v1/admin/auth-providers/provider-1', {
+				method: 'PATCH',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ name: 'New Name', clientSecret: 'new-secret' })
+			})
+		} as Parameters<typeof updateAuthProvider>[0]);
+
+		expect(response.status).toBe(200);
+		expect(auditCalls).toHaveLength(1);
+		expect(auditCalls[0][1]).toBe('auth-provider:update');
+		expect(auditCalls[0][2]?.details).toEqual({
+			providerId: 'provider-1',
+			changedKeys: ['name'],
+			clientSecretUpdated: true
+		});
+	});
+
+	test('logs auth-provider:delete on provider deletion', async () => {
+		dbState.findFirstQueue.push({
+			id: 'provider-1',
+			name: 'Delete Me',
+			type: 'oidc'
+		});
+
+		const response = await deleteAuthProvider({
+			params: { id: 'provider-1' },
+			locals: { user: createUser(), cluster: 'cluster-a' }
+		} as Parameters<typeof deleteAuthProvider>[0]);
+
+		expect(response.status).toBe(200);
+		expect(dbState.deleteRuns).toBe(2);
+		expect(auditCalls).toHaveLength(1);
+		expect(auditCalls[0][1]).toBe('auth-provider:delete');
+		expect(auditCalls[0][2]?.resourceName).toBe('Delete Me');
+	});
+
+	test('logs settings:update with changed keys only', async () => {
+		const response = await patchSettings({
+			locals: { user: createUser(), cluster: 'cluster-a' },
+			setHeaders: () => {},
+			request: new Request('http://localhost/api/v1/admin/settings', {
+				method: 'PATCH',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ allowSignup: false, domainAllowlist: ['Example.com'] })
+			})
+		} as Parameters<typeof patchSettings>[0]);
+
+		expect(response.status).toBe(200);
+		expect(settingWrites).toEqual([
+			['auth.allowSignup', 'false'],
+			['auth.domainAllowlist', '["example.com"]']
+		]);
+		expect(auditCalls).toHaveLength(1);
+		expect(auditCalls[0][1]).toBe('settings:update');
+		expect(auditCalls[0][2]?.details).toEqual({
+			requestedKeys: ['allowSignup', 'domainAllowlist'],
+			changedKeys: ['auth.allowSignup', 'auth.domainAllowlist']
+		});
+	});
+
+	test('logs k8s-client-pool:clear on pool clear mutation', async () => {
+		const response = await clearClientPool({
+			locals: { user: createUser(), cluster: 'cluster-a' }
+		} as Parameters<typeof clearClientPool>[0]);
+
+		expect(response.status).toBe(200);
+		expect(clearPoolCalls).toBe(1);
+		expect(auditCalls).toHaveLength(1);
+		expect(auditCalls[0][1]).toBe('k8s-client-pool:clear');
+	});
+});

--- a/src/tests/backup-encryption.test.ts
+++ b/src/tests/backup-encryption.test.ts
@@ -165,7 +165,9 @@ describe('Backup Encryption Module', () => {
 
 			// Mock existsSync to say the file exists, and readFileSync to return the encrypted buffer
 			const existsSpy = spyOn(nodeFs, 'existsSync').mockReturnValue(true);
-			const readSpy = spyOn(nodeFs, 'readFileSync').mockReturnValue(encrypted as unknown as string);
+			const readSpy = spyOn(nodeFs, 'readFileSync').mockImplementation(
+				() => encrypted as unknown as never
+			);
 
 			try {
 				const result = getDecryptedBackupBuffer(encFilename);
@@ -182,8 +184,8 @@ describe('Backup Encryption Module', () => {
 			delete process.env.BACKUP_ENCRYPTION_KEY;
 
 			const existsSpy = spyOn(nodeFs, 'existsSync').mockReturnValue(true);
-			const readSpy = spyOn(nodeFs, 'readFileSync').mockReturnValue(
-				Buffer.alloc(64) as unknown as string
+			const readSpy = spyOn(nodeFs, 'readFileSync').mockImplementation(
+				() => Buffer.alloc(64) as unknown as never
 			);
 
 			try {

--- a/src/tests/flux-list-cluster-wide-rbac.test.ts
+++ b/src/tests/flux-list-cluster-wide-rbac.test.ts
@@ -68,11 +68,12 @@ beforeEach(() => {
 describe('flux [resourceType] RBAC boundaries', () => {
 	test('GET uses explicit cluster-wide read permission for all-namespace list', async () => {
 		allowClusterWide = false;
+		const locals = { user: createUser(), cluster: 'cluster-a' };
 
 		await expect(
 			listGET({
 				params: { resourceType: 'gitrepositories' },
-				locals: { user: createUser(), cluster: 'cluster-a' },
+				locals,
 				setHeaders: () => {},
 				request: new Request('http://localhost/api/v1/flux/gitrepositories'),
 				url: new URL('http://localhost/api/v1/flux/gitrepositories')
@@ -82,18 +83,18 @@ describe('flux [resourceType] RBAC boundaries', () => {
 			body: { message: 'Permission denied' }
 		});
 
-		expect(clusterWideChecks).toHaveLength(1);
-		expect(clusterWideChecks[0][1]).toBe('cluster-a');
-		expect(scopedChecks).toHaveLength(0);
+		expect(clusterWideChecks).toEqual([[locals.user, 'cluster-a']]);
+		expect(scopedChecks).toEqual([]);
 	});
 
 	test('POST still uses namespace-scoped checkPermission for writes', async () => {
 		allowScoped = false;
+		const locals = { user: createUser(), cluster: 'cluster-a' };
 
 		await expect(
 			createPOST({
 				params: { resourceType: 'gitrepositories' },
-				locals: { user: createUser(), cluster: 'cluster-a' },
+				locals,
 				request: new Request('http://localhost/api/v1/flux/gitrepositories', {
 					method: 'POST',
 					headers: { 'content-type': 'application/json' },
@@ -110,11 +111,7 @@ describe('flux [resourceType] RBAC boundaries', () => {
 			body: { message: 'Permission denied' }
 		});
 
-		expect(scopedChecks).toHaveLength(1);
-		expect(scopedChecks[0][1]).toBe('write');
-		expect(scopedChecks[0][2]).toBe('GitRepository');
-		expect(scopedChecks[0][3]).toBe('default');
-		expect(scopedChecks[0][4]).toBe('cluster-a');
-		expect(clusterWideChecks).toHaveLength(0);
+		expect(scopedChecks).toEqual([[locals.user, 'write', 'GitRepository', 'default', 'cluster-a']]);
+		expect(clusterWideChecks).toEqual([]);
 	});
 });

--- a/src/tests/flux-list-cluster-wide-rbac.test.ts
+++ b/src/tests/flux-list-cluster-wide-rbac.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { User } from '../lib/server/db/schema.js';
+
+const clusterWideChecks: unknown[][] = [];
+const scopedChecks: unknown[][] = [];
+
+let allowClusterWide = true;
+let allowScoped = true;
+
+mock.module('$lib/server/rbac.js', () => ({
+	checkClusterWideReadPermission: async (...args: unknown[]) => {
+		clusterWideChecks.push(args);
+		return allowClusterWide;
+	},
+	checkPermission: async (...args: unknown[]) => {
+		scopedChecks.push(args);
+		return allowScoped;
+	}
+}));
+
+mock.module('$lib/server/kubernetes/client.js', () => ({
+	listFluxResources: async () => ({ items: [], total: 0, hasMore: false, offset: 0, limit: 50 }),
+	createFluxResource: async () => ({ ok: true })
+}));
+
+mock.module('$lib/server/kubernetes/errors.js', () => ({
+	handleApiError: (err: unknown) => {
+		throw err;
+	}
+}));
+
+mock.module('$lib/server/validation', () => ({
+	validateK8sNamespace: () => {},
+	validateFluxResourceSpec: () => null
+}));
+
+import {
+	GET as listGET,
+	POST as createPOST
+} from '../routes/api/v1/flux/[resourceType]/+server.js';
+
+function createUser(role: User['role'] = 'editor'): User {
+	const now = new Date();
+	return {
+		id: 'user-1',
+		username: 'editor',
+		email: null,
+		name: 'Editor',
+		emailVerified: false,
+		image: null,
+		role,
+		active: true,
+		isLocal: true,
+		requiresPasswordChange: false,
+		createdAt: now,
+		updatedAt: now,
+		preferences: null
+	};
+}
+
+beforeEach(() => {
+	clusterWideChecks.length = 0;
+	scopedChecks.length = 0;
+	allowClusterWide = true;
+	allowScoped = true;
+});
+
+describe('flux [resourceType] RBAC boundaries', () => {
+	test('GET uses explicit cluster-wide read permission for all-namespace list', async () => {
+		allowClusterWide = false;
+
+		await expect(
+			listGET({
+				params: { resourceType: 'gitrepositories' },
+				locals: { user: createUser(), cluster: 'cluster-a' },
+				setHeaders: () => {},
+				request: new Request('http://localhost/api/v1/flux/gitrepositories'),
+				url: new URL('http://localhost/api/v1/flux/gitrepositories')
+			} as Parameters<typeof listGET>[0])
+		).rejects.toMatchObject({
+			status: 403,
+			body: { message: 'Permission denied' }
+		});
+
+		expect(clusterWideChecks).toHaveLength(1);
+		expect(clusterWideChecks[0][1]).toBe('cluster-a');
+		expect(scopedChecks).toHaveLength(0);
+	});
+
+	test('POST still uses namespace-scoped checkPermission for writes', async () => {
+		allowScoped = false;
+
+		await expect(
+			createPOST({
+				params: { resourceType: 'gitrepositories' },
+				locals: { user: createUser(), cluster: 'cluster-a' },
+				request: new Request('http://localhost/api/v1/flux/gitrepositories', {
+					method: 'POST',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({
+						apiVersion: 'source.toolkit.fluxcd.io/v1',
+						kind: 'GitRepository',
+						metadata: { name: 'demo' },
+						spec: { interval: '1m' }
+					})
+				})
+			} as Parameters<typeof createPOST>[0])
+		).rejects.toMatchObject({
+			status: 403,
+			body: { message: 'Permission denied' }
+		});
+
+		expect(scopedChecks).toHaveLength(1);
+		expect(scopedChecks[0][1]).toBe('write');
+		expect(scopedChecks[0][2]).toBe('GitRepository');
+		expect(scopedChecks[0][3]).toBe('default');
+		expect(scopedChecks[0][4]).toBe('cluster-a');
+		expect(clusterWideChecks).toHaveLength(0);
+	});
+});

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -1,13 +1,81 @@
-import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import type { User } from '../lib/server/db/schema.js';
 import { isPublicRoute } from '../lib/isPublicRoute.js';
+import * as actualConfig from '../lib/server/config.js';
+import * as actualConstants from '../lib/server/config/constants.js';
 
-const TEST_DIR = import.meta.dir;
-
-function readRepoFile(relativePath: string): string {
-	return readFileSync(resolve(TEST_DIR, '..', relativePath), 'utf8');
+function createUser(role: User['role'] = 'admin'): User {
+	const now = new Date();
+	return {
+		id: 'user-1',
+		username: 'admin',
+		email: null,
+		name: 'Admin',
+		emailVerified: false,
+		image: null,
+		role,
+		active: true,
+		isLocal: true,
+		requiresPasswordChange: false,
+		createdAt: now,
+		updatedAt: now,
+		preferences: null
+	};
 }
+
+async function callMetrics(options: {
+	isProd: boolean;
+	metricsToken?: string;
+	authHeader?: string;
+	user?: User | null;
+	cluster?: string;
+}): Promise<Response> {
+	mock.module('$lib/server/config', () => ({ ...actualConfig, IS_PROD: options.isProd }));
+	mock.module('$lib/server/config.js', () => ({ ...actualConfig, IS_PROD: options.isProd }));
+	mock.module('$lib/server/config/constants', () => ({
+		...actualConstants,
+		GYRE_METRICS_TOKEN: options.metricsToken ?? ''
+	}));
+	mock.module('$lib/server/config/constants.js', () => ({
+		...actualConstants,
+		GYRE_METRICS_TOKEN: options.metricsToken ?? ''
+	}));
+	mock.module('$lib/server/rate-limiter', () => ({
+		checkRateLimit: () => {}
+	}));
+	mock.module('$lib/server/rbac.js', () => ({
+		checkPermission: async (user: User) => user.role === 'admin'
+	}));
+	mock.module('$lib/server/metrics', () => ({
+		register: {
+			metrics: async () => '# mock metrics\n',
+			contentType: 'text/plain; version=0.0.4'
+		}
+	}));
+
+	const { GET: metricsGET } = await import(
+		`../routes/metrics/+server.js?case=${Date.now()}-${Math.random()}`
+	);
+
+	const headers = new Headers();
+	if (options.authHeader) {
+		headers.set('authorization', options.authHeader);
+	}
+
+	return metricsGET({
+		request: new Request('http://localhost/metrics', { headers }),
+		setHeaders: () => {},
+		getClientAddress: () => '127.0.0.1',
+		locals: {
+			user: options.user ?? null,
+			cluster: options.cluster
+		}
+	} as Parameters<typeof metricsGET>[0]);
+}
+
+afterEach(() => {
+	mock.restore();
+});
 
 describe('hooks public auth route detection', () => {
 	test('treats arbitrary provider login and callback routes as public', () => {
@@ -29,17 +97,72 @@ describe('hooks public auth route detection', () => {
 		expect(isPublicRoute('/logo.svg/extra')).toBe(false);
 	});
 
-	test('keeps /metrics public while enforcing production auth and non-production token behavior', () => {
-		const source = readRepoFile('routes/metrics/+server.ts');
-		const constantsSource = readRepoFile('lib/server/config/constants.ts');
-
+	test('keeps /metrics public', () => {
 		expect(isPublicRoute('/metrics')).toBe(true);
-		expect(source).toContain('if (IS_PROD) {');
-		expect(source).toContain('hasValidBearerToken');
-		expect(source).toContain('checkPermission(');
-		expect(source).toContain('else if (GYRE_METRICS_TOKEN)');
-		expect(constantsSource).toContain(
-			'In production, /metrics requires either this bearer token or an authenticated admin session.'
-		);
+	});
+});
+
+describe('metrics handler auth behavior', () => {
+	test('returns 401 in production when no bearer token and no authenticated user', async () => {
+		const response = await callMetrics({
+			isProd: true,
+			metricsToken: 'secret-token'
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({ error: 'Unauthorized' });
+	});
+
+	test('returns 200 in production with authenticated admin session', async () => {
+		const response = await callMetrics({
+			isProd: true,
+			metricsToken: 'secret-token',
+			user: createUser('admin'),
+			cluster: 'cluster-a'
+		});
+
+		expect(response.status).toBe(200);
+		expect((await response.text()).length).toBeGreaterThan(0);
+	});
+
+	test('returns 200 in production with valid bearer token and no session', async () => {
+		const response = await callMetrics({
+			isProd: true,
+			metricsToken: 'secret-token',
+			authHeader: 'Bearer secret-token'
+		});
+
+		expect(response.status).toBe(200);
+		expect((await response.text()).length).toBeGreaterThan(0);
+	});
+
+	test('returns 401 in non-production when token is configured but bearer token is missing', async () => {
+		const response = await callMetrics({
+			isProd: false,
+			metricsToken: 'secret-token'
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({ error: 'Unauthorized' });
+	});
+
+	test('returns 200 in non-production when token is configured and bearer token is valid', async () => {
+		const response = await callMetrics({
+			isProd: false,
+			metricsToken: 'secret-token',
+			authHeader: 'Bearer secret-token'
+		});
+
+		expect(response.status).toBe(200);
+		expect((await response.text()).length).toBeGreaterThan(0);
+	});
+
+	test('returns 200 in non-production when no token is configured', async () => {
+		const response = await callMetrics({
+			isProd: false
+		});
+
+		expect(response.status).toBe(200);
+		expect((await response.text()).length).toBeGreaterThan(0);
 	});
 });

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -29,14 +29,17 @@ describe('hooks public auth route detection', () => {
 		expect(isPublicRoute('/logo.svg/extra')).toBe(false);
 	});
 
-	test('keeps /metrics public while using bearer auth only when GYRE_METRICS_TOKEN is configured', () => {
+	test('keeps /metrics public while enforcing production auth and non-production token behavior', () => {
 		const source = readRepoFile('routes/metrics/+server.ts');
 		const constantsSource = readRepoFile('lib/server/config/constants.ts');
 
 		expect(isPublicRoute('/metrics')).toBe(true);
-		expect(source).toContain('if (GYRE_METRICS_TOKEN) {');
-		expect(source).toContain('authHeader !== `Bearer ${GYRE_METRICS_TOKEN}`');
-		expect(source).not.toContain("locals.user?.role === 'admin'");
-		expect(constantsSource).toContain('If unset, /metrics is public.');
+		expect(source).toContain('if (IS_PROD) {');
+		expect(source).toContain('hasValidBearerToken');
+		expect(source).toContain('checkPermission(');
+		expect(source).toContain('else if (GYRE_METRICS_TOKEN)');
+		expect(constantsSource).toContain(
+			'In production, /metrics requires either this bearer token or an authenticated admin session.'
+		);
 	});
 });

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -44,7 +44,17 @@ async function callMetrics(options: {
 		checkRateLimit: () => {}
 	}));
 	mock.module('$lib/server/rbac.js', () => ({
-		checkPermission: async (user: User) => user.role === 'admin'
+		checkPermission: async (
+			user: User,
+			permission: string,
+			_resourceType: string | undefined,
+			_namespace: string | undefined,
+			cluster: string | undefined
+		) => {
+			expect(permission).toBe('admin');
+			expect(cluster).toBe(options.cluster);
+			return user.role === 'admin';
+		}
 	}));
 	mock.module('$lib/server/metrics', () => ({
 		register: {
@@ -97,7 +107,7 @@ describe('hooks public auth route detection', () => {
 		expect(isPublicRoute('/logo.svg/extra')).toBe(false);
 	});
 
-	test('keeps /metrics public', () => {
+	test('treats /metrics as hook-public', () => {
 		expect(isPublicRoute('/metrics')).toBe(true);
 	});
 });
@@ -107,6 +117,15 @@ describe('metrics handler auth behavior', () => {
 		const response = await callMetrics({
 			isProd: true,
 			metricsToken: 'secret-token'
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({ error: 'Unauthorized' });
+	});
+
+	test('returns 401 in production when metrics token is unset and request is unauthenticated', async () => {
+		const response = await callMetrics({
+			isProd: true
 		});
 
 		expect(response.status).toBe(401);

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -125,6 +125,17 @@ describe('metrics handler auth behavior', () => {
 		expect((await response.text()).length).toBeGreaterThan(0);
 	});
 
+	test('returns 403 in production with authenticated non-admin user and no bearer token', async () => {
+		const response = await callMetrics({
+			isProd: true,
+			metricsToken: 'secret-token',
+			user: createUser('editor'),
+			cluster: 'cluster-a'
+		});
+
+		expect(response.status).toBe(403);
+	});
+
 	test('returns 200 in production with valid bearer token and no session', async () => {
 		const response = await callMetrics({
 			isProd: true,

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -194,6 +194,8 @@ describe('metrics handler auth behavior', () => {
 		});
 
 		expect(response.status).toBe(401);
+		expect(response.headers.get('content-type')).toBe('application/json');
+		expect(await response.json()).toEqual({ error: 'Unauthorized' });
 	});
 
 	test('returns 401 in non-production when token is configured but bearer token is missing', async () => {

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import type { User } from '../lib/server/db/schema.js';
 import { isPublicRoute } from '../lib/isPublicRoute.js';
 import * as actualConfig from '../lib/server/config.js';
 import * as actualConstants from '../lib/server/config/constants.js';
+
+let checkPermissionSpy: ReturnType<typeof spyOn> | undefined;
 
 function createUser(role: User['role'] = 'admin'): User {
 	const now = new Date();
@@ -43,7 +45,8 @@ async function callMetrics(options: {
 	mock.module('$lib/server/rate-limiter', () => ({
 		checkRateLimit: () => {}
 	}));
-	mock.module('$lib/server/rbac.js', () => ({
+
+	const rbacModule = {
 		checkPermission: async (
 			user: User,
 			permission: string,
@@ -55,7 +58,21 @@ async function callMetrics(options: {
 			expect(cluster).toBe(options.cluster);
 			return user.role === 'admin';
 		}
-	}));
+	};
+	checkPermissionSpy = spyOn(rbacModule, 'checkPermission').mockImplementation(
+		async (
+			user: User,
+			permission: string,
+			_resourceType: string | undefined,
+			_namespace: string | undefined,
+			cluster: string | undefined
+		) => {
+			expect(permission).toBe('admin');
+			expect(cluster).toBe(options.cluster);
+			return user.role === 'admin';
+		}
+	);
+	mock.module('$lib/server/rbac.js', () => rbacModule);
 	mock.module('$lib/server/metrics', () => ({
 		register: {
 			metrics: async () => '# mock metrics\n',
@@ -85,6 +102,7 @@ async function callMetrics(options: {
 
 afterEach(() => {
 	mock.restore();
+	checkPermissionSpy = undefined;
 });
 
 describe('hooks public auth route detection', () => {
@@ -142,6 +160,7 @@ describe('metrics handler auth behavior', () => {
 
 		expect(response.status).toBe(200);
 		expect((await response.text()).length).toBeGreaterThan(0);
+		expect(checkPermissionSpy).toHaveBeenCalled();
 	});
 
 	test('returns 403 in production with authenticated non-admin user and no bearer token', async () => {
@@ -153,6 +172,7 @@ describe('metrics handler auth behavior', () => {
 		});
 
 		expect(response.status).toBe(403);
+		expect(checkPermissionSpy).toHaveBeenCalled();
 	});
 
 	test('returns 200 in production with valid bearer token and no session', async () => {

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -166,6 +166,16 @@ describe('metrics handler auth behavior', () => {
 		expect((await response.text()).length).toBeGreaterThan(0);
 	});
 
+	test('returns 401 in production when bearer token is invalid', async () => {
+		const response = await callMetrics({
+			isProd: true,
+			metricsToken: 'secret-token',
+			authHeader: 'Bearer wrong-token'
+		});
+
+		expect(response.status).toBe(401);
+	});
+
 	test('returns 401 in non-production when token is configured but bearer token is missing', async () => {
 		const response = await callMetrics({
 			isProd: false,
@@ -185,6 +195,17 @@ describe('metrics handler auth behavior', () => {
 
 		expect(response.status).toBe(200);
 		expect((await response.text()).length).toBeGreaterThan(0);
+	});
+
+	test('returns 401 in non-production when token is configured and bearer token is invalid', async () => {
+		const response = await callMetrics({
+			isProd: false,
+			metricsToken: 'secret-token',
+			authHeader: 'Bearer wrong-token'
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({ error: 'Unauthorized' });
 	});
 
 	test('returns 200 in non-production when no token is configured', async () => {

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -276,6 +276,19 @@ describe('getAuthSettings', () => {
 		expect(settings.allowSignup).toBe(true);
 		expect(settings.domainAllowlist).toEqual([]);
 	});
+
+	test('defaults allowSignup to false in production when unset', async () => {
+		const previousNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'production';
+
+		try {
+			const settings = await getAuthSettings();
+			expect(settings.allowSignup).toBe(false);
+		} finally {
+			if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+			else process.env.NODE_ENV = previousNodeEnv;
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -303,5 +316,22 @@ describe('seedAuthSettings', () => {
 			where: eq(schema.appSettings.key, SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED)
 		});
 		expect(row?.value).toBe('false');
+	});
+
+	test('seeds production-safe signup default when no env override is set', async () => {
+		const previousNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'production';
+
+		try {
+			await seedAuthSettings();
+
+			const row = await state.db!.query.appSettings.findFirst({
+				where: eq(schema.appSettings.key, SETTINGS_KEYS.AUTH_ALLOW_SIGNUP)
+			});
+			expect(row?.value).toBe('false');
+		} finally {
+			if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+			else process.env.NODE_ENV = previousNodeEnv;
+		}
 	});
 });

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -282,6 +282,8 @@ describe('getAuthSettings', () => {
 		process.env.NODE_ENV = 'production';
 
 		try {
+			unsetEnv('GYRE_AUTH_ALLOW_SIGNUP');
+			timeOffset += 200; // ensure cached values from prior reads are expired
 			const settings = await getAuthSettings();
 			expect(settings.allowSignup).toBe(false);
 		} finally {


### PR DESCRIPTION
## Summary
- enforce explicit cluster-wide RBAC checks for all-namespace Flux listing
- add explicit in-handler admin authorization checks for auth-provider admin handlers
- secure `/metrics` by default in production (bearer token or admin session) and add lightweight app health endpoints
- default `auth.allowSignup` to off in production when unset, including seed behavior
- add audit events for admin auth-provider mutations, settings updates, and K8s client-pool clear
- switch Docker/Helm health checks to `/api/v1/health`
- add RBAC/admin/audit/settings regression tests

Closes #426


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lightweight application health endpoints (/api/health and /api/v1/health).

* **Security Improvements**
  * Enforced in-handler RBAC for admin APIs and tightened /metrics access in production (requires bearer token or admin session).

* **Audit**
  * Added audit logging for admin mutations (create/update/delete/settings/cluster-pool clear).

* **Configuration**
  * Container/Kubernetes probes now target /api/v1/health.
  * Signup default is disabled in production.

* **Tests**
  * Added coverage for RBAC boundaries, metrics auth behavior, settings defaults, and audit events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->