### PR TITLE
Harden secrets handling for Helm and runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,15 @@ BETTER_AUTH_URL=http://localhost:5173
 # Set this separately when rotating auth/session secrets independently from encrypted OAuth secrets.
 # BETTER_AUTH_SECRET=
 
-# Optional. When set, backups are AES-256-GCM encrypted before being written to disk.
-# If unset, backups are stored as plain .db files with a warning logged.
+# Required in production. Optional in local development.
+# When set, backups are AES-256-GCM encrypted before being written to disk.
+# In development, if unset, backups are stored as plain .db files with a warning logged.
 # Generate with: openssl rand -hex 32
 BACKUP_ENCRYPTION_KEY=
+
+# Required in production. Optional in local development.
+# Protects /metrics with bearer-token auth (admin session access also works in production).
+GYRE_METRICS_TOKEN=
 # Optional: Default admin password for FIRST-TIME setup.
 # Works in both local and Kubernetes environments for initial account creation.
 # In production, it's recommended to let Gyre generate a secure secret instead.

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,32 @@
+name: Secret Scan
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run Trivy filesystem secret scan (blocking)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: secret
+          format: table
+          exit-code: '1'
+          trivyignores: .trivyignore

--- a/charts/gyre/templates/deployment.yaml
+++ b/charts/gyre/templates/deployment.yaml
@@ -26,8 +26,14 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if and (not .Values.encryption.existingSecret) (not (and .Values.encryption.allowInline (and .Values.encryption.gyreKey .Values.encryption.authKey))) }}
-      {{- fail "Encryption keys are required. Set encryption.existingSecret (recommended) or set encryption.allowInline=true with non-empty gyreKey and authKey." }}
+      {{- if and (not .Values.encryption.existingSecret) (not (and .Values.encryption.allowInline (and .Values.encryption.gyreKey .Values.encryption.authKey .Values.encryption.backupKey))) }}
+      {{- fail "Encryption keys are required. Set encryption.existingSecret (recommended) or set encryption.allowInline=true with non-empty gyreKey, authKey, and backupKey." }}
+      {{- end }}
+      {{- if not .Values.metrics.existingSecret }}
+      {{- fail "metrics.existingSecret is required for Helm deployments and must contain GYRE_METRICS_TOKEN." }}
+      {{- end }}
+      {{- if and (gt (len .Values.auth.providers) 0) (not .Values.auth.providersExistingSecret) }}
+      {{- fail "auth.providersExistingSecret is required when auth.providers is non-empty." }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -121,20 +127,30 @@ spec:
         - name: BETTER_AUTH_URL
           value: {{ get $originState "value" | quote }}
         {{- $encSecretName := .Values.encryption.existingSecret | default (printf "%s-encryption" (include "gyre.fullname" .)) }}
-        {{- if or .Values.encryption.existingSecret (and .Values.encryption.allowInline .Values.encryption.gyreKey) }}
         - name: GYRE_ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:
               name: {{ $encSecretName }}
               key: GYRE_ENCRYPTION_KEY
-        {{- end }}
-        {{- if or .Values.encryption.existingSecret (and .Values.encryption.allowInline .Values.encryption.authKey) }}
+              optional: false
         - name: AUTH_ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:
               name: {{ $encSecretName }}
               key: AUTH_ENCRYPTION_KEY
-        {{- end }}
+              optional: false
+        - name: BACKUP_ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $encSecretName }}
+              key: BACKUP_ENCRYPTION_KEY
+              optional: false
+        - name: GYRE_METRICS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.metrics.existingSecret }}
+              key: GYRE_METRICS_TOKEN
+              optional: false
         # Authentication settings
         {{- if .Values.auth }}
         - name: GYRE_AUTH_LOCAL_LOGIN_ENABLED
@@ -146,8 +162,15 @@ spec:
           value: {{ .Values.auth.domainAllowlist | toJson | quote }}
         {{- end }}
         {{- if .Values.auth.providers }}
+        {{- $providersWithoutSecrets := list }}
+        {{- range $provider := .Values.auth.providers }}
+        {{- if hasKey $provider "clientSecret" }}
+        {{- fail (printf "auth.providers[%q] contains forbidden field clientSecret. Provide secrets via auth.providersExistingSecret using key PROVIDER_%s_CLIENT_SECRET." $provider.name (regexReplaceAll "[^A-Z0-9]" ($provider.name | upper) "_")) }}
+        {{- end }}
+        {{- $providersWithoutSecrets = append $providersWithoutSecrets (omit $provider "clientSecret") }}
+        {{- end }}
         - name: GYRE_AUTH_PROVIDERS
-          value: {{ .Values.auth.providers | toJson | quote }}
+          value: {{ $providersWithoutSecrets | toJson | quote }}
         {{- end }}
         # Provider client secrets from existing secret
         {{- if .Values.auth.providersExistingSecret }}
@@ -163,7 +186,7 @@ spec:
             secretKeyRef:
               name: {{ $.Values.auth.providersExistingSecret }}
               key: PROVIDER_{{ $providerKey }}_CLIENT_SECRET
-              optional: true
+              optional: false
         {{- end }}
         {{- end }}
         {{- end }}

--- a/charts/gyre/templates/secret-encryption.yaml
+++ b/charts/gyre/templates/secret-encryption.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.encryption.existingSecret) .Values.encryption.allowInline (or .Values.encryption.gyreKey .Values.encryption.authKey) -}}
+{{- if and (not .Values.encryption.existingSecret) .Values.encryption.allowInline (and .Values.encryption.gyreKey .Values.encryption.authKey .Values.encryption.backupKey) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,5 +17,8 @@ data:
   {{- end }}
   {{- if .Values.encryption.authKey }}
   AUTH_ENCRYPTION_KEY: {{ .Values.encryption.authKey | b64enc }}
+  {{- end }}
+  {{- if .Values.encryption.backupKey }}
+  BACKUP_ENCRYPTION_KEY: {{ .Values.encryption.backupKey | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/gyre/values.schema.json
+++ b/charts/gyre/values.schema.json
@@ -197,6 +197,7 @@
       "properties": {
         "gyreKey": { "type": "string" },
         "authKey": { "type": "string" },
+        "backupKey": { "type": "string" },
         "existingSecret": { "type": "string" },
         "allowInline": { "type": "boolean" }
       },
@@ -207,9 +208,10 @@
       "then": {
         "properties": {
           "gyreKey": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" },
-          "authKey": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" }
+          "authKey": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" },
+          "backupKey": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" }
         },
-        "required": ["gyreKey", "authKey"]
+        "required": ["gyreKey", "authKey", "backupKey"]
       }
     },
     "auth": {
@@ -224,9 +226,74 @@
         },
         "providers": {
           "type": "array",
-          "items": { "type": "object" }
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "oidc",
+                  "oauth2-github",
+                  "oauth2-google",
+                  "oauth2-gitlab",
+                  "oauth2-generic"
+                ]
+              },
+              "enabled": { "type": "boolean" },
+              "clientId": { "type": "string", "minLength": 1 },
+              "issuerUrl": {
+                "anyOf": [{ "const": "" }, { "type": "string", "format": "uri" }]
+              },
+              "authorizationUrl": {
+                "anyOf": [{ "const": "" }, { "type": "string", "format": "uri" }]
+              },
+              "tokenUrl": {
+                "anyOf": [{ "const": "" }, { "type": "string", "format": "uri" }]
+              },
+              "userInfoUrl": {
+                "anyOf": [{ "const": "" }, { "type": "string", "format": "uri" }]
+              },
+              "jwksUrl": {
+                "anyOf": [{ "const": "" }, { "type": "string", "format": "uri" }]
+              },
+              "autoProvision": { "type": "boolean" },
+              "defaultRole": { "type": "string", "enum": ["admin", "editor", "viewer"] },
+              "roleMapping": {
+                "oneOf": [
+                  { "type": "string" },
+                  {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  }
+                ]
+              },
+              "roleClaim": { "type": "string" },
+              "usernameClaim": { "type": "string" },
+              "emailClaim": { "type": "string" },
+              "usePkce": { "type": "boolean" },
+              "scopes": { "type": "string" }
+            },
+            "required": ["name", "type", "clientId"]
+          }
         },
         "providersExistingSecret": { "type": "string" }
+      },
+      "if": {
+        "properties": {
+          "providers": { "type": "array", "minItems": 1 }
+        },
+        "required": ["providers"]
+      },
+      "then": {
+        "properties": {
+          "providersExistingSecret": { "type": "string", "minLength": 1 }
+        },
+        "required": ["providersExistingSecret"]
       }
     },
     "metrics": {
@@ -234,6 +301,7 @@
       "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
+        "existingSecret": { "type": "string", "minLength": 1 },
         "serviceMonitor": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/gyre/values.yaml
+++ b/charts/gyre/values.yaml
@@ -161,10 +161,13 @@ encryption:
   # Key for encrypting OAuth client secrets
   # DEPRECATED: Use existingSecret instead. If set, a Secret will be auto-created from this value.
   authKey: ""
+  # Key for encrypting database backups at rest
+  # DEPRECATED: Use existingSecret instead. If set, a Secret will be auto-created from this value.
+  backupKey: ""
   # Existing secret name containing encryption keys (recommended for production)
-  # Keys in secret should be named GYRE_ENCRYPTION_KEY and AUTH_ENCRYPTION_KEY
+  # Keys in secret should be named GYRE_ENCRYPTION_KEY, AUTH_ENCRYPTION_KEY, and BACKUP_ENCRYPTION_KEY
   existingSecret: ""
-  # Explicitly opt in to auto-creating a Secret from inline gyreKey/authKey values.
+  # Explicitly opt in to auto-creating a Secret from inline gyreKey/authKey/backupKey values.
   # Disabled by default. Set to true only for development/testing — inline values
   # are visible in `helm get values` and Helm release history.
   allowInline: false
@@ -178,28 +181,26 @@ auth:
   # Restrict OAuth signup to specific email domains (empty = allow all)
   domainAllowlist: []
   # OAuth/OIDC providers to seed on startup
-  # These are created if they don't exist, but won't overwrite admin UI changes
+  # These are created if they don't exist, but won't overwrite admin UI changes.
+  # Provider entries include metadata only (no secrets).
   providers: []
   # Example providers:
   # providers:
   #   - name: "GitHub"
   #     type: "oauth2-github"
   #     clientId: "your-client-id"
-  #     clientSecret: "your-client-secret"  # Will be encrypted at rest
   #     enabled: true
   #     autoProvision: true
   #     defaultRole: "viewer"
   #   - name: "Google"
   #     type: "oauth2-google"
   #     clientId: "your-client-id"
-  #     clientSecret: "your-client-secret"
   #     enabled: true
   #     autoProvision: true
   #     defaultRole: "viewer"
   #   - name: "Corporate SSO"
   #     type: "oidc"
   #     clientId: "your-client-id"
-  #     clientSecret: "your-client-secret"
   #     issuerUrl: "https://idp.company.com"
   #     enabled: true
   #     autoProvision: true
@@ -207,14 +208,15 @@ auth:
   #     scopes: "openid profile email groups"
   #     roleClaim: "groups"
   #     roleMapping: '{"admin":["DevOps"],"editor":["Developers"]}'
-  # Provider secrets from existing Kubernetes Secret (recommended for production)
-  # If set, clientSecret values in providers[] are ignored
-  # Secret should have keys like: PROVIDER_GITHUB_CLIENT_SECRET or
-  # PROVIDER_CORPORATE_SSO_CLIENT_SECRET.
+  # Provider secrets from existing Kubernetes Secret (required when providers[] is non-empty)
+  # Secret key format: PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET
+  # Examples: PROVIDER_GITHUB_CLIENT_SECRET, PROVIDER_CORPORATE_SSO_CLIENT_SECRET
   providersExistingSecret: ""
 # Metrics and Monitoring
 metrics:
   enabled: true
+  # Existing secret containing GYRE_METRICS_TOKEN (required for chart-managed deployments)
+  existingSecret: ""
   serviceMonitor:
     enabled: false
     interval: 30s

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -55,8 +55,10 @@ auth:
 ```
 
 `auth.providers` entries support OAuth/OIDC providers (for example GitHub, Google, generic OIDC).
+Provider objects are metadata-only and must not include `clientSecret`.
 
-If `auth.providersExistingSecret` is set, provider client secrets are read from secret keys named:
+When `auth.providers` is non-empty, `auth.providersExistingSecret` is required.
+Provider client secrets are read from secret keys named:
 
 - `PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET`
 
@@ -86,47 +88,48 @@ The referenced secret must provide:
 
 - `GYRE_ENCRYPTION_KEY`
 - `AUTH_ENCRYPTION_KEY`
+- `BACKUP_ENCRYPTION_KEY`
 
 ## Environment Variables
 
 ### Core Runtime Variables
 
-| Variable                | Description                                   | Default / Notes                                             |
-| ----------------------- | --------------------------------------------- | ----------------------------------------------------------- |
-| `DATABASE_URL`          | SQLite database path                          | `/data/gyre.db` in-cluster, `./data/gyre.db` local fallback |
-| `GYRE_ENCRYPTION_KEY`   | Encryption key for stored kubeconfigs         | 64-char hex (32 bytes), required in production              |
-| `AUTH_ENCRYPTION_KEY`   | Encryption key for auth/OAuth secrets         | 64-char hex (32 bytes), required in production              |
-| `BETTER_AUTH_URL`       | Public app origin used for auth callback URLs | `http://localhost:5173` in `.env.example`                   |
-| `BETTER_AUTH_SECRET`    | Optional explicit Better Auth secret          | Falls back to `AUTH_ENCRYPTION_KEY` when unset              |
-| `ADMIN_PASSWORD`        | Optional initial admin password               | If unset, Gyre auto-generates on first startup              |
-| `BACKUP_ENCRYPTION_KEY` | Optional backup-file encryption key           | 64-char hex; when unset backups are plain `.db`             |
-| `NODE_ENV`              | Runtime mode                                  | `development` / `production`                                |
-| `BODY_SIZE_LIMIT`       | Adapter-level max request body size           | Set to `>= 500M` for kubeconfig/backup uploads              |
+| Variable                | Description                                   | Default / Notes                                              |
+| ----------------------- | --------------------------------------------- | ------------------------------------------------------------ |
+| `DATABASE_URL`          | SQLite database path                          | `/data/gyre.db` in-cluster, `./data/gyre.db` local fallback  |
+| `GYRE_ENCRYPTION_KEY`   | Encryption key for stored kubeconfigs         | 64-char hex (32 bytes), required in production               |
+| `AUTH_ENCRYPTION_KEY`   | Encryption key for auth/OAuth secrets         | 64-char hex (32 bytes), required in production               |
+| `BETTER_AUTH_URL`       | Public app origin used for auth callback URLs | `http://localhost:5173` in `.env.example`                    |
+| `BETTER_AUTH_SECRET`    | Optional explicit Better Auth secret          | Falls back to `AUTH_ENCRYPTION_KEY` when unset               |
+| `ADMIN_PASSWORD`        | Optional initial admin password               | If unset, Gyre auto-generates on first startup               |
+| `BACKUP_ENCRYPTION_KEY` | Backup-file encryption key                    | 64-char hex; required in production, optional in development |
+| `NODE_ENV`              | Runtime mode                                  | `development` / `production`                                 |
+| `BODY_SIZE_LIMIT`       | Adapter-level max request body size           | Set to `>= 500M` for kubeconfig/backup uploads               |
 
 ### Tunable Constants
 
-| Variable                               | Description                                    | Default                         |
-| -------------------------------------- | ---------------------------------------------- | ------------------------------- |
-| `GYRE_POLL_INTERVAL_MS`                | Kubernetes polling interval                    | `5000`                          |
-| `GYRE_HEARTBEAT_INTERVAL_MS`           | SSE heartbeat interval                         | `30000`                         |
-| `GYRE_DASHBOARD_CACHE_TTL_MS`          | Dashboard cache TTL                            | `30000`                         |
-| `GYRE_SETTLING_PERIOD_MS`              | Settling period for ADDED events               | `30000`                         |
-| `GYRE_SETTINGS_CACHE_TTL_MS`           | Settings cache TTL                             | `30000`                         |
-| `GYRE_MAX_LOCAL_BACKUPS`               | Max local backups retained                     | `10`                            |
-| `GYRE_METRICS_TOKEN`                   | Optional bearer token for `/metrics`           | Unset (public metrics endpoint) |
-| `GYRE_SSE_MAX_CONNECTIONS_PER_SESSION` | Max SSE connections per session                | `3`                             |
-| `GYRE_SSE_MAX_CONNECTIONS_PER_USER`    | Max SSE connections per user                   | `5`                             |
-| `GYRE_SSE_CONNECTION_TIMEOUT_MS`       | SSE connection lifetime (`0` disables timeout) | `0`                             |
+| Variable                               | Description                                    | Default                                         |
+| -------------------------------------- | ---------------------------------------------- | ----------------------------------------------- |
+| `GYRE_POLL_INTERVAL_MS`                | Kubernetes polling interval                    | `5000`                                          |
+| `GYRE_HEARTBEAT_INTERVAL_MS`           | SSE heartbeat interval                         | `30000`                                         |
+| `GYRE_DASHBOARD_CACHE_TTL_MS`          | Dashboard cache TTL                            | `30000`                                         |
+| `GYRE_SETTLING_PERIOD_MS`              | Settling period for ADDED events               | `30000`                                         |
+| `GYRE_SETTINGS_CACHE_TTL_MS`           | Settings cache TTL                             | `30000`                                         |
+| `GYRE_MAX_LOCAL_BACKUPS`               | Max local backups retained                     | `10`                                            |
+| `GYRE_METRICS_TOKEN`                   | Bearer token for `/metrics`                    | Required in production; optional in development |
+| `GYRE_SSE_MAX_CONNECTIONS_PER_SESSION` | Max SSE connections per session                | `3`                                             |
+| `GYRE_SSE_MAX_CONNECTIONS_PER_USER`    | Max SSE connections per user                   | `5`                                             |
+| `GYRE_SSE_CONNECTION_TIMEOUT_MS`       | SSE connection lifetime (`0` disables timeout) | `0`                                             |
 
 ### Auth Settings Overrides
 
-| Variable                                                     | Description                                  |
-| ------------------------------------------------------------ | -------------------------------------------- |
-| `GYRE_AUTH_LOCAL_LOGIN_ENABLED`                              | Enable/disable local username/password login |
-| `GYRE_AUTH_ALLOW_SIGNUP`                                     | Allow OAuth auto-signup                      |
-| `GYRE_AUTH_DOMAIN_ALLOWLIST`                                 | JSON array of allowed signup domains         |
-| `GYRE_AUTH_PROVIDERS`                                        | JSON array used to seed auth providers       |
-| `GYRE_AUTH_PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET` | Per-provider secret override                 |
+| Variable                                                     | Description                                                      |
+| ------------------------------------------------------------ | ---------------------------------------------------------------- |
+| `GYRE_AUTH_LOCAL_LOGIN_ENABLED`                              | Enable/disable local username/password login                     |
+| `GYRE_AUTH_ALLOW_SIGNUP`                                     | Allow OAuth auto-signup                                          |
+| `GYRE_AUTH_DOMAIN_ALLOWLIST`                                 | JSON array of allowed signup domains                             |
+| `GYRE_AUTH_PROVIDERS`                                        | JSON array used to seed auth providers (no `clientSecret` field) |
+| `GYRE_AUTH_PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET` | Per-provider secret input for seeded providers                   |
 
 ## Helm-to-Env Mapping
 

--- a/documentation/docs/installation/helm-reference.md
+++ b/documentation/docs/installation/helm-reference.md
@@ -118,13 +118,14 @@ This guide provides a detailed reference for all configuration options available
 
 ## Metrics & Monitoring
 
-| Parameter                                 | Description                          | Default    |
-| ----------------------------------------- | ------------------------------------ | ---------- |
-| `metrics.enabled`                         | Enable application metrics           | `true`     |
-| `metrics.serviceMonitor.enabled`          | Create a Prometheus ServiceMonitor   | `false`    |
-| `metrics.serviceMonitor.interval`         | Scraping interval                    | `30s`      |
-| `metrics.serviceMonitor.path`             | Metrics path                         | `/metrics` |
-| `metrics.serviceMonitor.additionalLabels` | Additional labels for ServiceMonitor | `{}`       |
+| Parameter                                 | Description                            | Default    |
+| ----------------------------------------- | -------------------------------------- | ---------- |
+| `metrics.enabled`                         | Enable application metrics             | `true`     |
+| `metrics.existingSecret`                  | Secret containing `GYRE_METRICS_TOKEN` | `""`       |
+| `metrics.serviceMonitor.enabled`          | Create a Prometheus ServiceMonitor     | `false`    |
+| `metrics.serviceMonitor.interval`         | Scraping interval                      | `30s`      |
+| `metrics.serviceMonitor.path`             | Metrics path                           | `/metrics` |
+| `metrics.serviceMonitor.additionalLabels` | Additional labels for ServiceMonitor   | `{}`       |
 
 ## Network Policy
 
@@ -179,11 +180,20 @@ Helm config keys map to these runtime env vars:
 | --------------------------- | --------------------------------------- | ------- |
 | `encryption.gyreKey`        | Key for encrypting cluster kubeconfigs  | `""`    |
 | `encryption.authKey`        | Key for encrypting OAuth client secrets | `""`    |
+| `encryption.backupKey`      | Key for encrypting backup files         | `""`    |
 | `encryption.existingSecret` | Existing secret with encryption keys    | `""`    |
+
+`encryption.existingSecret` must include all of:
+
+- `GYRE_ENCRYPTION_KEY`
+- `AUTH_ENCRYPTION_KEY`
+- `BACKUP_ENCRYPTION_KEY`
 
 ## Auth Provider Secret Convention
 
-When `auth.providersExistingSecret` is set, each provider secret must use the provider-name convention shared by Helm and the runtime:
+`auth.providers` entries are metadata-only and must not include `clientSecret`.
+When `auth.providers` is non-empty, `auth.providersExistingSecret` is required.
+Each provider secret must use the provider-name convention shared by Helm and the runtime:
 
 - Secret key format: `PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET`
 - Env var format: `GYRE_AUTH_PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET`

--- a/documentation/docs/installation/index.md
+++ b/documentation/docs/installation/index.md
@@ -154,13 +154,15 @@ Enable SSO/OAuth:
 
 ```yaml
 auth:
-  enabled: true
   providers:
-    - name: github
-      type: github
+    - name: GitHub
+      type: oauth2-github
       clientId: 'your-client-id'
-      clientSecret: 'your-client-secret'
+  providersExistingSecret: gyre-auth-provider-secrets
 ```
+
+Provider objects are metadata-only. Store provider secrets in the referenced secret
+using keys like `PROVIDER_GITHUB_CLIENT_SECRET`.
 
 ### Resources
 

--- a/src/lib/server/auth/seed-providers.ts
+++ b/src/lib/server/auth/seed-providers.ts
@@ -18,33 +18,34 @@ const SUPPORTED_PROVIDER_TYPES = [
 	'oauth2-generic'
 ] as const;
 
-const ProviderSeedConfigSchema = z.object({
-	name: z.string().min(1),
-	type: z.enum(SUPPORTED_PROVIDER_TYPES),
-	enabled: z.boolean().optional(),
-	clientId: z.string().min(1),
-	clientSecret: z.string(),
-	issuerUrl: z.string().url().optional().or(z.literal('')).optional(),
-	authorizationUrl: z.string().url().optional().or(z.literal('')).optional(),
-	tokenUrl: z.string().url().optional().or(z.literal('')).optional(),
-	userInfoUrl: z.string().url().optional().or(z.literal('')).optional(),
-	jwksUrl: z.string().url().optional().or(z.literal('')).optional(),
-	autoProvision: z.boolean().optional(),
-	defaultRole: z.enum(['admin', 'editor', 'viewer']).optional(),
-	roleMapping: z.union([z.string(), z.record(z.string(), z.array(z.string()))]).optional(),
-	roleClaim: z.string().optional(),
-	usernameClaim: z.string().optional(),
-	emailClaim: z.string().optional(),
-	usePkce: z.boolean().optional(),
-	scopes: z.string().optional()
-});
+const ProviderSeedConfigSchema = z
+	.object({
+		name: z.string().min(1),
+		type: z.enum(SUPPORTED_PROVIDER_TYPES),
+		enabled: z.boolean().optional(),
+		clientId: z.string().min(1),
+		issuerUrl: z.string().url().optional().or(z.literal('')).optional(),
+		authorizationUrl: z.string().url().optional().or(z.literal('')).optional(),
+		tokenUrl: z.string().url().optional().or(z.literal('')).optional(),
+		userInfoUrl: z.string().url().optional().or(z.literal('')).optional(),
+		jwksUrl: z.string().url().optional().or(z.literal('')).optional(),
+		autoProvision: z.boolean().optional(),
+		defaultRole: z.enum(['admin', 'editor', 'viewer']).optional(),
+		roleMapping: z.union([z.string(), z.record(z.string(), z.array(z.string()))]).optional(),
+		roleClaim: z.string().optional(),
+		usernameClaim: z.string().optional(),
+		emailClaim: z.string().optional(),
+		usePkce: z.boolean().optional(),
+		scopes: z.string().optional()
+	})
+	.strict();
 
 type ProviderSeedConfig = z.infer<typeof ProviderSeedConfigSchema>;
 
 /**
  * Seed OAuth providers from environment variables.
  * Providers are read from GYRE_AUTH_PROVIDERS env var (JSON array).
- * Client secrets can be overridden from
+ * Client secrets are read only from
  * GYRE_AUTH_PROVIDER_{SANITIZED_PROVIDER_NAME}_CLIENT_SECRET env vars.
  *
  * @returns Object with created and skipped counts
@@ -56,7 +57,7 @@ export async function seedAuthProviders(): Promise<{ created: number; skipped: n
 		return { created: 0, skipped: 0 };
 	}
 
-	let providersConfig: ProviderSeedConfig[];
+	let providersConfig: unknown[];
 	try {
 		providersConfig = JSON.parse(providersJson);
 		if (!Array.isArray(providersConfig)) {
@@ -74,6 +75,22 @@ export async function seedAuthProviders(): Promise<{ created: number; skipped: n
 
 	for (let i = 0; i < providersConfig.length; i++) {
 		const config = providersConfig[i];
+		if (
+			typeof config === 'object' &&
+			config !== null &&
+			Object.prototype.hasOwnProperty.call(config, 'clientSecret')
+		) {
+			logger.warn(
+				{
+					issues: [
+						'clientSecret: inline clientSecret is not allowed; use GYRE_AUTH_PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET env var'
+					]
+				},
+				`Skipping provider at index ${i}: validation failed`
+			);
+			skipped++;
+			continue;
+		}
 
 		const parseResult = ProviderSeedConfigSchema.safeParse(config);
 		if (!parseResult.success) {
@@ -86,13 +103,15 @@ export async function seedAuthProviders(): Promise<{ created: number; skipped: n
 		}
 		const validatedConfig: ProviderSeedConfig = parseResult.data;
 
-		// Get client secret (from env var override or config)
+		// Get client secret from required per-provider env var.
 		const sanitizedName = validatedConfig.name.toUpperCase().replace(/[^A-Z0-9]/g, '_');
 		const envSecretKey = `GYRE_AUTH_PROVIDER_${sanitizedName}_CLIENT_SECRET`;
-		const clientSecret = process.env[envSecretKey] || validatedConfig.clientSecret;
+		const clientSecret = process.env[envSecretKey];
 
-		if (!clientSecret) {
-			logger.warn(`Skipping provider "${validatedConfig.name}": no client secret provided`);
+		if (!clientSecret || clientSecret.trim() === '') {
+			logger.error(
+				`Skipping provider "${validatedConfig.name}": missing required env var ${envSecretKey}`
+			);
 			skipped++;
 			continue;
 		}

--- a/src/lib/server/auth/seed-providers.ts
+++ b/src/lib/server/auth/seed-providers.ts
@@ -72,6 +72,7 @@ export async function seedAuthProviders(): Promise<{ created: number; skipped: n
 	// Pre-validate all providers and prepare DB records before touching the database
 	let skipped = 0;
 	const validProviders: NewAuthProvider[] = [];
+	const secretEnvKeyToProviderName = new Map<string, string>();
 
 	for (let i = 0; i < providersConfig.length; i++) {
 		const config = providersConfig[i];
@@ -106,6 +107,20 @@ export async function seedAuthProviders(): Promise<{ created: number; skipped: n
 		// Get client secret from required per-provider env var.
 		const sanitizedName = validatedConfig.name.toUpperCase().replace(/[^A-Z0-9]/g, '_');
 		const envSecretKey = `GYRE_AUTH_PROVIDER_${sanitizedName}_CLIENT_SECRET`;
+		const collidingProviderName = secretEnvKeyToProviderName.get(envSecretKey);
+		if (collidingProviderName) {
+			logger.warn(
+				{
+					providerName: validatedConfig.name,
+					collidingProviderName,
+					envSecretKey
+				},
+				`Skipping provider "${validatedConfig.name}": env secret key collision with provider "${collidingProviderName}"`
+			);
+			skipped++;
+			continue;
+		}
+		secretEnvKeyToProviderName.set(envSecretKey, validatedConfig.name);
 		const clientSecret = process.env[envSecretKey];
 
 		if (!clientSecret || clientSecret.trim() === '') {

--- a/src/lib/server/backup.ts
+++ b/src/lib/server/backup.ts
@@ -78,7 +78,7 @@ let hasWarnedUnencrypted = false;
  */
 function getBackupEncryptionKey(): Buffer | null {
 	if (cachedEncryptionKey !== undefined) return cachedEncryptionKey;
-	const keyHex = process.env.BACKUP_ENCRYPTION_KEY;
+	const keyHex = process.env.BACKUP_ENCRYPTION_KEY?.trim();
 	if (!keyHex) {
 		if (process.env.NODE_ENV === 'production') {
 			throw new BackupError(

--- a/src/lib/server/backup.ts
+++ b/src/lib/server/backup.ts
@@ -68,7 +68,8 @@ let hasWarnedUnencrypted = false;
 
 /**
  * Get the backup encryption key from BACKUP_ENCRYPTION_KEY env var.
- * Returns null if not set (encryption disabled).
+ * Returns null in non-production when not set (encryption disabled for local development).
+ * Throws in production when not set.
  * Throws if the key format is invalid.
  *
  * NOTE: Changing BACKUP_ENCRYPTION_KEY will render all existing encrypted
@@ -79,6 +80,11 @@ function getBackupEncryptionKey(): Buffer | null {
 	if (cachedEncryptionKey !== undefined) return cachedEncryptionKey;
 	const keyHex = process.env.BACKUP_ENCRYPTION_KEY;
 	if (!keyHex) {
+		if (process.env.NODE_ENV === 'production') {
+			throw new BackupError(
+				'BACKUP_ENCRYPTION_KEY must be set in production! Generate with: openssl rand -hex 32'
+			);
+		}
 		cachedEncryptionKey = null;
 		return cachedEncryptionKey;
 	}

--- a/src/lib/server/initialize.ts
+++ b/src/lib/server/initialize.ts
@@ -22,6 +22,7 @@ import { scheduleCleanup, stopCleanup } from './kubernetes/flux/reconciliation-c
 import { scheduleSessionCleanup, stopSessionCleanup } from './auth/session-cleanup.js';
 import { scheduleAuditLogCleanup, stopAuditLogCleanup } from './audit.js';
 import { closeAllEventStreams, setEventBusShuttingDown } from './events.js';
+import { validateProductionSecurityConfig } from './security-config.js';
 
 const IN_CLUSTER_NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
 
@@ -224,6 +225,15 @@ export async function initializeGyre(): Promise<void> {
 		logger.info('   ✓ Encryption validation passed');
 	} catch (error) {
 		logger.error(error, '   ✗ Encryption validation failed');
+		throw error;
+	}
+
+	logger.info('\n🛡️  Validating production security configuration...');
+	try {
+		validateProductionSecurityConfig();
+		logger.info('   ✓ Production security configuration validated');
+	} catch (error) {
+		logger.error(error, '   ✗ Production security configuration invalid');
 		throw error;
 	}
 

--- a/src/lib/server/initialize.ts
+++ b/src/lib/server/initialize.ts
@@ -228,13 +228,15 @@ export async function initializeGyre(): Promise<void> {
 		throw error;
 	}
 
-	logger.info('\n🛡️  Validating production security configuration...');
-	try {
-		validateProductionSecurityConfig();
-		logger.info('   ✓ Production security configuration validated');
-	} catch (error) {
-		logger.error(error, '   ✗ Production security configuration invalid');
-		throw error;
+	if (isProd) {
+		logger.info('\n🛡️  Validating production security configuration...');
+		try {
+			validateProductionSecurityConfig();
+			logger.info('   ✓ Production security configuration validated');
+		} catch (error) {
+			logger.error(error, '   ✗ Production security configuration invalid');
+			throw error;
+		}
 	}
 
 	// Initialize database connection and tables

--- a/src/lib/server/security-config.ts
+++ b/src/lib/server/security-config.ts
@@ -1,0 +1,24 @@
+/**
+ * Production security configuration validation.
+ */
+
+export function validateProductionSecurityConfig(): void {
+	if (process.env.NODE_ENV !== 'production') {
+		return;
+	}
+
+	const backupKey = process.env.BACKUP_ENCRYPTION_KEY?.trim();
+	if (!backupKey) {
+		throw new Error('BACKUP_ENCRYPTION_KEY must be set in production!');
+	}
+	if (!/^[0-9a-fA-F]{64}$/.test(backupKey)) {
+		throw new Error(
+			'BACKUP_ENCRYPTION_KEY must be 64 hexadecimal characters (32 bytes). Generate with: openssl rand -hex 32'
+		);
+	}
+
+	const metricsToken = process.env.GYRE_METRICS_TOKEN?.trim();
+	if (!metricsToken) {
+		throw new Error('GYRE_METRICS_TOKEN must be set in production!');
+	}
+}

--- a/src/routes/metrics/+server.ts
+++ b/src/routes/metrics/+server.ts
@@ -9,9 +9,17 @@ export const GET: RequestHandler = async ({ request, setHeaders, getClientAddres
 	checkRateLimit({ setHeaders }, `metrics:${getClientAddress()}`, 120, 60 * 1000);
 
 	const authHeader = request.headers.get('authorization') ?? '';
-	const hasValidBearerToken = !!GYRE_METRICS_TOKEN && authHeader === `Bearer ${GYRE_METRICS_TOKEN}`;
+	const metricsToken = GYRE_METRICS_TOKEN?.trim();
+	const hasValidBearerToken = !!metricsToken && authHeader === `Bearer ${metricsToken}`;
 
 	if (IS_PROD) {
+		if (!metricsToken) {
+			return new Response(JSON.stringify({ error: 'Metrics token is not configured' }), {
+				status: 503,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+
 		if (!hasValidBearerToken) {
 			if (!locals.user) {
 				return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -34,8 +42,8 @@ export const GET: RequestHandler = async ({ request, setHeaders, getClientAddres
 				});
 			}
 		}
-	} else if (GYRE_METRICS_TOKEN) {
-		if (authHeader !== `Bearer ${GYRE_METRICS_TOKEN}`) {
+	} else if (metricsToken) {
+		if (authHeader !== `Bearer ${metricsToken}`) {
 			return new Response(JSON.stringify({ error: 'Unauthorized' }), {
 				status: 401,
 				headers: { 'Content-Type': 'application/json' }

--- a/src/tests/auth-seed-providers.test.ts
+++ b/src/tests/auth-seed-providers.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+interface State {
+	inserted: Record<string, unknown>[];
+	encryptInputs: string[];
+	warnLogs: Array<[unknown, string] | [string]>;
+	errorLogs: Array<[unknown, string] | [string]>;
+	infoLogs: string[];
+}
+
+const state: State = {
+	inserted: [],
+	encryptInputs: [],
+	warnLogs: [],
+	errorLogs: [],
+	infoLogs: []
+};
+
+mock.module('../lib/server/logger.js', () => ({
+	logger: {
+		warn: (...args: [unknown, string] | [string]) => {
+			state.warnLogs.push(args);
+		},
+		error: (...args: [unknown, string] | [string]) => {
+			state.errorLogs.push(args);
+		},
+		info: (message: string) => {
+			state.infoLogs.push(message);
+		}
+	}
+}));
+
+mock.module('../lib/server/auth/crypto.js', () => ({
+	encryptSecret: (value: string) => {
+		state.encryptInputs.push(value);
+		return `enc:${value}`;
+	}
+}));
+
+function buildDbMock() {
+	return {
+		transaction: (cb: (tx: any) => void) => {
+			cb({
+				insert: () => ({
+					values: (provider: Record<string, unknown>) => ({
+						onConflictDoNothing: () => ({
+							returning: () => ({
+								all: () => {
+									state.inserted.push(provider);
+									return [provider];
+								}
+							})
+						})
+					})
+				})
+			});
+		}
+	};
+}
+
+mock.module('../lib/server/db/index.js', () => ({
+	getDb: async () => buildDbMock()
+}));
+
+mock.module('../lib/server/db.js', () => ({
+	getDb: async () => buildDbMock()
+}));
+
+mock.module('../lib/server/db', () => ({
+	getDb: async () => buildDbMock()
+}));
+
+mock.module('../lib/server/db/schema.js', () => ({
+	authProviders: {}
+}));
+
+mock.module('../lib/server/db/schema', () => ({
+	authProviders: {}
+}));
+
+const originalEnv = {
+	GYRE_AUTH_PROVIDERS: process.env.GYRE_AUTH_PROVIDERS,
+	GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET: process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET
+};
+
+beforeEach(() => {
+	state.inserted = [];
+	state.encryptInputs = [];
+	state.warnLogs = [];
+	state.errorLogs = [];
+	state.infoLogs = [];
+});
+
+afterEach(() => {
+	if (originalEnv.GYRE_AUTH_PROVIDERS === undefined) delete process.env.GYRE_AUTH_PROVIDERS;
+	else process.env.GYRE_AUTH_PROVIDERS = originalEnv.GYRE_AUTH_PROVIDERS;
+
+	if (originalEnv.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET === undefined) {
+		delete process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET;
+	} else {
+		process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET =
+			originalEnv.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET;
+	}
+});
+
+describe('seedAuthProviders', () => {
+	test('seeds provider when metadata JSON is valid and env secret exists', async () => {
+		process.env.GYRE_AUTH_PROVIDERS = JSON.stringify([
+			{
+				name: 'GitHub',
+				type: 'oauth2-github',
+				clientId: 'github-client-id'
+			}
+		]);
+		process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET = 'super-secret';
+
+		const { seedAuthProviders } = await import('../lib/server/auth/seed-providers.js');
+		const result = await seedAuthProviders();
+
+		expect(result).toEqual({ created: 1, skipped: 0 });
+		expect(state.encryptInputs).toEqual(['super-secret']);
+		expect(state.inserted.length).toBe(1);
+		expect(state.inserted[0].clientSecretEncrypted).toBe('enc:super-secret');
+	});
+
+	test('rejects providers that include forbidden clientSecret in JSON payload', async () => {
+		process.env.GYRE_AUTH_PROVIDERS = JSON.stringify([
+			{
+				name: 'GitHub',
+				type: 'oauth2-github',
+				clientId: 'github-client-id',
+				clientSecret: 'forbidden-inline-secret'
+			}
+		]);
+		process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET = 'super-secret';
+
+		const { seedAuthProviders } = await import('../lib/server/auth/seed-providers.js');
+		const result = await seedAuthProviders();
+
+		expect(result).toEqual({ created: 0, skipped: 1 });
+		expect(state.inserted.length).toBe(0);
+		expect(state.warnLogs.length).toBeGreaterThan(0);
+		expect(JSON.stringify(state.warnLogs)).toContain(
+			'clientSecret: inline clientSecret is not allowed'
+		);
+	});
+
+	test('skips provider with clear error when provider secret env var is missing', async () => {
+		process.env.GYRE_AUTH_PROVIDERS = JSON.stringify([
+			{
+				name: 'GitHub',
+				type: 'oauth2-github',
+				clientId: 'github-client-id'
+			}
+		]);
+		delete process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET;
+
+		const { seedAuthProviders } = await import('../lib/server/auth/seed-providers.js');
+		const result = await seedAuthProviders();
+
+		expect(result).toEqual({ created: 0, skipped: 1 });
+		expect(state.inserted.length).toBe(0);
+		expect(state.errorLogs.length).toBeGreaterThan(0);
+		expect(JSON.stringify(state.errorLogs)).toContain(
+			'missing required env var GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET'
+		);
+	});
+});

--- a/src/tests/backup-encryption.test.ts
+++ b/src/tests/backup-encryption.test.ts
@@ -19,12 +19,18 @@ function makeKey(): Buffer {
 
 describe('Backup Encryption Module', () => {
 	const originalEnv = process.env.BACKUP_ENCRYPTION_KEY;
+	const originalNodeEnv = process.env.NODE_ENV;
 
 	afterEach(() => {
 		if (originalEnv !== undefined) {
 			process.env.BACKUP_ENCRYPTION_KEY = originalEnv;
 		} else {
 			delete process.env.BACKUP_ENCRYPTION_KEY;
+		}
+		if (originalNodeEnv !== undefined) {
+			process.env.NODE_ENV = originalNodeEnv;
+		} else {
+			delete process.env.NODE_ENV;
 		}
 		_resetBackupEncryptionKeyCache();
 	});
@@ -120,9 +126,17 @@ describe('Backup Encryption Module', () => {
 	});
 
 	describe('_getBackupEncryptionKey', () => {
-		test('returns null when BACKUP_ENCRYPTION_KEY is not set', () => {
+		test('returns null in development when BACKUP_ENCRYPTION_KEY is not set', () => {
+			process.env.NODE_ENV = 'development';
 			delete process.env.BACKUP_ENCRYPTION_KEY;
 			expect(_getBackupEncryptionKey()).toBeNull();
+		});
+
+		test('throws in production when BACKUP_ENCRYPTION_KEY is not set', () => {
+			process.env.NODE_ENV = 'production';
+			delete process.env.BACKUP_ENCRYPTION_KEY;
+			expect(() => _getBackupEncryptionKey()).toThrow(BackupError);
+			expect(() => _getBackupEncryptionKey()).toThrow('BACKUP_ENCRYPTION_KEY must be set');
 		});
 
 		test('returns a 32-byte Buffer for a valid 64-char hex key', () => {

--- a/src/tests/helm-chart-regressions.test.ts
+++ b/src/tests/helm-chart-regressions.test.ts
@@ -44,12 +44,20 @@ describe('helm chart regressions', () => {
 
 		expect(source).toContain('.Values.origin');
 		expect(source).toContain('.Values.gatewayApi.tls');
+		expect(source).toContain(
+			'auth.providersExistingSecret is required when auth.providers is non-empty'
+		);
+		expect(source).toContain('contains forbidden field clientSecret');
 		expect(source).toContain('{{- $seen := dict }}');
 		expect(source).toContain('regexReplaceAll "[^A-Z0-9]" ($provider.name | upper) "_"');
 		expect(source).toContain('hasKey $seen $providerKey');
 		expect(source).toContain('index $seen $providerKey');
 		expect(source).toContain('GYRE_AUTH_PROVIDER_{{ $providerKey }}_CLIENT_SECRET');
 		expect(source).toContain('PROVIDER_{{ $providerKey }}_CLIENT_SECRET');
+		expect(source).toContain('optional: false');
+		expect(source).toContain('BACKUP_ENCRYPTION_KEY');
+		expect(source).toContain('GYRE_METRICS_TOKEN');
+		expect(source).toContain('metrics.existingSecret is required for Helm deployments');
 	});
 
 	test('values and templates include deployability defaults for service account and body size limit', () => {
@@ -85,5 +93,21 @@ describe('helm chart regressions', () => {
 		expect(schema.properties.config.properties.bodySizeLimit.pattern).toBe(
 			'^(?:[0-9]+(?:[KMG])?|Infinity)$'
 		);
+		expect(schema.properties.encryption.properties.backupKey.type).toBe('string');
+		expect(schema.properties.encryption.then.properties.backupKey.pattern).toBe(
+			'^[0-9a-fA-F]{64}$'
+		);
+		expect(schema.properties.auth.properties.providers.items.additionalProperties).toBe(false);
+		expect(schema.properties.auth.then.required).toContain('providersExistingSecret');
+		expect(schema.properties.metrics.properties.existingSecret.minLength).toBe(1);
+		expect(
+			schema.properties.auth.properties.providers.items.properties.clientSecret
+		).toBeUndefined();
+	});
+
+	test('inline encryption secret template includes BACKUP_ENCRYPTION_KEY', () => {
+		const source = readRepoFile('../charts/gyre/templates/secret-encryption.yaml');
+		expect(source).toContain('BACKUP_ENCRYPTION_KEY');
+		expect(source).toContain('.Values.encryption.backupKey');
 	});
 });

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -141,13 +141,24 @@ describe('metrics handler auth behavior', () => {
 		expect(await response.json()).toEqual({ error: 'Unauthorized' });
 	});
 
-	test('returns 401 in production when metrics token is unset and request is unauthenticated', async () => {
+	test('returns 503 in production when metrics token is unset and request is unauthenticated', async () => {
 		const response = await callMetrics({
 			isProd: true
 		});
 
-		expect(response.status).toBe(401);
-		expect(await response.json()).toEqual({ error: 'Unauthorized' });
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({ error: 'Metrics token is not configured' });
+	});
+
+	test('returns 503 in production when metrics token is unset even for admin session', async () => {
+		const response = await callMetrics({
+			isProd: true,
+			user: createUser('admin'),
+			cluster: 'cluster-a'
+		});
+
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({ error: 'Metrics token is not configured' });
 	});
 
 	test('returns 200 in production with authenticated admin session', async () => {

--- a/src/tests/security-config.test.ts
+++ b/src/tests/security-config.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { validateProductionSecurityConfig } from '../lib/server/security-config.js';
+
+const originalEnv = {
+	NODE_ENV: process.env.NODE_ENV,
+	BACKUP_ENCRYPTION_KEY: process.env.BACKUP_ENCRYPTION_KEY,
+	GYRE_METRICS_TOKEN: process.env.GYRE_METRICS_TOKEN
+};
+
+afterEach(() => {
+	if (originalEnv.NODE_ENV === undefined) delete process.env.NODE_ENV;
+	else process.env.NODE_ENV = originalEnv.NODE_ENV;
+
+	if (originalEnv.BACKUP_ENCRYPTION_KEY === undefined) delete process.env.BACKUP_ENCRYPTION_KEY;
+	else process.env.BACKUP_ENCRYPTION_KEY = originalEnv.BACKUP_ENCRYPTION_KEY;
+
+	if (originalEnv.GYRE_METRICS_TOKEN === undefined) delete process.env.GYRE_METRICS_TOKEN;
+	else process.env.GYRE_METRICS_TOKEN = originalEnv.GYRE_METRICS_TOKEN;
+});
+
+describe('validateProductionSecurityConfig', () => {
+	test('allows missing BACKUP_ENCRYPTION_KEY and GYRE_METRICS_TOKEN in development', () => {
+		process.env.NODE_ENV = 'development';
+		delete process.env.BACKUP_ENCRYPTION_KEY;
+		delete process.env.GYRE_METRICS_TOKEN;
+
+		expect(() => validateProductionSecurityConfig()).not.toThrow();
+	});
+
+	test('fails in production when BACKUP_ENCRYPTION_KEY is missing', () => {
+		process.env.NODE_ENV = 'production';
+		delete process.env.BACKUP_ENCRYPTION_KEY;
+		process.env.GYRE_METRICS_TOKEN = 'metrics-token';
+
+		expect(() => validateProductionSecurityConfig()).toThrow(
+			'BACKUP_ENCRYPTION_KEY must be set in production!'
+		);
+	});
+
+	test('fails in production when BACKUP_ENCRYPTION_KEY format is invalid', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.BACKUP_ENCRYPTION_KEY = 'not-a-hex-key';
+		process.env.GYRE_METRICS_TOKEN = 'metrics-token';
+
+		expect(() => validateProductionSecurityConfig()).toThrow(
+			'BACKUP_ENCRYPTION_KEY must be 64 hexadecimal characters (32 bytes). Generate with: openssl rand -hex 32'
+		);
+	});
+
+	test('fails in production when GYRE_METRICS_TOKEN is missing', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.BACKUP_ENCRYPTION_KEY = 'a'.repeat(64);
+		delete process.env.GYRE_METRICS_TOKEN;
+
+		expect(() => validateProductionSecurityConfig()).toThrow(
+			'GYRE_METRICS_TOKEN must be set in production!'
+		);
+	});
+
+	test('passes in production when BACKUP_ENCRYPTION_KEY and GYRE_METRICS_TOKEN are configured', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.BACKUP_ENCRYPTION_KEY = 'a'.repeat(64);
+		process.env.GYRE_METRICS_TOKEN = 'metrics-token';
+
+		expect(() => validateProductionSecurityConfig()).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary
- Removes inline provider secrets from Helm/runtime config and requires provider client secrets via `providersExistingSecret`.
- Adds production validation for `BACKUP_ENCRYPTION_KEY` and `GYRE_METRICS_TOKEN`, and wires metrics to require a secret-backed token in Helm deployments.
- Expands Helm schema/templates and docs to cover backup encryption, metrics secret configuration, and stricter provider seeding rules.
- Adds a blocking GitHub Actions secret scan workflow to catch leaked secrets in PRs and pushes.

## Testing
- Not run (changes reviewed from diff only).
- Added/updated unit and regression coverage for provider seeding, backup encryption behavior, security config validation, Helm chart constraints, and public route handling.
- Recommended check: run the test suite and a Helm template/render validation for the chart changes.
- Recommended check: verify the new secret-scan workflow passes on a sample PR with no secret findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics endpoint protected by a bearer token (configurable via GYRE_METRICS_TOKEN).

* **Security Enhancements**
  * Backup encryption key (BACKUP_ENCRYPTION_KEY) required in production.
  * Startup now validates production security config.
  * Auth providers are metadata-only; provider client secrets must be supplied via secrets.
  * Added automated secret scanning in CI.

* **Documentation**
  * Updated configuration and Helm guides with new requirements.

* **Tests**
  * Added tests covering security config, auth providers, metrics, and backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->