### PR TITLE
fix helm defaults for runtime deployability

### DIFF
--- a/charts/gyre/templates/configmap.yaml
+++ b/charts/gyre/templates/configmap.yaml
@@ -14,6 +14,8 @@ data:
   GYRE_DASHBOARD_CACHE_TTL_MS: {{ .Values.config.dashboardCacheTtlMs | quote }}
   # Settling period after ADDED events before emitting notifications in milliseconds
   GYRE_SETTLING_PERIOD_MS: {{ .Values.config.settlingPeriodMs | quote }}
+  # Adapter-node max request body size (bytes, K/M/G suffix, or Infinity)
+  BODY_SIZE_LIMIT: {{ .Values.config.bodySizeLimit | quote }}
   {{- if .Values.config.additionalConfig }}
   {{- toYaml .Values.config.additionalConfig | nindent 2 }}
   {{- end }}

--- a/charts/gyre/templates/deployment.yaml
+++ b/charts/gyre/templates/deployment.yaml
@@ -8,6 +8,9 @@ spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     type: Recreate  # Required for PVC with ReadWriteOnce
+  {{- if and .Values.config.additionalConfig (hasKey .Values.config.additionalConfig "BODY_SIZE_LIMIT") }}
+  {{- fail "config.additionalConfig.BODY_SIZE_LIMIT is reserved; use config.bodySizeLimit to avoid duplicate ownership." }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "gyre.selectorLabels" . | nindent 6 }}
@@ -88,6 +91,11 @@ spec:
             configMapKeyRef:
               name: {{ include "gyre.fullname" . }}-config
               key: GYRE_SETTLING_PERIOD_MS
+        - name: BODY_SIZE_LIMIT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "gyre.fullname" . }}-config
+              key: BODY_SIZE_LIMIT
         {{- range $key, $value := .Values.config.additionalConfig }}
         - name: {{ $key }}
           valueFrom:

--- a/charts/gyre/values.schema.json
+++ b/charts/gyre/values.schema.json
@@ -318,6 +318,10 @@
           "type": "integer",
           "minimum": 1000
         },
+        "bodySizeLimit": {
+          "type": "string",
+          "pattern": "^(?:[0-9]+(?:[KMG])?|Infinity)$"
+        },
         "additionalConfig": { "type": "object" }
       }
     },

--- a/charts/gyre/values.yaml
+++ b/charts/gyre/values.yaml
@@ -18,8 +18,8 @@ origin: ''
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: false
+  # Automatically mount a ServiceAccount token for in-cluster Kubernetes authentication.
+  automount: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -284,6 +284,8 @@ config:
   dashboardCacheTtlMs: 30000
   # Settling period after ADDED events before emitting notifications in milliseconds (default: 30s)
   settlingPeriodMs: 30000
+  # Adapter-node hard ceiling for request body size; keep at least as large as the largest upload path.
+  bodySizeLimit: 500M
   # Additional configuration key-value pairs
   additionalConfig: {}
     # Example:

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -29,6 +29,11 @@ service:
   type: ClusterIP
   port: 80
 
+serviceAccount:
+  create: true
+  # Default keeps ServiceAccount token mounted for in-cluster auth.
+  automount: true
+
 ingress:
   enabled: false
 
@@ -63,10 +68,12 @@ config:
   heartbeatIntervalMs: 30000
   dashboardCacheTtlMs: 30000
   settlingPeriodMs: 30000
+  bodySizeLimit: 500M
   additionalConfig: {}
 ```
 
 `config.additionalConfig` is passed through as extra environment variables.
+`config.additionalConfig.BODY_SIZE_LIMIT` is reserved and rejected by the chart; use `config.bodySizeLimit`.
 
 ### Encryption and Secrets
 
@@ -131,6 +138,7 @@ Helm values map directly to runtime env vars:
 | `config.heartbeatIntervalMs` | `GYRE_HEARTBEAT_INTERVAL_MS`    |
 | `config.dashboardCacheTtlMs` | `GYRE_DASHBOARD_CACHE_TTL_MS`   |
 | `config.settlingPeriodMs`    | `GYRE_SETTLING_PERIOD_MS`       |
+| `config.bodySizeLimit`       | `BODY_SIZE_LIMIT`               |
 | `auth.localLoginEnabled`     | `GYRE_AUTH_LOCAL_LOGIN_ENABLED` |
 | `auth.allowSignup`           | `GYRE_AUTH_ALLOW_SIGNUP`        |
 | `auth.domainAllowlist`       | `GYRE_AUTH_DOMAIN_ALLOWLIST`    |

--- a/documentation/docs/installation/helm-reference.md
+++ b/documentation/docs/installation/helm-reference.md
@@ -26,12 +26,12 @@ This guide provides a detailed reference for all configuration options available
 
 ## Service Account
 
-| Parameter                    | Description                  | Default |
-| ---------------------------- | ---------------------------- | ------- |
-| `serviceAccount.create`      | Create service account       | `true`  |
-| `serviceAccount.automount`   | Automount SA token           | `false` |
-| `serviceAccount.annotations` | SA annotations               | `{}`    |
-| `serviceAccount.name`        | SA name (generated if empty) | `""`    |
+| Parameter                    | Description                                       | Default |
+| ---------------------------- | ------------------------------------------------- | ------- |
+| `serviceAccount.create`      | Create service account                            | `true`  |
+| `serviceAccount.automount`   | Automount SA token for in-cluster Kubernetes auth | `true`  |
+| `serviceAccount.annotations` | SA annotations                                    | `{}`    |
+| `serviceAccount.name`        | SA name (generated if empty)                      | `""`    |
 
 ## Service Configuration
 
@@ -150,14 +150,15 @@ This guide provides a detailed reference for all configuration options available
 
 ## Application Configuration
 
-| Parameter                    | Description                              | Default |
-| ---------------------------- | ---------------------------------------- | ------- |
-| `config.create`              | Create ConfigMap for app configuration   | `true`  |
-| `config.pollIntervalMs`      | Kubernetes API polling interval (ms)     | `5000`  |
-| `config.heartbeatIntervalMs` | SSE heartbeat interval (ms)              | `30000` |
-| `config.dashboardCacheTtlMs` | Dashboard cache TTL (ms)                 | `30000` |
-| `config.settlingPeriodMs`    | Settling period for ADDED events (ms)    | `30000` |
-| `config.additionalConfig`    | Additional configuration key-value pairs | `{}`    |
+| Parameter                    | Description                                                         | Default |
+| ---------------------------- | ------------------------------------------------------------------- | ------- |
+| `config.create`              | Create ConfigMap for app configuration                              | `true`  |
+| `config.pollIntervalMs`      | Kubernetes API polling interval (ms)                                | `5000`  |
+| `config.heartbeatIntervalMs` | SSE heartbeat interval (ms)                                         | `30000` |
+| `config.dashboardCacheTtlMs` | Dashboard cache TTL (ms)                                            | `30000` |
+| `config.settlingPeriodMs`    | Settling period for ADDED events (ms)                               | `30000` |
+| `config.bodySizeLimit`       | Adapter request-body ceiling (`N`, `NK`, `NM`, `NG`, or `Infinity`) | `500M`  |
+| `config.additionalConfig`    | Additional configuration key-value pairs                            | `{}`    |
 
 Helm config keys map to these runtime env vars:
 
@@ -167,7 +168,10 @@ Helm config keys map to these runtime env vars:
 | `config.heartbeatIntervalMs` | `GYRE_HEARTBEAT_INTERVAL_MS`    |
 | `config.dashboardCacheTtlMs` | `GYRE_DASHBOARD_CACHE_TTL_MS`   |
 | `config.settlingPeriodMs`    | `GYRE_SETTLING_PERIOD_MS`       |
+| `config.bodySizeLimit`       | `BODY_SIZE_LIMIT`               |
 | `config.additionalConfig`    | Pass-through key/value env vars |
+
+`config.additionalConfig.BODY_SIZE_LIMIT` is reserved and rejected at render time. Use `config.bodySizeLimit` instead.
 
 ## Encryption Configuration
 

--- a/src/lib/server/kubernetes/config.ts
+++ b/src/lib/server/kubernetes/config.ts
@@ -3,21 +3,37 @@ import * as k8s from '@kubernetes/client-node';
 import { ConfigurationError } from './errors.js';
 
 /**
- * Configuration options kept for internal compatibility.
+ * @deprecated Compatibility shim only. Gyre does not support transport-layer
+ * overrides through this interface.
  *
- * Gyre currently supports only kubeconfig-provided / in-cluster connectivity
- * settings and rejects transport-layer overrides.
+ * Any non-empty override (or `insecureSkipVerify: true`) will throw
+ * `ConfigurationError`.
  */
 export interface KubeConfigOptions {
-	/** Custom CA certificate data (PEM format). Overrides the CA from kubeconfig. */
+	/**
+	 * @deprecated Compatibility shim only. Any non-empty value will throw
+	 * `ConfigurationError`.
+	 */
 	caData?: string;
-	/** Skip TLS certificate verification (insecure, use for testing/dev only). */
+	/**
+	 * @deprecated Compatibility shim only. Setting this to `true` will throw
+	 * `ConfigurationError`.
+	 */
 	insecureSkipVerify?: boolean;
-	/** HTTP proxy URL (e.g., http://proxy.example.com:8080). */
+	/**
+	 * @deprecated Compatibility shim only. Any non-empty value will throw
+	 * `ConfigurationError`.
+	 */
 	httpProxy?: string;
-	/** HTTPS proxy URL. Falls back to httpProxy if not specified. */
+	/**
+	 * @deprecated Compatibility shim only. Any non-empty value will throw
+	 * `ConfigurationError`.
+	 */
 	httpsProxy?: string;
-	/** Comma-separated list of hosts to exclude from proxy (e.g., localhost,.example.com). */
+	/**
+	 * @deprecated Compatibility shim only. Any non-empty value will throw
+	 * `ConfigurationError`.
+	 */
 	noProxy?: string;
 }
 
@@ -61,7 +77,11 @@ export function assertSupportedKubeConfigOptions(options?: KubeConfigOptions): v
  * 2. Local development: Falls back to KUBECONFIG env var or ~/.kube/config
  *
  * This allows the same code to work in both production and local development.
- * @param options - Optional TLS and proxy configuration
+ * Transport-layer overrides are not supported: any non-empty override (or
+ * `insecureSkipVerify: true`) is rejected with `ConfigurationError`.
+ *
+ * @param options - Compatibility shim for legacy callers; populated transport
+ * overrides will throw.
  */
 export function loadKubeConfig(options?: KubeConfigOptions): k8s.KubeConfig {
 	const config = new k8s.KubeConfig();

--- a/src/lib/server/kubernetes/config.ts
+++ b/src/lib/server/kubernetes/config.ts
@@ -3,8 +3,10 @@ import * as k8s from '@kubernetes/client-node';
 import { ConfigurationError } from './errors.js';
 
 /**
- * Configuration options for KubeConfig TLS and proxy settings.
- * Allows customization of certificate validation and HTTP proxies.
+ * Configuration options kept for internal compatibility.
+ *
+ * Gyre currently supports only kubeconfig-provided / in-cluster connectivity
+ * settings and rejects transport-layer overrides.
  */
 export interface KubeConfigOptions {
 	/** Custom CA certificate data (PEM format). Overrides the CA from kubeconfig. */
@@ -20,6 +22,40 @@ export interface KubeConfigOptions {
 }
 
 /**
+ * Reject unsupported kube transport overrides with a deterministic configuration error.
+ */
+export function assertSupportedKubeConfigOptions(options?: KubeConfigOptions): void {
+	if (!options) {
+		return;
+	}
+
+	const rejected: Array<keyof KubeConfigOptions> = [];
+	if (typeof options.caData === 'string' && options.caData.trim() !== '') {
+		rejected.push('caData');
+	}
+	if (options.insecureSkipVerify === true) {
+		rejected.push('insecureSkipVerify');
+	}
+	if (typeof options.httpProxy === 'string' && options.httpProxy.trim() !== '') {
+		rejected.push('httpProxy');
+	}
+	if (typeof options.httpsProxy === 'string' && options.httpsProxy.trim() !== '') {
+		rejected.push('httpsProxy');
+	}
+	if (typeof options.noProxy === 'string' && options.noProxy.trim() !== '') {
+		rejected.push('noProxy');
+	}
+
+	if (rejected.length > 0) {
+		throw new ConfigurationError(
+			`Unsupported kube connectivity override option(s): ${rejected.join(
+				', '
+			)}. Gyre currently supports only kubeconfig-provided / in-cluster connectivity settings.`
+		);
+	}
+}
+
+/**
  * Loads kubeconfig with automatic mode detection (like kubectl):
  * 1. In-cluster (production): Uses ServiceAccount if KUBERNETES_SERVICE_HOST is set
  * 2. Local development: Falls back to KUBECONFIG env var or ~/.kube/config
@@ -29,13 +65,13 @@ export interface KubeConfigOptions {
  */
 export function loadKubeConfig(options?: KubeConfigOptions): k8s.KubeConfig {
 	const config = new k8s.KubeConfig();
+	assertSupportedKubeConfigOptions(options);
 
 	try {
 		// Try in-cluster first (production mode)
 		if (process.env.KUBERNETES_SERVICE_HOST) {
 			config.loadFromCluster();
 			logger.info('✓ Using in-cluster configuration (ServiceAccount)');
-			applyConfigurationOptions(config, options);
 			return config;
 		}
 	} catch (error) {
@@ -47,7 +83,6 @@ export function loadKubeConfig(options?: KubeConfigOptions): k8s.KubeConfig {
 		// Tries: $KUBECONFIG, then ~/.kube/config
 		config.loadFromDefault();
 		logger.info('✓ Using local kubeconfig for development');
-		applyConfigurationOptions(config, options);
 		return config;
 	} catch (error) {
 		throw new ConfigurationError(
@@ -55,42 +90,6 @@ export function loadKubeConfig(options?: KubeConfigOptions): k8s.KubeConfig {
 				'For production: Ensure running in a pod with ServiceAccount. ' +
 				'For development: Set KUBECONFIG or create ~/.kube/config. ' +
 				`Error: ${error instanceof Error ? error.message : String(error)}`
-		);
-	}
-}
-
-/**
- * Apply TLS and proxy configuration options to a loaded KubeConfig.
- *
- * @experimental This function currently only logs configuration options.
- * Full implementation of custom CA certificates and proxy support requires
- * extending the HTTP agent creation and client-node configuration, which
- * is planned for a future enhancement.
- *
- * @param config - The KubeConfig to modify
- * @param options - Configuration options (currently unimplemented except for logging)
- */
-function applyConfigurationOptions(config: k8s.KubeConfig, options?: KubeConfigOptions): void {
-	if (!options) return;
-
-	// TODO(k8s-tls-proxy): Implement custom CA and proxy support
-	// - Pass caData to HTTP agent configuration
-	// - Create proxy agents based on HTTP_PROXY/HTTPS_PROXY
-	// - Wire into Kubernetes client factory
-
-	if (options.caData) {
-		logger.debug(
-			'Custom CA certificate option provided (unimplemented; see TODO in applyConfigurationOptions)'
-		);
-	}
-
-	if (options.insecureSkipVerify) {
-		logger.warn('⚠ TLS verification disabled for cluster (insecure, use for testing only)');
-	}
-
-	if (options.httpProxy || options.httpsProxy) {
-		logger.debug(
-			'Proxy configuration provided (unimplemented; see TODO in applyConfigurationOptions)'
 		);
 	}
 }

--- a/src/tests/helm-chart-regressions.test.ts
+++ b/src/tests/helm-chart-regressions.test.ts
@@ -52,6 +52,19 @@ describe('helm chart regressions', () => {
 		expect(source).toContain('PROVIDER_{{ $providerKey }}_CLIENT_SECRET');
 	});
 
+	test('values and templates include deployability defaults for service account and body size limit', () => {
+		const values = readRepoFile('../charts/gyre/values.yaml');
+		const configMap = readRepoFile('../charts/gyre/templates/configmap.yaml');
+		const deployment = readRepoFile('../charts/gyre/templates/deployment.yaml');
+
+		expect(values).toContain('automount: true');
+		expect(values).toContain('bodySizeLimit: 500M');
+		expect(configMap).toContain('BODY_SIZE_LIMIT: {{ .Values.config.bodySizeLimit | quote }}');
+		expect(deployment).toContain('- name: BODY_SIZE_LIMIT');
+		expect(deployment).toContain('key: BODY_SIZE_LIMIT');
+		expect(deployment).toContain('config.additionalConfig.BODY_SIZE_LIMIT is reserved');
+	});
+
 	test('values schema includes origin, gatewayApi.tls, and networkPolicy.egress.apiServer', () => {
 		const schema = JSON.parse(readRepoFile('../charts/gyre/values.schema.json'));
 
@@ -68,5 +81,9 @@ describe('helm chart regressions', () => {
 			schema.properties.networkPolicy.properties.egress.properties.apiServer.properties.ports.items
 				.type
 		).toBe('integer');
+		expect(schema.properties.config.properties.bodySizeLimit.type).toBe('string');
+		expect(schema.properties.config.properties.bodySizeLimit.pattern).toBe(
+			'^(?:[0-9]+(?:[KMG])?|Infinity)$'
+		);
 	});
 });

--- a/src/tests/k8s-client-reliability.test.ts
+++ b/src/tests/k8s-client-reliability.test.ts
@@ -244,6 +244,7 @@ describe('Kubeconfig Configuration Options', () => {
 			throw new Error('Expected ConfigurationError');
 		} catch (error) {
 			expect(error).toBeInstanceOf(ConfigurationError);
+			expect((error as Error).message).toContain('httpProxy');
 		}
 	});
 

--- a/src/tests/k8s-client-reliability.test.ts
+++ b/src/tests/k8s-client-reliability.test.ts
@@ -11,7 +11,10 @@ import {
 	gracefulShutdown,
 	auditLogSecretAccess
 } from '../lib/server/kubernetes/client.js';
-import { assertSupportedKubeConfigOptions } from '../lib/server/kubernetes/config.js';
+import {
+	assertSupportedKubeConfigOptions,
+	loadKubeConfig
+} from '../lib/server/kubernetes/config.js';
 import { ConfigurationError } from '../lib/server/kubernetes/errors.js';
 
 // ---------------------------------------------------------------------------
@@ -231,6 +234,17 @@ describe('Kubeconfig Configuration Options', () => {
 				noProxy: 'localhost,.example.com'
 			})
 		).toThrow(ConfigurationError);
+	});
+
+	test('runtime loadKubeConfig rejects transport overrides', async () => {
+		try {
+			await loadKubeConfig({
+				httpProxy: 'http://proxy:8080'
+			});
+			throw new Error('Expected ConfigurationError');
+		} catch (error) {
+			expect(error).toBeInstanceOf(ConfigurationError);
+		}
 	});
 
 	test('rejects multiple overrides and lists all rejected keys', () => {

--- a/src/tests/k8s-client-reliability.test.ts
+++ b/src/tests/k8s-client-reliability.test.ts
@@ -11,6 +11,8 @@ import {
 	gracefulShutdown,
 	auditLogSecretAccess
 } from '../lib/server/kubernetes/client.js';
+import { assertSupportedKubeConfigOptions } from '../lib/server/kubernetes/config.js';
+import { ConfigurationError } from '../lib/server/kubernetes/errors.js';
 
 // ---------------------------------------------------------------------------
 // HTTP Keep-Alive Configuration
@@ -172,19 +174,83 @@ describe('Secret Audit Logging', () => {
 // ---------------------------------------------------------------------------
 
 describe('Kubeconfig Configuration Options', () => {
-	test('KubeConfigOptions interface is properly defined', () => {
-		// This is a type-level test — it validates that the interface exists
-		// in actual code. At runtime, we just verify the concept works.
-		const options = {
-			caData: '-----BEGIN CERTIFICATE-----',
-			insecureSkipVerify: false,
-			httpProxy: 'http://proxy:8080',
-			httpsProxy: 'https://proxy:8443',
-			noProxy: 'localhost,.example.com'
-		};
+	test('allows undefined options', () => {
+		expect(() => assertSupportedKubeConfigOptions()).not.toThrow();
+	});
 
-		expect(options.caData).toBeDefined();
-		expect(options.insecureSkipVerify).toBe(false);
-		expect(options.httpProxy).toBeDefined();
+	test('allows empty options object', () => {
+		expect(() => assertSupportedKubeConfigOptions({})).not.toThrow();
+	});
+
+	test('allows insecureSkipVerify=false', () => {
+		expect(() =>
+			assertSupportedKubeConfigOptions({
+				insecureSkipVerify: false
+			})
+		).not.toThrow();
+	});
+
+	test('allows empty-string transport overrides', () => {
+		expect(() =>
+			assertSupportedKubeConfigOptions({
+				caData: '',
+				httpProxy: '',
+				httpsProxy: '',
+				noProxy: ''
+			})
+		).not.toThrow();
+	});
+
+	test('rejects caData override', () => {
+		expect(() =>
+			assertSupportedKubeConfigOptions({
+				caData: '-----BEGIN CERTIFICATE-----'
+			})
+		).toThrow(ConfigurationError);
+	});
+
+	test('rejects httpProxy override', () => {
+		expect(() =>
+			assertSupportedKubeConfigOptions({
+				httpProxy: 'http://proxy:8080'
+			})
+		).toThrow(ConfigurationError);
+	});
+
+	test('rejects httpsProxy override', () => {
+		expect(() =>
+			assertSupportedKubeConfigOptions({
+				httpsProxy: 'https://proxy:8443'
+			})
+		).toThrow(ConfigurationError);
+	});
+
+	test('rejects noProxy override', () => {
+		expect(() =>
+			assertSupportedKubeConfigOptions({
+				noProxy: 'localhost,.example.com'
+			})
+		).toThrow(ConfigurationError);
+	});
+
+	test('rejects multiple overrides and lists all rejected keys', () => {
+		try {
+			assertSupportedKubeConfigOptions({
+				caData: '-----BEGIN CERTIFICATE-----',
+				insecureSkipVerify: true,
+				httpProxy: 'http://proxy:8080',
+				httpsProxy: 'https://proxy:8443',
+				noProxy: 'localhost,.example.com'
+			});
+			throw new Error('Expected ConfigurationError');
+		} catch (error) {
+			expect(error).toBeInstanceOf(ConfigurationError);
+			const message = (error as Error).message;
+			expect(message).toContain('caData');
+			expect(message).toContain('insecureSkipVerify');
+			expect(message).toContain('httpProxy');
+			expect(message).toContain('httpsProxy');
+			expect(message).toContain('noProxy');
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Align Helm defaults with in-cluster runtime deployability by enabling ServiceAccount token automounting by default.
- Add a dedicated `config.bodySizeLimit` Helm value and wire it through the ConfigMap and Deployment as `BODY_SIZE_LIMIT`.
- Reserve `config.additionalConfig.BODY_SIZE_LIMIT` to prevent duplicate ownership and render-time conflicts.
- Tighten kubeconfig handling by rejecting unsupported transport overrides with deterministic configuration errors.
- Update chart reference docs and configuration docs to reflect the new defaults and mapping.

## Testing
- Added Helm regression checks covering the new ServiceAccount and body size limit defaults.
- Added schema assertions for `config.bodySizeLimit` validation.
- Added runtime reliability tests for supported and rejected kubeconfig override combinations.
- Not run: full test suite or Helm render/install against a live cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added config.bodySizeLimit (default 500M) and exposed it as a BODY_SIZE_LIMIT runtime environment variable.
  * Service account token is now automounted by default for in-cluster authentication.

* **Chores**
  * Rendering/validation now rejects BODY_SIZE_LIMIT supplied via generic additional config — must use config.bodySizeLimit.
  * Values schema enforces allowed body-size formats.

* **Documentation**
  * Docs updated to reflect bodySizeLimit, env mapping, and automount behavior.

* **Tests**
  * Regression and reliability tests added to cover new behavior and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->