### PR TITLE
Harden CI verification and Bun test coverage

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,6 +34,11 @@ jobs:
         with:
           bun-version: 1.3.10
 
+      - name: Setup Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+        with:
+          version: 'v3.20.1'
+
       - name: Get bun.lock file for caching
         id: bun-lock-hash
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
-          version: 'v3.20.1'
+          version: 'v4.1.4'
 
       - name: Get bun.lock file for caching
         id: bun-lock-hash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ The easiest way to start developing is using the provided devcontainer:
 - `bun install` - Install dependencies
 - `bun run dev` - Start development server
 - `bun run verify` - Local pre-commit/pre-push verification (auto-format + lint + typecheck + build)
-- `bun run verify:ci` - Strict CI-equivalent verification (no auto-format)
+- `bun run verify:ci` - Release gate parity for CI (format:check + lint + typecheck + tests + build)
+- `bun test` - Full Bun test suite (requires Helm on PATH for chart render regression tests)
 
 ## Questions?
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"format": "oxfmt . --write --ignore-path .oxfmtignore",
 		"format:check": "oxfmt . --check --ignore-path .oxfmtignore",
 		"verify": "bun run format && bun run lint && bun run check && bun run build",
-		"verify:ci": "bun run format:check && bun run lint && bun run check && bun run build",
+		"verify:ci": "bun run format:check && bun run lint && bun run check && bun test && bun run build",
 		"test": "bun test",
 		"test:watch": "bun test --watch"
 	},

--- a/src/tests/flux-action-routes.test.ts
+++ b/src/tests/flux-action-routes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { User } from '../lib/server/db/schema.js';
 
 const capturedPermissionChecks: unknown[][] = [];
@@ -91,6 +91,10 @@ beforeEach(() => {
 	capturedReconcileCalls.length = 0;
 	capturedToggleSuspendCalls.length = 0;
 	capturedLogWrites.length = 0;
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 describe('Flux action routes normalize plural resource types', () => {

--- a/src/tests/flux-actions.test.ts
+++ b/src/tests/flux-actions.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
 
+mock.restore();
+
 spyOn(console, 'log').mockImplementation(() => {});
 
 // Capture API calls
@@ -33,7 +35,7 @@ import {
 	toggleSuspendResource,
 	reconcileResource,
 	deleteResource
-} from '../lib/server/kubernetes/flux/actions.js';
+} from '../lib/server/kubernetes/flux/actions.ts?sut';
 
 describe('toggleSuspendResource', () => {
 	beforeEach(() => {

--- a/src/tests/flux-security.test.ts
+++ b/src/tests/flux-security.test.ts
@@ -5,13 +5,16 @@
  * apiVersion/kind mismatch detection, namespace validation, and YAML schema
  * restrictions — without requiring full SvelteKit route infrastructure.
  */
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, mock } from 'bun:test';
 import yaml from 'js-yaml';
+
+mock.restore();
+
 import {
 	getResourceDef,
 	getResourceTypeByPlural,
 	FLUX_RESOURCES
-} from '../lib/server/kubernetes/flux/resources.js';
+} from '../lib/server/kubernetes/flux/resources.js?sut';
 import {
 	K8S_NAME_REGEX,
 	validateK8sNamespace,
@@ -23,7 +26,7 @@ import {
 	LABEL_KEY_PATTERN,
 	LABEL_VALUE_PATTERN,
 	SUBSTITUTE_VAR_PATTERN
-} from '../lib/server/validation.js';
+} from '../lib/server/validation.js?sut';
 
 // ---------------------------------------------------------------------------
 // apiVersion / kind mismatch logic (mirrors POST handler checks)

--- a/src/tests/helpers/oauth.ts
+++ b/src/tests/helpers/oauth.ts
@@ -1,0 +1,11 @@
+import { expect } from 'bun:test';
+
+export async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
+	try {
+		await promise;
+		throw new Error(`Expected rejection with OAuthError code ${code}`);
+	} catch (error) {
+		expect((error as { name?: string }).name).toBe('OAuthError');
+		expect((error as { code?: string }).code).toBe(code);
+	}
+}

--- a/src/tests/k8s-timeout.test.ts
+++ b/src/tests/k8s-timeout.test.ts
@@ -1,4 +1,6 @@
-import { describe, test, expect, beforeEach, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
+
+mock.restore();
 
 // Suppress console noise from handleK8sError's server-side logging and DB init.
 spyOn(console, 'log').mockImplementation(() => {});
@@ -10,7 +12,7 @@ import {
 	handleK8sError,
 	clearClientPool,
 	_createTimeoutMiddleware
-} from '../lib/server/kubernetes/client.js';
+} from '../lib/server/kubernetes/client.js?sut';
 import {
 	KubernetesTimeoutError,
 	ClusterUnavailableError,

--- a/src/tests/logger.test.ts
+++ b/src/tests/logger.test.ts
@@ -1,5 +1,7 @@
-import { expect, test, describe, spyOn } from 'bun:test';
-import { logger } from '../lib/server/logger.js';
+import { expect, test, describe, mock, spyOn } from 'bun:test';
+import { logger } from '../lib/server/logger.js?sut';
+
+mock.restore();
 
 describe('Logger Redaction', () => {
 	test('redacts sensitive fields like password', () => {

--- a/src/tests/oauth-callback-route.test.ts
+++ b/src/tests/oauth-callback-route.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { INVALID_SPAN_CONTEXT, trace } from '@opentelemetry/api';
 import type { Cookies } from '@sveltejs/kit';
 import type { User } from '../lib/server/db/schema.js';
+
+mock.restore();
 
 function createCallbackState() {
 	return {
@@ -23,7 +25,14 @@ mock.module('$lib/server/auth/oauth', () => ({
 		})
 	}),
 	OAuthError: class OAuthError extends Error {
-		code = 'GENERIC';
+		constructor(
+			message: string,
+			public code: string,
+			public details?: unknown
+		) {
+			super(message);
+			this.name = 'OAuthError';
+		}
 	}
 }));
 
@@ -152,6 +161,10 @@ function buildEvent(
 
 beforeEach(() => {
 	Object.assign(callbackState, createCallbackState());
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 describe('oauth callback route', () => {

--- a/src/tests/oauth-github.test.ts
+++ b/src/tests/oauth-github.test.ts
@@ -9,6 +9,7 @@ import {
 	mock,
 	spyOn
 } from 'bun:test';
+import { expectOAuthErrorCode } from './helpers/oauth.js';
 
 mock.restore();
 
@@ -86,16 +87,6 @@ function makeProvider(configOverrides: Partial<typeof mockConfig> = {}) {
 		config: { ...mockConfig, ...configOverrides } as never,
 		redirectUri: 'https://example.com/callback'
 	});
-}
-
-async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
-	try {
-		await promise;
-		throw new Error(`Expected rejection with OAuthError code ${code}`);
-	} catch (error) {
-		expect((error as { name?: string }).name).toBe('OAuthError');
-		expect((error as { code?: string }).code).toBe(code);
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests/oauth-github.test.ts
+++ b/src/tests/oauth-github.test.ts
@@ -10,6 +10,8 @@ import {
 	spyOn
 } from 'bun:test';
 
+mock.restore();
+
 let consoleLogSpy: ReturnType<typeof spyOn>;
 let consoleErrorSpy: ReturnType<typeof spyOn>;
 let consoleWarnSpy: ReturnType<typeof spyOn>;
@@ -52,7 +54,7 @@ mock.module('arctic', () => ({
 	}
 }));
 
-import { GitHubProvider } from '../lib/server/auth/oauth/providers/github.js';
+import { GitHubProvider } from '../lib/server/auth/oauth/providers/github.js?sut';
 
 const mockConfig = {
 	id: 'github-1',
@@ -84,6 +86,16 @@ function makeProvider(configOverrides: Partial<typeof mockConfig> = {}) {
 		config: { ...mockConfig, ...configOverrides } as never,
 		redirectUri: 'https://example.com/callback'
 	});
+}
+
+async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
+	try {
+		await promise;
+		throw new Error(`Expected rejection with OAuthError code ${code}`);
+	} catch (error) {
+		expect((error as { name?: string }).name).toBe('OAuthError');
+		expect((error as { code?: string }).code).toBe(code);
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -177,9 +189,10 @@ describe('GitHubProvider.validateCallback() — PKCE path', () => {
 		});
 		try {
 			const provider = makeProvider();
-			await expect(provider.validateCallback('code', 'verifier')).rejects.toMatchObject({
-				code: 'TOKEN_EXCHANGE_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.validateCallback('code', 'verifier'),
+				'TOKEN_EXCHANGE_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}
@@ -219,10 +232,10 @@ describe('GitHubProvider.validateCallback() — error handling', () => {
 
 	test('throws OAuthError with TOKEN_EXCHANGE_FAILED when token endpoint returns non-OK', async () => {
 		const provider = makeProvider();
-		await expect(provider.validateCallback('bad-code', 'verifier')).rejects.toMatchObject({
-			name: 'OAuthError',
-			code: 'TOKEN_EXCHANGE_FAILED'
-		});
+		await expectOAuthErrorCode(
+			provider.validateCallback('bad-code', 'verifier'),
+			'TOKEN_EXCHANGE_FAILED'
+		);
 	});
 });
 
@@ -405,11 +418,9 @@ describe('GitHubProvider.getUserInfo() — API failure', () => {
 
 	test('throws OAuthError with USERINFO_FAILED code on GitHub API failure', async () => {
 		const provider = makeProvider();
-		await expect(
-			provider.getUserInfo({ accessToken: 'bad-token', tokenType: 'Bearer' })
-		).rejects.toMatchObject({
-			name: 'OAuthError',
-			code: 'USERINFO_FAILED'
-		});
+		await expectOAuthErrorCode(
+			provider.getUserInfo({ accessToken: 'bad-token', tokenType: 'Bearer' }),
+			'USERINFO_FAILED'
+		);
 	});
 });

--- a/src/tests/oauth-gitlab.test.ts
+++ b/src/tests/oauth-gitlab.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, afterAll, mock, spyOn } from 'bun:test';
 
+mock.restore();
+
 const consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
 const consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
 const consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
@@ -45,7 +47,7 @@ mock.module('$lib/server/logger.js', () => ({
 	logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }
 }));
 
-import { GitLabProvider } from '../lib/server/auth/oauth/providers/gitlab.js';
+import { GitLabProvider } from '../lib/server/auth/oauth/providers/gitlab.js?sut';
 
 const mockConfig = {
 	id: 'gitlab-1',
@@ -76,6 +78,16 @@ function makeProvider(overrides: Record<string, unknown> = {}) {
 		config: { ...mockConfig, ...overrides } as typeof mockConfig,
 		redirectUri: 'https://app.example.com/callback'
 	});
+}
+
+async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
+	try {
+		await promise;
+		throw new Error(`Expected rejection with OAuthError code ${code}`);
+	} catch (error) {
+		expect((error as { name?: string }).name).toBe('OAuthError');
+		expect((error as { code?: string }).code).toBe(code);
+	}
 }
 
 interface FetchMockContext {
@@ -223,9 +235,10 @@ describe('GitLabProvider.validateCallback() — PKCE path', () => {
 		});
 		try {
 			const provider = makeProvider();
-			await expect(provider.validateCallback('auth-code', 'my-verifier')).rejects.toMatchObject({
-				code: 'TOKEN_EXCHANGE_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.validateCallback('auth-code', 'my-verifier'),
+				'TOKEN_EXCHANGE_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}
@@ -255,10 +268,10 @@ describe('GitLabProvider.validateCallback() — error handling', () => {
 		});
 		try {
 			const provider = makeProvider();
-			await expect(provider.validateCallback('bad-code', 'verifier')).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'TOKEN_EXCHANGE_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.validateCallback('bad-code', 'verifier'),
+				'TOKEN_EXCHANGE_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}
@@ -296,10 +309,7 @@ describe('GitLabProvider.refreshAccessToken()', () => {
 		});
 		try {
 			const provider = makeProvider();
-			await expect(provider.refreshAccessToken!('bad-token')).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'TOKEN_REFRESH_FAILED'
-			});
+			await expectOAuthErrorCode(provider.refreshAccessToken!('bad-token'), 'TOKEN_REFRESH_FAILED');
 		} finally {
 			spy.mockRestore();
 		}
@@ -407,12 +417,10 @@ describe('GitLabProvider.getUserInfo()', () => {
 		});
 		try {
 			const provider = makeProvider();
-			await expect(
-				provider.getUserInfo({ accessToken: 'bad-token', tokenType: 'Bearer' })
-			).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'USERINFO_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.getUserInfo({ accessToken: 'bad-token', tokenType: 'Bearer' }),
+				'USERINFO_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}

--- a/src/tests/oauth-gitlab.test.ts
+++ b/src/tests/oauth-gitlab.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, afterAll, mock, spyOn } from 'bun:test';
+import { expectOAuthErrorCode } from './helpers/oauth.js';
 
 mock.restore();
 
@@ -78,16 +79,6 @@ function makeProvider(overrides: Record<string, unknown> = {}) {
 		config: { ...mockConfig, ...overrides } as typeof mockConfig,
 		redirectUri: 'https://app.example.com/callback'
 	});
-}
-
-async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
-	try {
-		await promise;
-		throw new Error(`Expected rejection with OAuthError code ${code}`);
-	} catch (error) {
-		expect((error as { name?: string }).name).toBe('OAuthError');
-		expect((error as { code?: string }).code).toBe(code);
-	}
 }
 
 interface FetchMockContext {

--- a/src/tests/oauth-google.test.ts
+++ b/src/tests/oauth-google.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, mock, spyOn } from 'bun:test';
 
+mock.restore();
+
 spyOn(console, 'log').mockImplementation(() => {});
 spyOn(console, 'error').mockImplementation(() => {});
 spyOn(console, 'warn').mockImplementation(() => {});
@@ -43,7 +45,7 @@ mock.module('jose', () => ({
 	decodeJwt: () => mockJwtClaims
 }));
 
-import { GoogleProvider } from '../lib/server/auth/oauth/providers/google.js';
+import { GoogleProvider } from '../lib/server/auth/oauth/providers/google.js?sut';
 
 const mockConfig = {
 	id: 'google-1',
@@ -74,6 +76,16 @@ function makeProvider(overrides: Record<string, unknown> = {}) {
 		config: { ...mockConfig, ...overrides } as typeof mockConfig,
 		redirectUri: 'https://app.example.com/callback'
 	});
+}
+
+async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
+	try {
+		await promise;
+		throw new Error(`Expected rejection with OAuthError code ${code}`);
+	} catch (error) {
+		expect((error as { name?: string }).name).toBe('OAuthError');
+		expect((error as { code?: string }).code).toBe(code);
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -143,10 +155,7 @@ describe('GoogleProvider.validateCallback()', () => {
 		try {
 			// Create a fresh provider so the Arctic client is initialized fresh
 			const provider = makeProvider();
-			await expect(provider.validateCallback('bad-code')).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'TOKEN_EXCHANGE_FAILED'
-			});
+			await expectOAuthErrorCode(provider.validateCallback('bad-code'), 'TOKEN_EXCHANGE_FAILED');
 		} finally {
 			arcticShouldThrow = false;
 		}
@@ -222,12 +231,10 @@ describe('GoogleProvider.getUserInfo()', () => {
 			throw new Error('Network error');
 		});
 		try {
-			await expect(
-				provider.getUserInfo({ accessToken: 'bad-token', tokenType: 'Bearer' })
-			).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'USERINFO_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.getUserInfo({ accessToken: 'bad-token', tokenType: 'Bearer' }),
+				'USERINFO_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}

--- a/src/tests/oauth-google.test.ts
+++ b/src/tests/oauth-google.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, mock, spyOn } from 'bun:test';
+import { expectOAuthErrorCode } from './helpers/oauth.js';
 
 mock.restore();
 
@@ -76,16 +77,6 @@ function makeProvider(overrides: Record<string, unknown> = {}) {
 		config: { ...mockConfig, ...overrides } as typeof mockConfig,
 		redirectUri: 'https://app.example.com/callback'
 	});
-}
-
-async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
-	try {
-		await promise;
-		throw new Error(`Expected rejection with OAuthError code ${code}`);
-	} catch (error) {
-		expect((error as { name?: string }).name).toBe('OAuthError');
-		expect((error as { code?: string }).code).toBe(code);
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests/oauth-oidc.test.ts
+++ b/src/tests/oauth-oidc.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { expectOAuthErrorCode } from './helpers/oauth.js';
 
 mock.restore();
 
@@ -83,16 +84,6 @@ function makeProvider(configOverrides: Partial<typeof mockConfig> = {}) {
 		config: { ...mockConfig, ...configOverrides } as never,
 		redirectUri: 'https://app.example.com/cb'
 	});
-}
-
-async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
-	try {
-		await promise;
-		throw new Error(`Expected rejection with OAuthError code ${code}`);
-	} catch (error) {
-		expect((error as { name?: string }).name).toBe('OAuthError');
-		expect((error as { code?: string }).code).toBe(code);
-	}
 }
 
 function mockDiscovery(discovery = MOCK_DISCOVERY) {

--- a/src/tests/oauth-oidc.test.ts
+++ b/src/tests/oauth-oidc.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 
+mock.restore();
+
 let consoleLogSpy: ReturnType<typeof spyOn>;
 let consoleErrorSpy: ReturnType<typeof spyOn>;
 let consoleWarnSpy: ReturnType<typeof spyOn>;
@@ -37,8 +39,8 @@ mock.module('jose', () => ({
 	})
 }));
 
-import { OIDCProvider } from '../lib/server/auth/oauth/providers/oidc.js';
-import { validateProviderConfig } from '../lib/server/auth/oauth/index.js';
+import { OIDCProvider } from '../lib/server/auth/oauth/providers/oidc.js?sut';
+import { validateProviderConfig } from '../lib/server/auth/oauth/index.js?sut';
 import { OAuthError } from '../lib/server/auth/oauth/types.js';
 
 const MOCK_DISCOVERY = {
@@ -83,6 +85,16 @@ function makeProvider(configOverrides: Partial<typeof mockConfig> = {}) {
 	});
 }
 
+async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
+	try {
+		await promise;
+		throw new Error(`Expected rejection with OAuthError code ${code}`);
+	} catch (error) {
+		expect((error as { name?: string }).name).toBe('OAuthError');
+		expect((error as { code?: string }).code).toBe(code);
+	}
+}
+
 function mockDiscovery(discovery = MOCK_DISCOVERY) {
 	return spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 		const urlStr = url.toString();
@@ -123,7 +135,7 @@ describe('OIDCProvider — constructor', () => {
 				redirectUri: 'https://app.example.com/cb'
 			});
 		} catch (e) {
-			expect(e).toMatchObject({ code: 'INVALID_CONFIG' });
+			expect((e as { code?: string }).code).toBe('INVALID_CONFIG');
 		}
 	});
 
@@ -268,10 +280,10 @@ describe('OIDCProvider — discover()', () => {
 			);
 		});
 		try {
-			await expect(provider.getAuthorizationUrl('state', 'verifier')).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'DISCOVERY_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.getAuthorizationUrl('state', 'verifier'),
+				'DISCOVERY_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}
@@ -293,10 +305,10 @@ describe('OIDCProvider — discover()', () => {
 			);
 		});
 		try {
-			await expect(provider.getAuthorizationUrl('state', 'verifier')).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'DISCOVERY_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.getAuthorizationUrl('state', 'verifier'),
+				'DISCOVERY_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}
@@ -318,10 +330,10 @@ describe('OIDCProvider — discover()', () => {
 			);
 		});
 		try {
-			await expect(provider.getAuthorizationUrl('state', 'verifier')).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'DISCOVERY_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.getAuthorizationUrl('state', 'verifier'),
+				'DISCOVERY_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}
@@ -466,10 +478,10 @@ describe('OIDCProvider.validateCallback()', () => {
 			return new Response('not found', { status: 404 });
 		});
 		try {
-			await expect(provider.validateCallback('bad-code', 'verifier')).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'TOKEN_EXCHANGE_FAILED'
-			});
+			await expectOAuthErrorCode(
+				provider.validateCallback('bad-code', 'verifier'),
+				'TOKEN_EXCHANGE_FAILED'
+			);
 		} finally {
 			spy.mockRestore();
 		}
@@ -579,12 +591,10 @@ describe('OIDCProvider.getUserInfo()', () => {
 			return new Response('not found', { status: 404 });
 		});
 		try {
-			await expect(
-				provider.getUserInfo({ accessToken: 'access-token', tokenType: 'Bearer' })
-			).rejects.toMatchObject({
-				name: 'OAuthError',
-				code: 'NO_USER_INFO'
-			});
+			await expectOAuthErrorCode(
+				provider.getUserInfo({ accessToken: 'access-token', tokenType: 'Bearer' }),
+				'NO_USER_INFO'
+			);
 		} finally {
 			spy.mockRestore();
 		}

--- a/src/tests/pagination.test.ts
+++ b/src/tests/pagination.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
 
+mock.restore();
+
 spyOn(console, 'log').mockImplementation(() => {});
 import { Database } from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
@@ -26,7 +28,7 @@ mock.module('bcryptjs', () => ({
 	compare: async () => true
 }));
 
-import { listUsersPaginated, createUser } from '../lib/server/auth.js';
+import { listUsersPaginated } from '../lib/server/auth.js?sut';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -43,6 +45,7 @@ const CREATE_USERS_TABLE = `
 		role TEXT NOT NULL DEFAULT 'viewer',
 		active INTEGER NOT NULL DEFAULT 1,
 		is_local INTEGER NOT NULL DEFAULT 1,
+		requires_password_change INTEGER NOT NULL DEFAULT 0,
 		created_at INTEGER NOT NULL DEFAULT (unixepoch()),
 		updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
 		preferences TEXT
@@ -86,19 +89,25 @@ describe('Pagination Logic', () => {
 	beforeEach(async () => {
 		state.db = setupInMemoryDb();
 
-		// Create some test users
 		prefix = `pagetest_${Date.now()}`;
-		// We insert directly using helper or createUser function?
-		// createUser uses getDb(), which is mocked to return state.db.
-		// So we can use createUser.
-
 		for (let i = 0; i < 15; i++) {
-			try {
-				await createUser(`${prefix}_${i}`, 'password123', 'viewer', `${prefix}_${i}@example.com`);
-			} catch (e) {
-				// eslint-disable-next-line no-console
-				console.error('Failed to create test user', e);
-			}
+			const now = new Date();
+			state
+				.db!.insert(schema.users)
+				.values({
+					id: `user_${prefix}_${i}`,
+					username: `${prefix}_${i}`,
+					name: `${prefix}_${i}`,
+					email: `${prefix}_${i}@example.com`,
+					role: 'viewer',
+					active: true,
+					isLocal: true,
+					requiresPasswordChange: false,
+					emailVerified: false,
+					createdAt: now,
+					updatedAt: now
+				})
+				.run();
 		}
 	});
 

--- a/src/tests/rate-limiter.test.ts
+++ b/src/tests/rate-limiter.test.ts
@@ -1,12 +1,53 @@
-import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import * as schema from '../lib/server/db/schema.js';
+
+const state: { db: ReturnType<typeof drizzle<typeof schema>> | null } = { db: null };
+
+const CREATE_RATE_LIMITS = `
+	CREATE TABLE IF NOT EXISTS rate_limits (
+		key TEXT PRIMARY KEY,
+		current_window_count INTEGER NOT NULL DEFAULT 0,
+		previous_window_count INTEGER NOT NULL DEFAULT 0,
+		last_window_start INTEGER NOT NULL DEFAULT 0,
+		expire_at INTEGER NOT NULL,
+		updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+	)
+`;
+
+const CREATE_LOGIN_LOCKOUTS = `
+	CREATE TABLE IF NOT EXISTS login_lockouts (
+		username TEXT PRIMARY KEY,
+		failed_attempts INTEGER NOT NULL DEFAULT 0,
+		locked_until INTEGER,
+		updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+	)
+`;
+
+function setupInMemoryDb() {
+	const sqlite = new Database(':memory:');
+	sqlite.exec(CREATE_RATE_LIMITS);
+	sqlite.exec(CREATE_LOGIN_LOCKOUTS);
+	return drizzle(sqlite, { schema });
+}
+
+mock.module('../lib/server/db/index.js', () => ({
+	getDbSync: () => state.db,
+	getDb: async () => state.db,
+	schema
+}));
 
 spyOn(console, 'log').mockImplementation(() => {});
-import { RateLimiter, SSEConnectionLimiter } from '../lib/server/rate-limiter';
+import { RateLimiter, SSEConnectionLimiter } from '../lib/server/rate-limiter?sut';
+
+mock.restore();
 
 describe('RateLimiter', () => {
 	let limiter: RateLimiter;
 
 	beforeEach(() => {
+		state.db = setupInMemoryDb();
 		// Each test gets a fresh instance with empty storage; prevents state leaking
 		// across tests (since RateLimiter storage is instance-level, not module-level).
 		limiter = new RateLimiter();
@@ -16,6 +57,7 @@ describe('RateLimiter', () => {
 		// Explicitly stop the interval to avoid lingering timers.
 		// The stop() method clears the internal setInterval created in the constructor.
 		limiter.stop();
+		state.db = null;
 	});
 
 	describe('basic rate limiting', () => {
@@ -113,16 +155,18 @@ describe('RateLimiter', () => {
 			expect(result.limited).toBe(false);
 		});
 
-		test('fresh instance starts with clean state for any key', () => {
+		test('new instances share persisted counters for the same key', () => {
 			// Exhaust a key in one instance
 			const old = new RateLimiter();
 			old.check('shared-key', 1, 60_000);
 			old.check('shared-key', 1, 60_000); // now blocked in old
 
-			// New instance has no memory of old traffic
+			// Rate limiter state is persisted in DB and therefore shared.
 			const fresh = new RateLimiter();
 			const result = fresh.check('shared-key', 1, 60_000);
-			expect(result.limited).toBe(false);
+			expect(result.limited).toBe(true);
+			old.stop();
+			fresh.stop();
 		});
 
 		test('multiple requests from the same key within one window accumulate correctly', () => {

--- a/src/tests/rbac.test.ts
+++ b/src/tests/rbac.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
 
+mock.restore();
+
 spyOn(console, 'log').mockImplementation(() => {});
 
 import { Database } from 'bun:sqlite';
@@ -22,7 +24,7 @@ import {
 	isAdmin,
 	requirePermission,
 	RbacError
-} from '../lib/server/rbac.js';
+} from '../lib/server/rbac.js?sut';
 import type { User } from '../lib/server/db/schema.js';
 
 // ---------------------------------------------------------------------------

--- a/src/tests/session-cleanup.test.ts
+++ b/src/tests/session-cleanup.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
 
+mock.restore();
+
 spyOn(console, 'log').mockImplementation(() => {});
 import { Database } from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
@@ -19,7 +21,7 @@ import {
 	deleteUserSessions,
 	generateSessionId,
 	generateUserId
-} from '../lib/server/auth.js';
+} from '../lib/server/auth.js?sut';
 
 const CREATE_USERS_TABLE = `
 	CREATE TABLE IF NOT EXISTS users (
@@ -32,6 +34,7 @@ const CREATE_USERS_TABLE = `
 		role TEXT NOT NULL DEFAULT 'viewer',
 		active INTEGER NOT NULL DEFAULT 1,
 		is_local INTEGER NOT NULL DEFAULT 1,
+		requires_password_change INTEGER NOT NULL DEFAULT 0,
 		created_at INTEGER NOT NULL DEFAULT (unixepoch()),
 		updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
 		preferences TEXT

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 
+mock.restore();
+
 spyOn(console, 'log').mockImplementation(() => {});
 
 import { Database } from 'bun:sqlite';
@@ -30,7 +32,7 @@ import {
 	isSettingOverriddenByEnv,
 	seedAuthSettings,
 	SETTINGS_KEYS
-} from '../lib/server/settings.js';
+} from '../lib/server/settings.js?sut';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/tests/sso-auto-provision.test.ts
+++ b/src/tests/sso-auto-provision.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
+mock.restore();
+
 function flattenSqlParts(value: unknown): string[] {
 	if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
 		return [String(value)];
@@ -140,7 +142,7 @@ mock.module('$lib/server/logger.js', () => ({
 	}
 }));
 
-import { createOrUpdateSSOUser } from '../lib/server/auth/sso.js';
+import { createOrUpdateSSOUser } from '../lib/server/auth/sso.js?sut';
 
 function createProviderConfig(emailClaim = 'email') {
 	return {


### PR DESCRIPTION
## Summary
- Align `verify:ci` with the release gate by running `format:check`, lint, typecheck, the full Bun test suite, and build.
- Update CI lint workflow to install Helm so chart-render regression tests can run reliably.
- Refresh contributing docs to match the new verification flow and test requirements.
- Harden tests by isolating module state, switching several imports to `?sut`, and making OAuth error assertions more explicit.
- Update in-memory test fixtures for auth, pagination, rate limiting, sessions, and RBAC to reflect current schema and persistence behavior.

## Testing
- Not run locally.
- CI lint workflow now includes Helm setup before cache and verification steps.
- Bun test suite is expected to pass with Helm available on `PATH`.
- `verify:ci` now exercises tests as part of the release-gate parity check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm CLI setup to the CI lint/typecheck workflow.

* **Documentation**
  * Updated contributor guide: CI verification now documents running the full test suite (`bun test`) and requires Helm on PATH for chart tests; verify:ci script updated accordingly.

* **Tests**
  * Improved mock isolation across many tests (global restores), introduced a shared OAuth error assertion helper, and adjusted several test DB/setup behaviors for more reliable suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->