### PR TITLE
refactor(server): modularize request pipeline and shared flux services

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,7 +10,11 @@ import { enforceCsrfProtection } from '$lib/server/request/csrf.js';
 import { normalizeHandleError, resolveRouteAndMapErrors } from '$lib/server/request/errors.js';
 import { ensureGyreInitialized, isGyreInitialized } from '$lib/server/request/initialization.js';
 import { enforceGlobalRateLimit } from '$lib/server/request/rate-limit.js';
-import { enforceRequestSizeLimits } from '$lib/server/request/request-size.js';
+import {
+	createPayloadTooLargeResponse,
+	enforceRequestSizeLimits,
+	isPayloadTooLargeError
+} from '$lib/server/request/request-size.js';
 import { hydrateSessionLocals } from '$lib/server/request/session.js';
 
 export const handle: Handle = async ({ event, resolve }) => {
@@ -22,7 +26,23 @@ export const handle: Handle = async ({ event, resolve }) => {
 			return finalizeResponse(event, requestSizeResponse, context);
 		}
 
-		await ensureGyreInitialized();
+		try {
+			await ensureGyreInitialized();
+		} catch {
+			const serviceUnavailableResponse = event.url.pathname.startsWith('/api/')
+				? new Response(
+						JSON.stringify({
+							error: 'Service Unavailable',
+							message: 'Gyre is still initializing'
+						}),
+						{
+							status: 503,
+							headers: { 'Content-Type': 'application/json' }
+						}
+					)
+				: new Response('Service Unavailable', { status: 503 });
+			return finalizeResponse(event, serviceUnavailableResponse, context);
+		}
 
 		const rateLimitResponse = enforceGlobalRateLimit(event, isGyreInitialized());
 		if (rateLimitResponse) {
@@ -32,7 +52,15 @@ export const handle: Handle = async ({ event, resolve }) => {
 		// Session cookies are managed in the session helper via BETTER_AUTH_SESSION_COOKIE_NAME.
 		await hydrateSessionLocals(event);
 
-		const csrfResponse = await enforceCsrfProtection(event);
+		let csrfResponse: Response | null = null;
+		try {
+			csrfResponse = await enforceCsrfProtection(event);
+		} catch (err) {
+			if (isPayloadTooLargeError(err)) {
+				return finalizeResponse(event, createPayloadTooLargeResponse(event, err), context);
+			}
+			throw err;
+		}
 		if (csrfResponse) {
 			return finalizeResponse(event, csrfResponse, context);
 		}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,4 @@
-import { withRequestContext } from '$lib/server/logger.js';
+import { logger, withRequestContext } from '$lib/server/logger.js';
 import type { Handle } from '@sveltejs/kit';
 import {
 	enforceAdminRouteGate,
@@ -28,7 +28,8 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 		try {
 			await ensureGyreInitialized();
-		} catch {
+		} catch (err) {
+			logger.error(err, 'Failed to ensure Gyre is initialized during request handling');
 			const serviceUnavailableResponse = event.url.pathname.startsWith('/api/')
 				? new Response(
 						JSON.stringify({

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,403 +1,56 @@
-import { logger, withRequestContext } from '$lib/server/logger.js';
-import { isRedirect, isHttpError, type Handle } from '@sveltejs/kit';
+import { withRequestContext } from '$lib/server/logger.js';
+import type { Handle } from '@sveltejs/kit';
 import {
-	BETTER_AUTH_SESSION_COOKIE_NAME,
-	getBetterAuthSession
-} from '$lib/server/auth/better-auth';
-import { initializeGyre } from '$lib/server/initialize';
-import { httpRequestDurationMicroseconds } from '$lib/server/metrics';
-import { getRequestSizeLimit, validateRequestSize, formatSize } from '$lib/server/request-limits';
-import { generateCsrfToken, validateCsrfToken } from '$lib/server/csrf';
-import { CSRF_COOKIE_OPTIONS, IS_PROD, ADMIN_ROUTE_PREFIXES } from '$lib/server/config';
-import { tryCheckRateLimit } from '$lib/server/rate-limiter';
-import { getClusterById } from '$lib/server/clusters';
-import { errorToHttpResponse } from '$lib/server/kubernetes/errors';
-import { normalizeError } from '$lib/utils/error-normalization';
-import { isPublicRoute, STATIC_PATTERNS } from '$lib/isPublicRoute.js';
-
-// Initialize Gyre on first request
-let initialized = false;
-let initializingPromise: Promise<void> | undefined;
-
-const STATE_CHANGING_METHODS = ['POST', 'PUT', 'DELETE', 'PATCH'];
-
-function setSecurityHeaders(response: Response): void {
-	response.headers.set('X-Content-Type-Options', 'nosniff');
-	response.headers.set('X-Frame-Options', 'DENY');
-	response.headers.set('X-Permitted-Cross-Domain-Policies', 'none');
-	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-	// Content-Security-Policy is managed by SvelteKit via kit.csp in svelte.config.js,
-	// which injects per-request nonces into inline hydration scripts. Setting it here
-	// would overwrite those nonces and break page hydration.
-	if (IS_PROD) {
-		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-	}
-}
-
-/**
- * Handle function to manage:
- * 1. Request size validation (DoS protection)
- * 2. Session authentication
- * 3. Cluster context via cookies
- * 4. RBAC checks (future enhancement)
- */
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	enforceAdminRouteGate,
+	enforceAuthenticationGate,
+	resolveClusterContext
+} from '$lib/server/request/access.js';
+import { assignRequestContext, finalizeResponse } from '$lib/server/request/context.js';
+import { enforceCsrfProtection } from '$lib/server/request/csrf.js';
+import { normalizeHandleError, resolveRouteAndMapErrors } from '$lib/server/request/errors.js';
+import { ensureGyreInitialized, isGyreInitialized } from '$lib/server/request/initialization.js';
+import { enforceGlobalRateLimit } from '$lib/server/request/rate-limit.js';
+import { enforceRequestSizeLimits } from '$lib/server/request/request-size.js';
+import { hydrateSessionLocals } from '$lib/server/request/session.js';
 
 export const handle: Handle = async ({ event, resolve }) => {
-	const requestIdRaw = event.request.headers.get('x-request-id');
-	const requestId =
-		requestIdRaw && UUID_REGEX.test(requestIdRaw) ? requestIdRaw : crypto.randomUUID();
-	event.locals.requestId = requestId;
+	const context = assignRequestContext(event);
 
-	return withRequestContext(requestId, async () => {
-		const start = Date.now();
-		const { url, cookies, request } = event;
-		const path = url.pathname;
-
-		const recordResponse = (response: Response) => {
-			if (!path.startsWith('/metrics')) {
-				const duration = (Date.now() - start) / 1000;
-				const routeTemplate = event.route?.id || path;
-				httpRequestDurationMicroseconds
-					.labels(event.request.method, routeTemplate, response.status.toString())
-					.observe(duration);
-			}
-			response.headers.set('x-request-id', requestId);
-			setSecurityHeaders(response);
-			return response;
-		};
-
-		function isPayloadTooLargeError(
-			err: unknown
-		): err is { isPayloadTooLarge: true; size: number; limit: number } {
-			if (typeof err !== 'object' || err === null) return false;
-			const e = err as Record<string, unknown>;
-			return (
-				e.isPayloadTooLarge === true && typeof e.size === 'number' && typeof e.limit === 'number'
-			);
+	return withRequestContext(context.requestId, async () => {
+		const requestSizeResponse = await enforceRequestSizeLimits(event);
+		if (requestSizeResponse) {
+			return finalizeResponse(event, requestSizeResponse, context);
 		}
 
-		function payloadTooLargeResponse(
-			err: { size: number; limit: number },
-			req: Request,
-			reqPath: string
-		): Response {
-			logger.warn(
-				{ method: req.method, path: reqPath, size: err.size, limit: err.limit },
-				'Request size exceeded limit'
-			);
-			if (reqPath.startsWith('/api/')) {
-				return recordResponse(
-					new Response(
-						JSON.stringify({
-							error: 'Payload Too Large',
-							message: `Request payload exceeds maximum size of ${formatSize(err.limit)}`
-						}),
-						{ status: 413, headers: { 'Content-Type': 'application/json' } }
-					)
-				);
-			}
-			const redirectParams = new URLSearchParams(url.search);
-			redirectParams.set('_error', 'payload_too_large');
-			return recordResponse(
-				new Response(null, {
-					status: 303,
-					headers: { Location: `${reqPath}?${redirectParams}` }
-				})
-			);
+		await ensureGyreInitialized();
+
+		const rateLimitResponse = enforceGlobalRateLimit(event, isGyreInitialized());
+		if (rateLimitResponse) {
+			return finalizeResponse(event, rateLimitResponse, context);
 		}
 
-		// Validate request size to prevent DoS attacks
-		const sizeLimit = getRequestSizeLimit(path, request.method);
-		const contentLength = request.headers.get('content-length') ?? undefined;
-		const sizeValidation = validateRequestSize(contentLength, sizeLimit, request.method);
+		// Session cookies are managed in the session helper via BETTER_AUTH_SESSION_COOKIE_NAME.
+		await hydrateSessionLocals(event);
 
-		if (!sizeValidation.valid) {
-			// For API routes return a JSON 413; for page/form routes redirect back with
-			// an error param so the user sees the form rather than a raw JSON response.
-			// NOTE: Pages that receive this redirect must read ?_error=payload_too_large
-			// from their load function and surface it to the user.
-			return payloadTooLargeResponse(
-				{ size: sizeValidation.size, limit: sizeValidation.limit },
-				request,
-				path
-			);
+		const csrfResponse = await enforceCsrfProtection(event);
+		if (csrfResponse) {
+			return finalizeResponse(event, csrfResponse, context);
 		}
 
-		// Streaming size guard: catches chunked/transfer-encoded requests that omit
-		// Content-Length. The full body is piped through the transform before the
-		// handler runs so size violations are rejected immediately. Using
-		// ByteLengthQueuingStrategy lets the readable buffer up to sizeLimit bytes
-		// so pipeTo can resolve without a concurrent reader; event.request is only
-		// constructed after the guard resolves successfully.
-		// Skip pre-read when Content-Length is present — the header-based check
-		// above already enforces the limit without consuming the stream.
-		if (
-			request.body &&
-			STATE_CHANGING_METHODS.includes(request.method) &&
-			!request.headers.has('content-length')
-		) {
-			let bytesRead = 0;
-			const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>(
-				{
-					transform(chunk, controller) {
-						bytesRead += chunk.byteLength;
-						if (bytesRead > sizeLimit) {
-							controller.error(
-								Object.assign(new Error('Payload Too Large'), {
-									isPayloadTooLarge: true,
-									limit: sizeLimit,
-									size: bytesRead
-								})
-							);
-							return;
-						}
-						controller.enqueue(chunk);
-					}
-				},
-				undefined,
-				new ByteLengthQueuingStrategy({ highWaterMark: sizeLimit })
-			);
-			try {
-				await request.body.pipeTo(writable);
-			} catch (err) {
-				if (isPayloadTooLargeError(err)) return payloadTooLargeResponse(err, request, path);
-				// Any other pipe failure (client disconnect, stream abort, upstream error)
-				// leaves `readable` in an errored state. Do not hand a broken stream to
-				// downstream handlers — return a stream-failure response instead.
-				return recordResponse(new Response('Stream error', { status: 499 }));
-			}
-			event.request = new Request(request, {
-				body: readable,
-				duplex: 'half'
-			} as RequestInit);
+		const authGateResponse = enforceAuthenticationGate(event);
+		if (authGateResponse) {
+			return finalizeResponse(event, authGateResponse, context);
 		}
 
-		// Initialize Gyre on first request — promise lock prevents concurrent init calls
-		if (!initialized) {
-			if (!initializingPromise) {
-				initializingPromise = initializeGyre()
-					.then(() => {
-						initialized = true;
-					})
-					.catch((error) => {
-						logger.error(error, 'Failed to initialize Gyre:');
-						// Continue anyway - let the request fail naturally if DB is truly broken
-					})
-					.finally(() => {
-						initializingPromise = undefined;
-					});
-			}
-			await initializingPromise;
+		await resolveClusterContext(event);
+
+		const adminGateResponse = enforceAdminRouteGate(event);
+		if (adminGateResponse) {
+			return finalizeResponse(event, adminGateResponse, context);
 		}
 
-		// Global rate limiting: 300 req/min per IP (skip static assets and health checks)
-		// Run this only after initialization so the backing table exists on a fresh database.
-		const isStaticAsset = STATIC_PATTERNS.some((p) => p.test(path));
-		const isHealthEndpoint =
-			path === '/api/health' ||
-			path === '/api/v1/health' ||
-			path === '/api/flux/health' ||
-			path === '/api/v1/flux/health';
-		if (initialized && !isStaticAsset && !isHealthEndpoint) {
-			const ip = event.getClientAddress();
-			// Pass a no-op setHeaders so the global limiter doesn't set X-RateLimit-* on the event —
-			// endpoint-specific limiters own those headers and SvelteKit throws if they're set twice.
-			const globalLimit = tryCheckRateLimit(
-				{ setHeaders: () => {} },
-				`global:${ip}`,
-				300,
-				60 * 1000
-			);
-			if (globalLimit.limited) {
-				return recordResponse(
-					new Response(
-						JSON.stringify({
-							error: 'Too Many Requests',
-							message: 'Rate limit exceeded. Please try again later.'
-						}),
-						{
-							status: 429,
-							headers: {
-								'Content-Type': 'application/json',
-								'Retry-After': globalLimit.retryAfter.toString()
-							}
-						}
-					)
-				);
-			}
-		}
-
-		// Initialize locals with defaults
-		event.locals.user = null;
-		event.locals.session = null;
-		event.locals.cluster = undefined;
-
-		// Check for session cookie
-		if (cookies.get(BETTER_AUTH_SESSION_COOKIE_NAME)) {
-			const sessionData = await getBetterAuthSession(request, cookies);
-			if (sessionData) {
-				event.locals.user = sessionData.user;
-				event.locals.session = sessionData.session;
-
-				// Set CSRF token cookie (non-httpOnly so JS can read it)
-				const csrfToken = generateCsrfToken(sessionData.session.id);
-				if (cookies.get('gyre_csrf') !== csrfToken) {
-					cookies.set('gyre_csrf', csrfToken, CSRF_COOKIE_OPTIONS);
-				}
-			} else {
-				// Session is expired, invalid, or the user has been deactivated
-				// (getSession already revoked all DB sessions in the inactive-user case).
-				// Clear the stale cookie so the client doesn't keep replaying it.
-				cookies.delete(BETTER_AUTH_SESSION_COOKIE_NAME, { path: '/' });
-			}
-		}
-
-		// Validate CSRF token for state-changing methods on authenticated, non-public routes
-		if (
-			event.locals.session &&
-			STATE_CHANGING_METHODS.includes(request.method) &&
-			!isPublicRoute(path)
-		) {
-			// Header first; fall back to form body for use:enhance forms that still
-			// submit _csrf as a hidden field until they are migrated to the header.
-			// Only call formData() when the header is absent and the content-type is
-			// form-compatible to avoid parsing non-form bodies or masking size errors.
-			// Clone event.request (not the original `request` whose body is already
-			// piped into the size-guard transform).
-			const headerToken = request.headers.get('x-csrf-token');
-			let csrfToken: string;
-			if (headerToken !== null) {
-				csrfToken = headerToken;
-			} else {
-				const contentType = request.headers.get('content-type') ?? '';
-				const isFormCompatible =
-					contentType.startsWith('multipart/form-data') ||
-					contentType.startsWith('application/x-www-form-urlencoded');
-				if (isFormCompatible) {
-					try {
-						const fd = await event.request.clone().formData();
-						const rawToken = fd.get('_csrf');
-						csrfToken = typeof rawToken === 'string' ? rawToken : '';
-					} catch (err) {
-						if (isPayloadTooLargeError(err)) throw err;
-						csrfToken = '';
-					}
-				} else {
-					csrfToken = '';
-				}
-			}
-
-			if (!validateCsrfToken(event.locals.session.id, csrfToken)) {
-				logger.warn('CSRF token validation failed', {
-					userId: event.locals.user?.id,
-					method: request.method,
-					path
-				});
-				return recordResponse(
-					new Response(
-						JSON.stringify({ error: 'Forbidden', message: 'Invalid or missing CSRF token' }),
-						{ status: 403, headers: { 'Content-Type': 'application/json' } }
-					)
-				);
-			}
-		}
-
-		// If not authenticated and not a public route, redirect to login
-		if (!event.locals.user && !isPublicRoute(path)) {
-			// For API routes, return 401
-			if (path.startsWith('/api/')) {
-				return recordResponse(
-					new Response(
-						JSON.stringify({ error: 'Unauthorized', message: 'Authentication required' }),
-						{
-							status: 401,
-							headers: { 'Content-Type': 'application/json' }
-						}
-					)
-				);
-			}
-
-			// For page routes, redirect to login preserving return destination.
-			// Validate via URL parse so backslash-normalization and scheme-relative bypasses are caught
-			// by the parser before our origin check runs.
-			let safeReturnTo = '/';
-			try {
-				const parsed = new URL(path + url.search, url.origin);
-				if (parsed.origin === url.origin) {
-					safeReturnTo = parsed.pathname + parsed.search;
-				}
-			} catch {
-				// malformed value — fall back to '/'
-			}
-			return recordResponse(
-				new Response(null, {
-					status: 302,
-					headers: { Location: `/login?returnTo=${encodeURIComponent(safeReturnTo)}` }
-				})
-			);
-		}
-
-		// Handle cluster context from cookies (for multi-cluster support)
-		const cluster = cookies.get('gyre_cluster');
-		if (cluster) {
-			// Validate the cluster exists in the database (skip for built-in in-cluster context)
-			if (cluster !== 'in-cluster') {
-				// Let DB errors propagate — don't silently fall back on infrastructure failures
-				const clusterRecord = await getClusterById(cluster);
-				if (!clusterRecord || !clusterRecord.isActive) {
-					// Unknown or inactive cluster — clear the stale cookie and fall back to in-cluster
-					cookies.delete('gyre_cluster', { path: '/' });
-					event.locals.cluster = 'in-cluster';
-				} else {
-					event.locals.cluster = cluster;
-				}
-			} else {
-				event.locals.cluster = cluster;
-			}
-		} else {
-			// Default to 'in-cluster' context
-			event.locals.cluster = 'in-cluster';
-		}
-
-		// Protect admin API routes
-		if (
-			ADMIN_ROUTE_PREFIXES.some((prefix) => path === prefix || path.startsWith(prefix + '/')) &&
-			event.locals.user?.role !== 'admin'
-		) {
-			return recordResponse(
-				new Response(JSON.stringify({ error: 'Forbidden', message: 'Admin access required' }), {
-					status: 403,
-					headers: { 'Content-Type': 'application/json' }
-				})
-			);
-		}
-
-		if (path.startsWith('/api/')) {
-			try {
-				const response = await resolve(event);
-				return recordResponse(response);
-			} catch (err) {
-				if (isPayloadTooLargeError(err)) return payloadTooLargeResponse(err, request, path);
-				if (isRedirect(err) || isHttpError(err)) throw err;
-				logger.error(err, `Unhandled error in API route ${path}:`);
-				const { status, body } = errorToHttpResponse(err);
-				return recordResponse(
-					new Response(JSON.stringify(body), {
-						status,
-						headers: { 'Content-Type': 'application/json' }
-					})
-				);
-			}
-		}
-
-		try {
-			const response = await resolve(event);
-			return recordResponse(response);
-		} catch (err) {
-			if (isPayloadTooLargeError(err)) return payloadTooLargeResponse(err, request, path);
-			throw err;
-		}
+		const response = await resolveRouteAndMapErrors(event, resolve);
+		return finalizeResponse(event, response, context);
 	});
 };
 
@@ -411,13 +64,5 @@ export function handleError({
 	error: unknown;
 	event: { url: URL; locals?: App.Locals };
 }) {
-	const requestId = event.locals?.requestId;
-	if (requestId) {
-		logger.error(error, `Error in ${event.url.pathname}:`, { requestId });
-	} else {
-		logger.error(error, `Error in ${event.url.pathname}:`);
-	}
-
-	const { code, status } = normalizeError(error);
-	return { message: 'An unexpected error occurred', code, status };
+	return normalizeHandleError({ error, event });
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,11 +10,7 @@ import { enforceCsrfProtection } from '$lib/server/request/csrf.js';
 import { normalizeHandleError, resolveRouteAndMapErrors } from '$lib/server/request/errors.js';
 import { ensureGyreInitialized, isGyreInitialized } from '$lib/server/request/initialization.js';
 import { enforceGlobalRateLimit } from '$lib/server/request/rate-limit.js';
-import {
-	createPayloadTooLargeResponse,
-	enforceRequestSizeLimits,
-	isPayloadTooLargeError
-} from '$lib/server/request/request-size.js';
+import { enforceRequestSizeLimits } from '$lib/server/request/request-size.js';
 import { hydrateSessionLocals } from '$lib/server/request/session.js';
 
 export const handle: Handle = async ({ event, resolve }) => {
@@ -24,6 +20,11 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const requestSizeResponse = await enforceRequestSizeLimits(event);
 		if (requestSizeResponse) {
 			return finalizeResponse(event, requestSizeResponse, context);
+		}
+
+		const rateLimitResponse = enforceGlobalRateLimit(event, isGyreInitialized());
+		if (rateLimitResponse) {
+			return finalizeResponse(event, rateLimitResponse, context);
 		}
 
 		try {
@@ -45,40 +46,29 @@ export const handle: Handle = async ({ event, resolve }) => {
 			return finalizeResponse(event, serviceUnavailableResponse, context);
 		}
 
-		const rateLimitResponse = enforceGlobalRateLimit(event, isGyreInitialized());
-		if (rateLimitResponse) {
-			return finalizeResponse(event, rateLimitResponse, context);
-		}
+		const response = await resolveRouteAndMapErrors(event, async () => {
+			// Session cookies are managed in the session helper via BETTER_AUTH_SESSION_COOKIE_NAME.
+			await hydrateSessionLocals(event);
 
-		// Session cookies are managed in the session helper via BETTER_AUTH_SESSION_COOKIE_NAME.
-		await hydrateSessionLocals(event);
-
-		let csrfResponse: Response | null = null;
-		try {
-			csrfResponse = await enforceCsrfProtection(event);
-		} catch (err) {
-			if (isPayloadTooLargeError(err)) {
-				return finalizeResponse(event, createPayloadTooLargeResponse(event, err), context);
+			const csrfResponse = await enforceCsrfProtection(event);
+			if (csrfResponse) {
+				return csrfResponse;
 			}
-			throw err;
-		}
-		if (csrfResponse) {
-			return finalizeResponse(event, csrfResponse, context);
-		}
 
-		const authGateResponse = enforceAuthenticationGate(event);
-		if (authGateResponse) {
-			return finalizeResponse(event, authGateResponse, context);
-		}
+			const authGateResponse = enforceAuthenticationGate(event);
+			if (authGateResponse) {
+				return authGateResponse;
+			}
 
-		await resolveClusterContext(event);
+			await resolveClusterContext(event);
 
-		const adminGateResponse = enforceAdminRouteGate(event);
-		if (adminGateResponse) {
-			return finalizeResponse(event, adminGateResponse, context);
-		}
+			const adminGateResponse = enforceAdminRouteGate(event);
+			if (adminGateResponse) {
+				return adminGateResponse;
+			}
 
-		const response = await resolveRouteAndMapErrors(event, resolve);
+			return resolve(event);
+		});
 		return finalizeResponse(event, response, context);
 	});
 };

--- a/src/lib/server/flux/services.ts
+++ b/src/lib/server/flux/services.ts
@@ -1,0 +1,242 @@
+import { error } from '@sveltejs/kit';
+import * as k8s from '@kubernetes/client-node';
+import {
+	getFluxResource,
+	getFluxResourceStatus,
+	getKubeConfig,
+	getPoolMetrics,
+	listFluxResources,
+	type ListOptions,
+	type ReqCache
+} from '$lib/server/kubernetes/client.js';
+import { validateKubeConfig } from '$lib/server/kubernetes/config.js';
+import { handleApiError } from '$lib/server/kubernetes/errors.js';
+import {
+	getAllResourcePlurals,
+	getAllResourceTypes,
+	resolveFluxResourceType
+} from '$lib/server/kubernetes/flux/resources.js';
+import { logger } from '$lib/server/logger.js';
+import { getResourceStatus } from '$lib/utils/relationships.js';
+
+export const DEFAULT_FLUX_VERSION = 'v2.x.x';
+
+const MAX_CONNECTION_CACHE_SIZE = 20;
+const CONNECTION_CACHE_TTL = 30 * 1000;
+
+const connectionCache = new Map<string, { connected: boolean; timestamp: number }>();
+
+function pruneConnectionCache() {
+	const now = Date.now();
+	for (const [key, value] of connectionCache.entries()) {
+		if (now - value.timestamp > CONNECTION_CACHE_TTL * 10) {
+			connectionCache.delete(key);
+		}
+	}
+
+	if (connectionCache.size > MAX_CONNECTION_CACHE_SIZE) {
+		const sorted = [...connectionCache.entries()].sort((a, b) => a[1].timestamp - b[1].timestamp);
+		sorted
+			.slice(0, connectionCache.size - MAX_CONNECTION_CACHE_SIZE)
+			.forEach(([key]) => connectionCache.delete(key));
+	}
+}
+
+export async function getFluxHealthSummary({
+	locals,
+	includeDetails
+}: {
+	locals: App.Locals;
+	includeDetails: boolean;
+}) {
+	const selectedCluster = locals.cluster;
+	const config = await getKubeConfig(selectedCluster);
+	const currentContext = config.getCurrentContext();
+
+	const cacheKey = selectedCluster || 'default';
+	const cached = connectionCache.get(cacheKey) || { connected: false, timestamp: 0 };
+
+	let isValid = false;
+	if (Date.now() - cached.timestamp < CONNECTION_CACHE_TTL) {
+		isValid = cached.connected;
+	} else {
+		isValid = await validateKubeConfig(config);
+		pruneConnectionCache();
+		connectionCache.set(cacheKey, { connected: isValid, timestamp: Date.now() });
+	}
+
+	if (!isValid) {
+		throw error(503, {
+			message: 'Unable to connect to Kubernetes cluster'
+		});
+	}
+
+	if (!includeDetails) {
+		return { status: 'healthy' as const };
+	}
+
+	const isInCluster = !!process.env.KUBERNETES_SERVICE_HOST;
+
+	return {
+		status: 'healthy' as const,
+		kubernetes: {
+			connected: true,
+			configStrategy: isInCluster ? 'in-cluster' : 'local-kubeconfig',
+			configSource: isInCluster ? 'ServiceAccount' : 'kubeconfig',
+			currentContext,
+			availableContexts: config.getContexts().map((context) => context.name),
+			connectionPool: getPoolMetrics()
+		}
+	};
+}
+
+export async function getFluxInstalledVersion({ locals }: { locals: App.Locals }) {
+	try {
+		const config = await getKubeConfig(locals.cluster);
+		const appsApi = config.makeApiClient(k8s.AppsV1Api);
+		const namespace = 'flux-system';
+
+		try {
+			const response = await appsApi.listNamespacedDeployment({ namespace });
+			const deployments = response.items;
+
+			if (deployments.length > 0) {
+				const fluxDeployment = deployments.find(
+					(deployment) =>
+						deployment.metadata?.labels?.['app.kubernetes.io/part-of'] === 'flux' ||
+						deployment.metadata?.name?.includes('source-controller')
+				);
+
+				const version =
+					fluxDeployment?.metadata?.labels?.['app.kubernetes.io/version'] ||
+					deployments[0].metadata?.labels?.['app.kubernetes.io/version'];
+
+				if (version) {
+					return { version };
+				}
+			}
+
+			const coreApi = config.makeApiClient(k8s.CoreV1Api);
+			const namespaceResponse = await coreApi.readNamespace({ name: namespace });
+			return {
+				version:
+					namespaceResponse.metadata?.labels?.['app.kubernetes.io/version'] || DEFAULT_FLUX_VERSION
+			};
+		} catch (err) {
+			logger.warn(err, 'Failed to fetch version from deployments, trying fallback:');
+			return { version: DEFAULT_FLUX_VERSION };
+		}
+	} catch (err) {
+		handleApiError(err, 'Error fetching Flux version');
+	}
+}
+
+export async function getFluxOverviewSummary({ locals }: { locals: App.Locals }) {
+	const context = locals.cluster;
+	const resourceTypes = getAllResourceTypes();
+	const reqCache: ReqCache = new Map();
+
+	const results = await Promise.all(
+		resourceTypes.map(async (type) => {
+			try {
+				const data = await listFluxResources(type, context, reqCache);
+				const items = data.items || [];
+
+				let healthy = 0;
+				let failed = 0;
+				let suspended = 0;
+
+				for (const item of items) {
+					const status = getResourceStatus(item);
+					if (status === 'ready') healthy++;
+					else if (status === 'failed') failed++;
+					else if (status === 'suspended') suspended++;
+				}
+
+				return {
+					type,
+					total: items.length,
+					healthy,
+					failed,
+					suspended
+				};
+			} catch (err) {
+				logger.warn({ type, err }, 'Failed to list Flux resources for overview');
+				return { type, total: 0, healthy: 0, failed: 0, suspended: 0, error: true };
+			}
+		})
+	);
+
+	return {
+		timestamp: new Date().toISOString(),
+		partialFailure: results.some((result) => result.error),
+		results: results.filter((result) => !result.error)
+	};
+}
+
+export async function listFluxResourcesForType({
+	locals,
+	query,
+	resourceType
+}: {
+	locals: App.Locals;
+	query: ListOptions;
+	resourceType: string;
+}) {
+	const resolvedType = resolveFluxResourceType(resourceType);
+	if (!resolvedType) {
+		const validPlurals = getAllResourcePlurals();
+		throw error(400, {
+			message: `Invalid resource type: ${resourceType}. Valid types: ${validPlurals.join(', ')}`
+		});
+	}
+
+	const reqCache: ReqCache = new Map();
+
+	try {
+		const result = await listFluxResources(resolvedType, locals.cluster, reqCache, query);
+		return {
+			resourceType: resolvedType,
+			result
+		};
+	} catch (err) {
+		handleApiError(err, `Error listing ${resolvedType} resources`);
+	}
+}
+
+export async function getFluxResourceDetail({
+	locals,
+	name,
+	namespace,
+	resourceType,
+	statusOnly
+}: {
+	locals: App.Locals;
+	name: string;
+	namespace: string;
+	resourceType: string;
+	statusOnly: boolean;
+}) {
+	const resolvedType = resolveFluxResourceType(resourceType);
+	if (!resolvedType) {
+		const validPlurals = getAllResourcePlurals();
+		throw error(400, {
+			message: `Invalid resource type: ${resourceType}. Valid types: ${validPlurals.join(', ')}`
+		});
+	}
+
+	const reqCache: ReqCache = new Map();
+
+	try {
+		const resource = statusOnly
+			? await getFluxResourceStatus(resolvedType, namespace, name, locals.cluster, reqCache)
+			: await getFluxResource(resolvedType, namespace, name, locals.cluster, reqCache);
+
+		return {
+			resource,
+			resourceType: resolvedType
+		};
+	} catch (err) {
+		handleApiError(err, `Error fetching ${resolvedType} ${namespace}/${name}`);
+	}
+}

--- a/src/lib/server/flux/services.ts
+++ b/src/lib/server/flux/services.ts
@@ -26,6 +26,55 @@ const CONNECTION_CACHE_TTL = 30 * 1000;
 
 const connectionCache = new Map<string, { connected: boolean; timestamp: number }>();
 
+function getK8sStatusCode(err: unknown): number | undefined {
+	if (typeof err !== 'object' || err === null) {
+		return undefined;
+	}
+
+	const candidate = err as {
+		code?: unknown;
+		response?: { statusCode?: unknown };
+		status?: unknown;
+	};
+	const parseStatus = (value: unknown): number | undefined => {
+		if (typeof value === 'number') {
+			return value;
+		}
+		if (typeof value === 'string' && /^\d+$/.test(value)) {
+			return Number(value);
+		}
+		return undefined;
+	};
+
+	const code = parseStatus(candidate.code);
+	if (code !== undefined) {
+		return code;
+	}
+	const responseCode = parseStatus(candidate.response?.statusCode);
+	if (responseCode !== undefined) {
+		return responseCode;
+	}
+	const status = parseStatus(candidate.status);
+	if (status !== undefined) {
+		return status;
+	}
+	return undefined;
+}
+
+function isNotFoundError(err: unknown): boolean {
+	return getK8sStatusCode(err) === 404;
+}
+
+function ensureResolvedFluxResourceType(resourceType: string) {
+	const resolvedType = resolveFluxResourceType(resourceType);
+	if (!resolvedType) {
+		throw error(400, {
+			message: `Invalid resource type: ${resourceType}. Valid types: ${getAllResourcePlurals().join(', ')}`
+		});
+	}
+	return resolvedType;
+}
+
 function pruneConnectionCache() {
 	const now = Date.now();
 	for (const [key, value] of connectionCache.entries()) {
@@ -49,45 +98,49 @@ export async function getFluxHealthSummary({
 	locals: App.Locals;
 	includeDetails: boolean;
 }) {
-	const selectedCluster = locals.cluster;
-	const config = await getKubeConfig(selectedCluster);
-	const currentContext = config.getCurrentContext();
+	try {
+		const selectedCluster = locals.cluster;
+		const config = await getKubeConfig(selectedCluster);
+		const currentContext = config.getCurrentContext();
 
-	const cacheKey = selectedCluster || 'default';
-	const cached = connectionCache.get(cacheKey) || { connected: false, timestamp: 0 };
+		const cacheKey = selectedCluster || 'default';
+		const cached = connectionCache.get(cacheKey) || { connected: false, timestamp: 0 };
 
-	let isValid = false;
-	if (Date.now() - cached.timestamp < CONNECTION_CACHE_TTL) {
-		isValid = cached.connected;
-	} else {
-		isValid = await validateKubeConfig(config);
-		pruneConnectionCache();
-		connectionCache.set(cacheKey, { connected: isValid, timestamp: Date.now() });
-	}
-
-	if (!isValid) {
-		throw error(503, {
-			message: 'Unable to connect to Kubernetes cluster'
-		});
-	}
-
-	if (!includeDetails) {
-		return { status: 'healthy' as const };
-	}
-
-	const isInCluster = !!process.env.KUBERNETES_SERVICE_HOST;
-
-	return {
-		status: 'healthy' as const,
-		kubernetes: {
-			connected: true,
-			configStrategy: isInCluster ? 'in-cluster' : 'local-kubeconfig',
-			configSource: isInCluster ? 'ServiceAccount' : 'kubeconfig',
-			currentContext,
-			availableContexts: config.getContexts().map((context) => context.name),
-			connectionPool: getPoolMetrics()
+		let isValid = false;
+		if (Date.now() - cached.timestamp < CONNECTION_CACHE_TTL) {
+			isValid = cached.connected;
+		} else {
+			isValid = await validateKubeConfig(config);
+			pruneConnectionCache();
+			connectionCache.set(cacheKey, { connected: isValid, timestamp: Date.now() });
 		}
-	};
+
+		if (!isValid) {
+			throw error(503, {
+				message: 'Unable to connect to Kubernetes cluster'
+			});
+		}
+
+		if (!includeDetails) {
+			return { status: 'healthy' as const };
+		}
+
+		const isInCluster = !!process.env.KUBERNETES_SERVICE_HOST;
+
+		return {
+			status: 'healthy' as const,
+			kubernetes: {
+				connected: true,
+				configStrategy: isInCluster ? 'in-cluster' : 'local-kubeconfig',
+				configSource: isInCluster ? 'ServiceAccount' : 'kubeconfig',
+				currentContext,
+				availableContexts: config.getContexts().map((context) => context.name),
+				connectionPool: getPoolMetrics()
+			}
+		};
+	} catch (err) {
+		handleApiError(err, 'Error fetching Flux health summary');
+	}
 }
 
 export async function getFluxInstalledVersion({ locals }: { locals: App.Locals }) {
@@ -95,36 +148,50 @@ export async function getFluxInstalledVersion({ locals }: { locals: App.Locals }
 		const config = await getKubeConfig(locals.cluster);
 		const appsApi = config.makeApiClient(k8s.AppsV1Api);
 		const namespace = 'flux-system';
+		const coreApi = config.makeApiClient(k8s.CoreV1Api);
 
+		let deployments: k8s.V1Deployment[] = [];
 		try {
 			const response = await appsApi.listNamespacedDeployment({ namespace });
-			const deployments = response.items;
-
-			if (deployments.length > 0) {
-				const fluxDeployment = deployments.find(
-					(deployment) =>
-						deployment.metadata?.labels?.['app.kubernetes.io/part-of'] === 'flux' ||
-						deployment.metadata?.name?.includes('source-controller')
-				);
-
-				const version =
-					fluxDeployment?.metadata?.labels?.['app.kubernetes.io/version'] ||
-					deployments[0].metadata?.labels?.['app.kubernetes.io/version'];
-
-				if (version) {
-					return { version };
-				}
+			deployments = response.items ?? [];
+		} catch (err) {
+			if (isNotFoundError(err)) {
+				logger.warn({ err }, 'Flux namespace/deployments not found; using default Flux version');
+				return { version: DEFAULT_FLUX_VERSION };
 			}
+			logger.warn({ err }, 'Failed to list Flux deployments');
+			throw err;
+		}
 
-			const coreApi = config.makeApiClient(k8s.CoreV1Api);
+		if (deployments.length > 0) {
+			const fluxDeployment = deployments.find(
+				(deployment) =>
+					deployment.metadata?.labels?.['app.kubernetes.io/part-of'] === 'flux' ||
+					deployment.metadata?.name?.includes('source-controller')
+			);
+
+			const version =
+				fluxDeployment?.metadata?.labels?.['app.kubernetes.io/version'] ||
+				deployments[0].metadata?.labels?.['app.kubernetes.io/version'];
+
+			if (version) {
+				return { version };
+			}
+		}
+
+		try {
 			const namespaceResponse = await coreApi.readNamespace({ name: namespace });
 			return {
 				version:
 					namespaceResponse.metadata?.labels?.['app.kubernetes.io/version'] || DEFAULT_FLUX_VERSION
 			};
 		} catch (err) {
-			logger.warn(err, 'Failed to fetch version from deployments, trying fallback:');
-			return { version: DEFAULT_FLUX_VERSION };
+			if (isNotFoundError(err)) {
+				logger.warn({ err }, 'Flux namespace not found while reading version label');
+				return { version: DEFAULT_FLUX_VERSION };
+			}
+			logger.warn({ err }, 'Failed to read Flux namespace while determining version');
+			throw err;
 		}
 	} catch (err) {
 		handleApiError(err, 'Error fetching Flux version');
@@ -183,13 +250,7 @@ export async function listFluxResourcesForType({
 	query: ListOptions;
 	resourceType: string;
 }) {
-	const resolvedType = resolveFluxResourceType(resourceType);
-	if (!resolvedType) {
-		const validPlurals = getAllResourcePlurals();
-		throw error(400, {
-			message: `Invalid resource type: ${resourceType}. Valid types: ${validPlurals.join(', ')}`
-		});
-	}
+	const resolvedType = ensureResolvedFluxResourceType(resourceType);
 
 	const reqCache: ReqCache = new Map();
 
@@ -217,13 +278,7 @@ export async function getFluxResourceDetail({
 	resourceType: string;
 	statusOnly: boolean;
 }) {
-	const resolvedType = resolveFluxResourceType(resourceType);
-	if (!resolvedType) {
-		const validPlurals = getAllResourcePlurals();
-		throw error(400, {
-			message: `Invalid resource type: ${resourceType}. Valid types: ${validPlurals.join(', ')}`
-		});
-	}
+	const resolvedType = ensureResolvedFluxResourceType(resourceType);
 
 	const reqCache: ReqCache = new Map();
 

--- a/src/lib/server/flux/services.ts
+++ b/src/lib/server/flux/services.ts
@@ -23,6 +23,7 @@ export const DEFAULT_FLUX_VERSION = 'v2.x.x';
 
 const MAX_CONNECTION_CACHE_SIZE = 20;
 const CONNECTION_CACHE_TTL = 30 * 1000;
+const NO_CLUSTER_SELECTED_CACHE_KEY = '__NO_CLUSTER_SELECTED__';
 
 const connectionCache = new Map<string, { connected: boolean; timestamp: number }>();
 
@@ -103,7 +104,7 @@ export async function getFluxHealthSummary({
 		const config = await getKubeConfig(selectedCluster);
 		const currentContext = config.getCurrentContext();
 
-		const cacheKey = selectedCluster || 'default';
+		const cacheKey = selectedCluster ?? NO_CLUSTER_SELECTED_CACHE_KEY;
 		const cached = connectionCache.get(cacheKey) || { connected: false, timestamp: 0 };
 
 		let isValid = false;

--- a/src/lib/server/http/guards.ts
+++ b/src/lib/server/http/guards.ts
@@ -1,0 +1,71 @@
+import { error } from '@sveltejs/kit';
+import {
+	checkClusterWideReadPermission,
+	checkPermission,
+	requirePermission,
+	RbacError,
+	type RbacAction
+} from '$lib/server/rbac.js';
+
+export function requireAuthenticatedUser(locals: App.Locals) {
+	if (!locals.user) {
+		throw error(401, { message: 'Authentication required' });
+	}
+
+	return locals.user;
+}
+
+export function requireClusterContext(locals: App.Locals) {
+	if (!locals.cluster) {
+		throw error(400, { message: 'Cluster context required' });
+	}
+
+	return locals.cluster;
+}
+
+export async function requireClusterWideRead(locals: App.Locals): Promise<void> {
+	const user = requireAuthenticatedUser(locals);
+	const hasPermission = await checkClusterWideReadPermission(user, locals.cluster);
+
+	if (!hasPermission) {
+		throw error(403, { message: 'Permission denied' });
+	}
+}
+
+export async function requireScopedPermission(
+	locals: App.Locals,
+	action: RbacAction,
+	resourceType: string,
+	namespace?: string
+): Promise<void> {
+	const user = requireAuthenticatedUser(locals);
+	const hasPermission = await checkPermission(
+		user,
+		action,
+		resourceType,
+		namespace,
+		locals.cluster
+	);
+
+	if (!hasPermission) {
+		throw error(403, { message: 'Permission denied' });
+	}
+}
+
+export async function requireAdminPermission(
+	locals: App.Locals,
+	resourceType?: string,
+	namespace?: string
+): Promise<void> {
+	const user = requireAuthenticatedUser(locals);
+
+	try {
+		await requirePermission(user, 'admin', resourceType, namespace, locals.cluster);
+	} catch (err) {
+		if (err instanceof RbacError) {
+			throw error(403, { message: 'Permission denied' });
+		}
+
+		throw err;
+	}
+}

--- a/src/lib/server/http/transport.ts
+++ b/src/lib/server/http/transport.ts
@@ -21,7 +21,7 @@ export function respondNotModified(request: Request, etag: string | null): Respo
 	}
 
 	if (ifNoneMatch.trim() === '*') {
-		return new Response(null, { status: 304 });
+		return new Response(null, { status: 304, headers: { ETag: etag } });
 	}
 
 	const normalizedEtag = normalizeEtagValue(etag);
@@ -32,5 +32,5 @@ export function respondNotModified(request: Request, etag: string | null): Respo
 		return null;
 	}
 
-	return new Response(null, { status: 304 });
+	return new Response(null, { status: 304, headers: { ETag: etag } });
 }

--- a/src/lib/server/http/transport.ts
+++ b/src/lib/server/http/transport.ts
@@ -9,8 +9,26 @@ export function computeWeakEtag(resourceVersion: string | null | undefined): str
 	return resourceVersion ? `W/"${resourceVersion}"` : null;
 }
 
+function normalizeEtagValue(value: string): string {
+	const withoutWeakPrefix = value.trim().replace(/^W\/\s*/i, '');
+	return withoutWeakPrefix.replace(/^"(.*)"$/, '$1');
+}
+
 export function respondNotModified(request: Request, etag: string | null): Response | null {
-	if (!etag || request.headers.get('if-none-match') !== etag) {
+	const ifNoneMatch = request.headers.get('if-none-match');
+	if (!etag || !ifNoneMatch) {
+		return null;
+	}
+
+	if (ifNoneMatch.trim() === '*') {
+		return new Response(null, { status: 304 });
+	}
+
+	const normalizedEtag = normalizeEtagValue(etag);
+	const matches = ifNoneMatch
+		.split(',')
+		.some((token) => normalizeEtagValue(token) === normalizedEtag);
+	if (!matches) {
 		return null;
 	}
 

--- a/src/lib/server/http/transport.ts
+++ b/src/lib/server/http/transport.ts
@@ -1,0 +1,18 @@
+export function setPrivateCacheHeaders(
+	setHeaders: (headers: Record<string, string>) => void,
+	cacheControl: string
+): void {
+	setHeaders({ 'Cache-Control': cacheControl });
+}
+
+export function computeWeakEtag(resourceVersion: string | null | undefined): string | null {
+	return resourceVersion ? `W/"${resourceVersion}"` : null;
+}
+
+export function respondNotModified(request: Request, etag: string | null): Response | null {
+	if (!etag || request.headers.get('if-none-match') !== etag) {
+		return null;
+	}
+
+	return new Response(null, { status: 304 });
+}

--- a/src/lib/server/request/access.ts
+++ b/src/lib/server/request/access.ts
@@ -1,0 +1,80 @@
+import { ADMIN_ROUTE_PREFIXES } from '$lib/server/config.js';
+import { getClusterById } from '$lib/server/clusters.js';
+import { isPublicRoute } from '$lib/isPublicRoute.js';
+import type { RequestEvent } from '@sveltejs/kit';
+
+export function enforceAuthenticationGate(
+	event: Pick<RequestEvent, 'locals' | 'url'>
+): Response | null {
+	const path = event.url.pathname;
+	if (event.locals.user || isPublicRoute(path)) {
+		return null;
+	}
+
+	if (path.startsWith('/api/')) {
+		return new Response(
+			JSON.stringify({ error: 'Unauthorized', message: 'Authentication required' }),
+			{
+				status: 401,
+				headers: { 'Content-Type': 'application/json' }
+			}
+		);
+	}
+
+	let safeReturnTo = '/';
+	try {
+		const parsed = new URL(path + event.url.search, event.url.origin);
+		if (parsed.origin === event.url.origin) {
+			safeReturnTo = parsed.pathname + parsed.search;
+		}
+	} catch {
+		// malformed value — fall back to '/'
+	}
+
+	return new Response(null, {
+		status: 302,
+		headers: { Location: `/login?returnTo=${encodeURIComponent(safeReturnTo)}` }
+	});
+}
+
+export async function resolveClusterContext(
+	event: Pick<RequestEvent, 'cookies' | 'locals'>
+): Promise<void> {
+	const cluster = event.cookies.get('gyre_cluster');
+	if (!cluster) {
+		event.locals.cluster = 'in-cluster';
+		return;
+	}
+
+	if (cluster === 'in-cluster') {
+		event.locals.cluster = cluster;
+		return;
+	}
+
+	const clusterRecord = await getClusterById(cluster);
+	if (!clusterRecord || !clusterRecord.isActive) {
+		event.cookies.delete('gyre_cluster', { path: '/' });
+		event.locals.cluster = 'in-cluster';
+		return;
+	}
+
+	event.locals.cluster = cluster;
+}
+
+export function enforceAdminRouteGate(
+	event: Pick<RequestEvent, 'locals' | 'url'>
+): Response | null {
+	const path = event.url.pathname;
+	const isAdminRoute = ADMIN_ROUTE_PREFIXES.some(
+		(prefix) => path === prefix || path.startsWith(prefix + '/')
+	);
+
+	if (!isAdminRoute || event.locals.user?.role === 'admin') {
+		return null;
+	}
+
+	return new Response(JSON.stringify({ error: 'Forbidden', message: 'Admin access required' }), {
+		status: 403,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}

--- a/src/lib/server/request/context.ts
+++ b/src/lib/server/request/context.ts
@@ -1,0 +1,56 @@
+import { IS_PROD } from '$lib/server/config.js';
+import { httpRequestDurationMicroseconds } from '$lib/server/metrics.js';
+import type { RequestEvent } from '@sveltejs/kit';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface RequestContextState {
+	path: string;
+	requestId: string;
+	startTimeMs: number;
+}
+
+function setSecurityHeaders(response: Response): void {
+	response.headers.set('X-Content-Type-Options', 'nosniff');
+	response.headers.set('X-Frame-Options', 'DENY');
+	response.headers.set('X-Permitted-Cross-Domain-Policies', 'none');
+	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+	// Content-Security-Policy is managed by SvelteKit via kit.csp in svelte.config.js,
+	// which injects per-request nonces into inline hydration scripts. Setting it here
+	// would overwrite those nonces and break page hydration.
+	if (IS_PROD) {
+		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+	}
+}
+
+export function assignRequestContext(event: RequestEvent): RequestContextState {
+	const requestIdRaw = event.request.headers.get('x-request-id');
+	const requestId =
+		requestIdRaw && UUID_REGEX.test(requestIdRaw) ? requestIdRaw : crypto.randomUUID();
+
+	event.locals.requestId = requestId;
+
+	return {
+		path: event.url.pathname,
+		requestId,
+		startTimeMs: Date.now()
+	};
+}
+
+export function finalizeResponse(
+	event: RequestEvent,
+	response: Response,
+	context: RequestContextState
+): Response {
+	if (!context.path.startsWith('/metrics')) {
+		const duration = (Date.now() - context.startTimeMs) / 1000;
+		const routeTemplate = event.route?.id || context.path;
+		httpRequestDurationMicroseconds
+			.labels(event.request.method, routeTemplate, response.status.toString())
+			.observe(duration);
+	}
+
+	response.headers.set('x-request-id', context.requestId);
+	setSecurityHeaders(response);
+	return response;
+}

--- a/src/lib/server/request/csrf.ts
+++ b/src/lib/server/request/csrf.ts
@@ -1,0 +1,69 @@
+import { validateCsrfToken } from '$lib/server/csrf.js';
+import { logger } from '$lib/server/logger.js';
+import { isPublicRoute } from '$lib/isPublicRoute.js';
+import { STATE_CHANGING_METHODS, isPayloadTooLargeError } from './request-size.js';
+import type { RequestEvent } from '@sveltejs/kit';
+
+export async function enforceCsrfProtection(
+	event: Pick<RequestEvent, 'locals' | 'request' | 'url'>
+): Promise<Response | null> {
+	const path = event.url.pathname;
+	if (
+		!event.locals.session ||
+		!STATE_CHANGING_METHODS.includes(event.request.method) ||
+		isPublicRoute(path)
+	) {
+		return null;
+	}
+
+	// Header first; fall back to form body for use:enhance forms that still
+	// submit _csrf as a hidden field until they are migrated to the header.
+	// Only call formData() when the header is absent and the content-type is
+	// form-compatible to avoid parsing non-form bodies or masking size errors.
+	// Clone event.request (not the original request whose body is already
+	// piped into the size-guard transform).
+	const headerToken = event.request.headers.get('x-csrf-token');
+	let csrfToken: string;
+
+	if (headerToken !== null) {
+		csrfToken = headerToken;
+	} else {
+		const contentType = event.request.headers.get('content-type') ?? '';
+		const isFormCompatible =
+			contentType.startsWith('multipart/form-data') ||
+			contentType.startsWith('application/x-www-form-urlencoded');
+
+		if (isFormCompatible) {
+			try {
+				const formData = await event.request.clone().formData();
+				const rawToken = formData.get('_csrf');
+				csrfToken = typeof rawToken === 'string' ? rawToken : '';
+			} catch (err) {
+				if (isPayloadTooLargeError(err)) {
+					throw err;
+				}
+				csrfToken = '';
+			}
+		} else {
+			csrfToken = '';
+		}
+	}
+
+	if (validateCsrfToken(event.locals.session.id, csrfToken)) {
+		return null;
+	}
+
+	logger.warn('CSRF token validation failed', {
+		userId: event.locals.user?.id,
+		method: event.request.method,
+		path
+	});
+
+	return new Response(
+		JSON.stringify({ error: 'Forbidden', message: 'Invalid or missing CSRF token' }),
+		{
+			status: 403,
+			headers: { 'Content-Type': 'application/json' }
+		}
+	);
+}

--- a/src/lib/server/request/errors.ts
+++ b/src/lib/server/request/errors.ts
@@ -1,0 +1,60 @@
+import { errorToHttpResponse } from '$lib/server/kubernetes/errors.js';
+import { logger } from '$lib/server/logger.js';
+import { normalizeError } from '$lib/utils/error-normalization.js';
+import { isHttpError, isRedirect, type RequestEvent, type ResolveOptions } from '@sveltejs/kit';
+import { createPayloadTooLargeResponse, isPayloadTooLargeError } from './request-size.js';
+
+export async function resolveRouteAndMapErrors(
+	event: RequestEvent,
+	resolve: (event: RequestEvent, opts?: ResolveOptions) => Response | Promise<Response>
+): Promise<Response> {
+	const path = event.url.pathname;
+
+	if (path.startsWith('/api/')) {
+		try {
+			return await resolve(event);
+		} catch (err) {
+			if (isPayloadTooLargeError(err)) {
+				return createPayloadTooLargeResponse(event, err);
+			}
+
+			if (isRedirect(err) || isHttpError(err)) {
+				throw err;
+			}
+
+			logger.error(err, `Unhandled error in API route ${path}:`);
+			const { status, body } = errorToHttpResponse(err);
+			return new Response(JSON.stringify(body), {
+				status,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+	}
+
+	try {
+		return await resolve(event);
+	} catch (err) {
+		if (isPayloadTooLargeError(err)) {
+			return createPayloadTooLargeResponse(event, err);
+		}
+		throw err;
+	}
+}
+
+export function normalizeHandleError({
+	error,
+	event
+}: {
+	error: unknown;
+	event: { locals?: App.Locals; url: URL };
+}) {
+	const requestId = event.locals?.requestId;
+	if (requestId) {
+		logger.error(error, `Error in ${event.url.pathname}:`, { requestId });
+	} else {
+		logger.error(error, `Error in ${event.url.pathname}:`);
+	}
+
+	const { code, status } = normalizeError(error);
+	return { message: 'An unexpected error occurred', code, status };
+}

--- a/src/lib/server/request/initialization.ts
+++ b/src/lib/server/request/initialization.ts
@@ -1,0 +1,31 @@
+import { initializeGyre } from '$lib/server/initialize.js';
+import { logger } from '$lib/server/logger.js';
+
+let initialized = false;
+let initializingPromise: Promise<void> | undefined;
+
+export async function ensureGyreInitialized(): Promise<void> {
+	if (initialized) {
+		return;
+	}
+
+	if (!initializingPromise) {
+		initializingPromise = initializeGyre()
+			.then(() => {
+				initialized = true;
+			})
+			.catch((error) => {
+				logger.error(error, 'Failed to initialize Gyre:');
+				// Continue anyway - let the request fail naturally if DB is truly broken
+			})
+			.finally(() => {
+				initializingPromise = undefined;
+			});
+	}
+
+	await initializingPromise;
+}
+
+export function isGyreInitialized(): boolean {
+	return initialized;
+}

--- a/src/lib/server/request/initialization.ts
+++ b/src/lib/server/request/initialization.ts
@@ -16,7 +16,7 @@ export async function ensureGyreInitialized(): Promise<void> {
 			})
 			.catch((error) => {
 				logger.error(error, 'Failed to initialize Gyre:');
-				// Continue anyway - let the request fail naturally if DB is truly broken
+				throw error;
 			})
 			.finally(() => {
 				initializingPromise = undefined;

--- a/src/lib/server/request/rate-limit.ts
+++ b/src/lib/server/request/rate-limit.ts
@@ -1,0 +1,43 @@
+import { tryCheckRateLimit } from '$lib/server/rate-limiter.js';
+import { STATIC_PATTERNS } from '$lib/isPublicRoute.js';
+import type { RequestEvent } from '@sveltejs/kit';
+
+export function enforceGlobalRateLimit(
+	event: Pick<RequestEvent, 'getClientAddress' | 'url'>,
+	initialized: boolean
+): Response | null {
+	const path = event.url.pathname;
+	const isStaticAsset = STATIC_PATTERNS.some((pattern) => pattern.test(path));
+	const isHealthEndpoint =
+		path === '/api/health' ||
+		path === '/api/v1/health' ||
+		path === '/api/flux/health' ||
+		path === '/api/v1/flux/health';
+
+	if (!initialized || isStaticAsset || isHealthEndpoint) {
+		return null;
+	}
+
+	const ip = event.getClientAddress();
+	// Pass a no-op setHeaders so the global limiter doesn't set X-RateLimit-* on the event —
+	// endpoint-specific limiters own those headers and SvelteKit throws if they're set twice.
+	const globalLimit = tryCheckRateLimit({ setHeaders: () => {} }, `global:${ip}`, 300, 60 * 1000);
+
+	if (!globalLimit.limited) {
+		return null;
+	}
+
+	return new Response(
+		JSON.stringify({
+			error: 'Too Many Requests',
+			message: 'Rate limit exceeded. Please try again later.'
+		}),
+		{
+			status: 429,
+			headers: {
+				'Content-Type': 'application/json',
+				'Retry-After': globalLimit.retryAfter.toString()
+			}
+		}
+	);
+}

--- a/src/lib/server/request/request-size.ts
+++ b/src/lib/server/request/request-size.ts
@@ -72,52 +72,33 @@ export async function enforceRequestSizeLimits(event: RequestEvent): Promise<Res
 	}
 
 	// Streaming size guard: catches chunked/transfer-encoded requests that omit
-	// Content-Length. The full body is piped through the transform before the
-	// handler runs so size violations are rejected immediately. Using
-	// ByteLengthQueuingStrategy lets the readable buffer up to sizeLimit bytes
-	// so pipeTo can resolve without a concurrent reader; event.request is only
-	// constructed after the guard resolves successfully.
-	// Skip pre-read when Content-Length is present — the header-based check
-	// above already enforces the limit without consuming the stream.
+	// Content-Length by wrapping the body in a transform that errors once the
+	// configured limit is exceeded. This keeps enforcement non-blocking and
+	// avoids pre-draining the request body in memory.
 	if (
 		request.body &&
 		STATE_CHANGING_METHODS.includes(request.method) &&
 		!request.headers.has('content-length')
 	) {
 		let bytesRead = 0;
-		const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>(
-			{
-				transform(chunk, controller) {
-					bytesRead += chunk.byteLength;
-					if (bytesRead > sizeLimit) {
-						controller.error(
-							Object.assign(new Error('Payload Too Large'), {
-								isPayloadTooLarge: true,
-								limit: sizeLimit,
-								size: bytesRead
-							})
-						);
-						return;
-					}
-					controller.enqueue(chunk);
+		const transformStream = new TransformStream<Uint8Array, Uint8Array>({
+			transform(chunk, controller) {
+				bytesRead += chunk.byteLength;
+				if (bytesRead > sizeLimit) {
+					controller.error(
+						Object.assign(new Error('Payload Too Large'), {
+							isPayloadTooLarge: true,
+							limit: sizeLimit,
+							size: bytesRead
+						})
+					);
+					return;
 				}
-			},
-			undefined,
-			new ByteLengthQueuingStrategy({ highWaterMark: sizeLimit })
-		);
-
-		try {
-			await request.body.pipeTo(writable);
-		} catch (err) {
-			if (isPayloadTooLargeError(err)) {
-				return createPayloadTooLargeResponse(event, err);
+				controller.enqueue(chunk);
 			}
+		});
 
-			// Any other pipe failure (client disconnect, stream abort, upstream error)
-			// leaves `readable` in an errored state. Do not hand a broken stream to
-			// downstream handlers — return a stream-failure response instead.
-			return new Response('Stream error', { status: 499 });
-		}
+		const readable = request.body.pipeThrough(transformStream);
 
 		event.request = new Request(request, {
 			body: readable,

--- a/src/lib/server/request/request-size.ts
+++ b/src/lib/server/request/request-size.ts
@@ -1,0 +1,129 @@
+import { logger } from '$lib/server/logger.js';
+import {
+	formatSize,
+	getRequestSizeLimit,
+	validateRequestSize
+} from '$lib/server/request-limits.js';
+import type { RequestEvent } from '@sveltejs/kit';
+
+export const STATE_CHANGING_METHODS = ['POST', 'PUT', 'DELETE', 'PATCH'];
+
+export type PayloadTooLargeError = Error & {
+	isPayloadTooLarge: true;
+	limit: number;
+	size: number;
+};
+
+export function isPayloadTooLargeError(err: unknown): err is PayloadTooLargeError {
+	if (typeof err !== 'object' || err === null) return false;
+	const candidate = err as Record<string, unknown>;
+	return (
+		candidate.isPayloadTooLarge === true &&
+		typeof candidate.size === 'number' &&
+		typeof candidate.limit === 'number'
+	);
+}
+
+export function createPayloadTooLargeResponse(
+	event: Pick<RequestEvent, 'request' | 'url'>,
+	err: { limit: number; size: number }
+): Response {
+	const path = event.url.pathname;
+
+	logger.warn(
+		{ method: event.request.method, path, size: err.size, limit: err.limit },
+		'Request size exceeded limit'
+	);
+
+	if (path.startsWith('/api/')) {
+		return new Response(
+			JSON.stringify({
+				error: 'Payload Too Large',
+				message: `Request payload exceeds maximum size of ${formatSize(err.limit)}`
+			}),
+			{
+				status: 413,
+				headers: { 'Content-Type': 'application/json' }
+			}
+		);
+	}
+
+	const redirectParams = new URLSearchParams(event.url.search);
+	redirectParams.set('_error', 'payload_too_large');
+
+	return new Response(null, {
+		status: 303,
+		headers: { Location: `${path}?${redirectParams}` }
+	});
+}
+
+export async function enforceRequestSizeLimits(event: RequestEvent): Promise<Response | null> {
+	const { request } = event;
+	const path = event.url.pathname;
+	const sizeLimit = getRequestSizeLimit(path, request.method);
+	const contentLength = request.headers.get('content-length') ?? undefined;
+	const sizeValidation = validateRequestSize(contentLength, sizeLimit, request.method);
+
+	if (!sizeValidation.valid) {
+		return createPayloadTooLargeResponse(event, {
+			size: sizeValidation.size,
+			limit: sizeValidation.limit
+		});
+	}
+
+	// Streaming size guard: catches chunked/transfer-encoded requests that omit
+	// Content-Length. The full body is piped through the transform before the
+	// handler runs so size violations are rejected immediately. Using
+	// ByteLengthQueuingStrategy lets the readable buffer up to sizeLimit bytes
+	// so pipeTo can resolve without a concurrent reader; event.request is only
+	// constructed after the guard resolves successfully.
+	// Skip pre-read when Content-Length is present — the header-based check
+	// above already enforces the limit without consuming the stream.
+	if (
+		request.body &&
+		STATE_CHANGING_METHODS.includes(request.method) &&
+		!request.headers.has('content-length')
+	) {
+		let bytesRead = 0;
+		const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>(
+			{
+				transform(chunk, controller) {
+					bytesRead += chunk.byteLength;
+					if (bytesRead > sizeLimit) {
+						controller.error(
+							Object.assign(new Error('Payload Too Large'), {
+								isPayloadTooLarge: true,
+								limit: sizeLimit,
+								size: bytesRead
+							})
+						);
+						return;
+					}
+					controller.enqueue(chunk);
+				}
+			},
+			undefined,
+			new ByteLengthQueuingStrategy({ highWaterMark: sizeLimit })
+		);
+
+		try {
+			await request.body.pipeTo(writable);
+		} catch (err) {
+			if (isPayloadTooLargeError(err)) {
+				return createPayloadTooLargeResponse(event, err);
+			}
+
+			// Any other pipe failure (client disconnect, stream abort, upstream error)
+			// leaves `readable` in an errored state. Do not hand a broken stream to
+			// downstream handlers — return a stream-failure response instead.
+			return new Response('Stream error', { status: 499 });
+		}
+
+		event.request = new Request(request, {
+			body: readable,
+			duplex: 'half'
+		} as RequestInit);
+	}
+
+	return null;
+}

--- a/src/lib/server/request/session.ts
+++ b/src/lib/server/request/session.ts
@@ -1,0 +1,33 @@
+import {
+	BETTER_AUTH_SESSION_COOKIE_NAME,
+	getBetterAuthSession
+} from '$lib/server/auth/better-auth.js';
+import { CSRF_COOKIE_OPTIONS } from '$lib/server/config.js';
+import { generateCsrfToken } from '$lib/server/csrf.js';
+import type { RequestEvent } from '@sveltejs/kit';
+
+export async function hydrateSessionLocals(
+	event: Pick<RequestEvent, 'cookies' | 'locals' | 'request'>
+): Promise<void> {
+	event.locals.user = null;
+	event.locals.session = null;
+	event.locals.cluster = undefined;
+
+	if (!event.cookies.get(BETTER_AUTH_SESSION_COOKIE_NAME)) {
+		return;
+	}
+
+	const sessionData = await getBetterAuthSession(event.request, event.cookies);
+	if (!sessionData) {
+		event.cookies.delete(BETTER_AUTH_SESSION_COOKIE_NAME, { path: '/' });
+		return;
+	}
+
+	event.locals.user = sessionData.user;
+	event.locals.session = sessionData.session;
+
+	const csrfToken = generateCsrfToken(sessionData.session.id);
+	if (event.cookies.get('gyre_csrf') !== csrfToken) {
+		event.cookies.set('gyre_csrf', csrfToken, CSRF_COOKIE_OPTIONS);
+	}
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -20,11 +20,11 @@ function isHttpErrorLike(error: unknown): error is { status: number } {
 export const load: LayoutServerLoad = async ({ locals, depends }) => {
 	depends('gyre:layout');
 
-	let health = {
-		connected: false,
-		clusterName: undefined as string | undefined,
-		availableClusters: [] as string[],
-		error: undefined as string | undefined
+	let health: {
+		connected: boolean;
+		clusterName?: string;
+		availableClusters: string[];
+		error?: string;
 	};
 
 	try {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,53 +1,71 @@
 import type { LayoutServerLoad } from './$types';
 import pkg from '../../package.json';
 import { serializeUser } from '$lib/server/auth';
-import { logger } from '$lib/server/logger.js';
-import { fetchWithRetry } from '$lib/utils/fetch';
+import {
+	DEFAULT_FLUX_VERSION,
+	getFluxHealthSummary,
+	getFluxInstalledVersion
+} from '$lib/server/flux/services.js';
+import { requireClusterWideRead } from '$lib/server/http/guards.js';
 
-const DEFAULT_FLUX_VERSION = 'v2.x.x';
+function isHttpErrorLike(error: unknown): error is { status: number } {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'status' in error &&
+		typeof (error as { status: unknown }).status === 'number'
+	);
+}
 
-export const load: LayoutServerLoad = async ({ fetch: svelteFetch, locals, depends }) => {
+export const load: LayoutServerLoad = async ({ locals, depends }) => {
 	depends('gyre:layout');
+
+	let health = {
+		connected: false,
+		clusterName: undefined as string | undefined,
+		availableClusters: [] as string[],
+		error: undefined as string | undefined
+	};
+
 	try {
-		const [healthRes, versionRes] = await Promise.all([
-			fetchWithRetry('/api/v1/flux/health', undefined, {
-				fetchFn: svelteFetch,
-				maxRetries: 0,
-				logger
-			}),
-			fetchWithRetry('/api/v1/flux/version', undefined, {
-				fetchFn: svelteFetch,
-				maxRetries: 0,
-				logger
-			})
-		]);
+		const healthData = await getFluxHealthSummary({
+			locals,
+			includeDetails: Boolean(locals.user)
+		});
 
-		const healthData = healthRes.ok ? await healthRes.json() : null;
-		const versionData = versionRes.ok ? await versionRes.json() : { version: DEFAULT_FLUX_VERSION };
-
-		return {
-			health: {
-				connected: healthData?.kubernetes?.connected ?? false,
-				clusterName: healthData?.kubernetes?.currentContext ?? undefined,
-				availableClusters: healthData?.kubernetes?.availableContexts ?? [],
-				error: healthRes.ok ? undefined : 'Failed to retrieve cluster health status'
-			},
-			fluxVersion: versionData.version,
-			gyreVersion: pkg.version,
-			user: serializeUser(locals.user)
+		health = {
+			connected: healthData.kubernetes?.connected ?? false,
+			clusterName: healthData.kubernetes?.currentContext ?? undefined,
+			availableClusters: healthData.kubernetes?.availableContexts ?? [],
+			error: undefined
 		};
 	} catch (error) {
-		// Surface cluster connection error in health.error side-channel
-		return {
-			health: {
-				connected: false,
-				clusterName: undefined,
-				availableClusters: [],
-				error: error instanceof Error ? error.message : 'Failed to connect to cluster API'
-			},
-			fluxVersion: DEFAULT_FLUX_VERSION,
-			gyreVersion: pkg.version,
-			user: serializeUser(locals.user)
+		health = {
+			connected: false,
+			clusterName: undefined,
+			availableClusters: [],
+			error: isHttpErrorLike(error)
+				? 'Failed to retrieve cluster health status'
+				: error instanceof Error
+					? error.message
+					: 'Failed to connect to cluster API'
 		};
 	}
+
+	let fluxVersion = DEFAULT_FLUX_VERSION;
+	if (locals.user) {
+		try {
+			await requireClusterWideRead(locals);
+			fluxVersion = (await getFluxInstalledVersion({ locals })).version;
+		} catch {
+			fluxVersion = DEFAULT_FLUX_VERSION;
+		}
+	}
+
+	return {
+		health,
+		fluxVersion,
+		gyreVersion: pkg.version,
+		user: serializeUser(locals.user)
+	};
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -8,6 +8,7 @@ import { requireClusterWideRead } from '$lib/server/http/guards.js';
 export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 	// Get health data from parent layout
 	const parentData = await parent();
+	const requestedCluster = locals.cluster ?? '__NO_CLUSTER_SELECTED__';
 
 	// Function to fetch data (can be returned as a promise to be streamed)
 	const fetchGroupCounts = async () => {
@@ -20,8 +21,8 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 			>;
 		}
 
-		// Create cache key based on cluster
-		const cacheKey = `dashboard-${parentData.health?.clusterName || 'default'}`;
+		// Create cache key based on the requested cluster identifier, not health metadata.
+		const cacheKey = `dashboard-${requestedCluster}`;
 		const cached = getDashboardCache(cacheKey);
 
 		// Return cached data if still valid

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -5,6 +5,12 @@ import { getDashboardCache, setDashboardCache } from '$lib/server/dashboard-cach
 import { getFluxOverviewSummary } from '$lib/server/flux/services.js';
 import { requireClusterWideRead } from '$lib/server/http/guards.js';
 
+type GroupCounts = Record<
+	string,
+	{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
+>;
+const EMPTY_GROUP_COUNTS: GroupCounts = {};
+
 export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 	// Get health data from parent layout
 	const parentData = await parent();
@@ -15,10 +21,7 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 		try {
 			await requireClusterWideRead(locals);
 		} catch {
-			return {} as Record<
-				string,
-				{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
-			>;
+			return EMPTY_GROUP_COUNTS;
 		}
 
 		// Create cache key based on the requested cluster identifier, not health metadata.
@@ -27,20 +30,14 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 
 		// Return cached data if still valid
 		if (cached !== null) {
-			return cached as Record<
-				string,
-				{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
-			>;
+			return cached as GroupCounts;
 		}
 
 		let overviewData;
 		try {
 			overviewData = await getFluxOverviewSummary({ locals });
 		} catch {
-			return {} as Record<
-				string,
-				{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
-			>;
+			return EMPTY_GROUP_COUNTS;
 		}
 
 		const results = overviewData.results || [];
@@ -49,10 +46,7 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 		const successfulTypes = new Set(results.map((r: { type: string }) => r.type));
 
 		// Map overview results back to resourceGroups structure
-		const groupCounts: Record<
-			string,
-			{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
-		> = {};
+		const groupCounts: GroupCounts = {};
 
 		for (const group of resourceGroups) {
 			let groupTotal = 0;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,11 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { resourceGroups } from '$lib/config/resources';
-import { logger } from '$lib/server/logger.js';
-import { fetchWithRetry } from '$lib/utils/fetch';
 import { DASHBOARD_CACHE_TTL_MS } from '$lib/server/config/constants';
 import { getDashboardCache, setDashboardCache } from '$lib/server/dashboard-cache';
+import { getFluxOverviewSummary } from '$lib/server/flux/services.js';
+import { requireClusterWideRead } from '$lib/server/http/guards.js';
 
-export const load: PageServerLoad = async ({ fetch: svelteFetch, parent, setHeaders }) => {
+export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 	// Get health data from parent layout
 	const parentData = await parent();
 
@@ -23,19 +23,25 @@ export const load: PageServerLoad = async ({ fetch: svelteFetch, parent, setHead
 			>;
 		}
 
-		// Fetch batched overview results
-		const response = await fetchWithRetry('/api/v1/flux/overview', undefined, {
-			fetchFn: svelteFetch,
-			logger
-		});
-		if (!response.ok) {
+		try {
+			await requireClusterWideRead(locals);
+		} catch {
 			return {} as Record<
 				string,
 				{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
 			>;
 		}
 
-		const overviewData = await response.json();
+		let overviewData;
+		try {
+			overviewData = await getFluxOverviewSummary({ locals });
+		} catch {
+			return {} as Record<
+				string,
+				{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
+			>;
+		}
+
 		const results = overviewData.results || [];
 
 		// Build set of resource types that succeeded (absent types errored)

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -11,6 +11,15 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 
 	// Function to fetch data (can be returned as a promise to be streamed)
 	const fetchGroupCounts = async () => {
+		try {
+			await requireClusterWideRead(locals);
+		} catch {
+			return {} as Record<
+				string,
+				{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
+			>;
+		}
+
 		// Create cache key based on cluster
 		const cacheKey = `dashboard-${parentData.health?.clusterName || 'default'}`;
 		const cached = getDashboardCache(cacheKey);
@@ -18,15 +27,6 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 		// Return cached data if still valid
 		if (cached !== null) {
 			return cached as Record<
-				string,
-				{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
-			>;
-		}
-
-		try {
-			await requireClusterWideRead(locals);
-		} catch {
-			return {} as Record<
 				string,
 				{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
 			>;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,15 +1,64 @@
 import type { PageServerLoad } from './$types';
+import { isHttpError } from '@sveltejs/kit';
 import { resourceGroups } from '$lib/config/resources';
 import { DASHBOARD_CACHE_TTL_MS } from '$lib/server/config/constants';
 import { getDashboardCache, setDashboardCache } from '$lib/server/dashboard-cache';
 import { getFluxOverviewSummary } from '$lib/server/flux/services.js';
 import { requireClusterWideRead } from '$lib/server/http/guards.js';
+import { AuthorizationError } from '$lib/server/kubernetes/errors.js';
+import { RbacError } from '$lib/server/rbac.js';
 
 type GroupCounts = Record<
 	string,
 	{ total: number; healthy: number; failed: number; suspended: number; error: boolean }
 >;
 const EMPTY_GROUP_COUNTS: GroupCounts = {};
+type GroupCountValue = GroupCounts[string];
+type OverviewResult = {
+	type: string;
+	total: number;
+	healthy: number;
+	failed: number;
+	suspended: number;
+};
+
+function parseHttpStatus(value: unknown): number | null {
+	if (typeof value === 'number') {
+		return value;
+	}
+	if (typeof value === 'string' && /^\d+$/.test(value)) {
+		return Number(value);
+	}
+	return null;
+}
+
+function isPermissionErrorLike(error: unknown): boolean {
+	if (isHttpError(error)) {
+		return error.status === 401 || error.status === 403;
+	}
+	if (error instanceof RbacError || error instanceof AuthorizationError) {
+		return true;
+	}
+
+	if (typeof error !== 'object' || error === null) {
+		return false;
+	}
+
+	const candidate = error as { code?: unknown; name?: unknown; status?: unknown };
+	const statusCode = parseHttpStatus(candidate.status) ?? parseHttpStatus(candidate.code);
+	if (statusCode === 401 || statusCode === 403) {
+		return true;
+	}
+
+	if (typeof candidate.code === 'string') {
+		const normalizedCode = candidate.code.toLowerCase();
+		if (normalizedCode === 'forbidden' || normalizedCode === 'unauthorized') {
+			return true;
+		}
+	}
+
+	return candidate.name === 'AuthorizationError' || candidate.name === 'RbacError';
+}
 
 export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 	// Get health data from parent layout
@@ -20,7 +69,10 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 	const fetchGroupCounts = async () => {
 		try {
 			await requireClusterWideRead(locals);
-		} catch {
+		} catch (error) {
+			if (!isPermissionErrorLike(error)) {
+				throw error;
+			}
 			return EMPTY_GROUP_COUNTS;
 		}
 
@@ -36,14 +88,36 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 		let overviewData;
 		try {
 			overviewData = await getFluxOverviewSummary({ locals });
-		} catch {
+		} catch (error) {
+			if (!isPermissionErrorLike(error)) {
+				throw error;
+			}
 			return EMPTY_GROUP_COUNTS;
 		}
 
-		const results = overviewData.results || [];
+		const overviewResults = (overviewData.results ?? []) as OverviewResult[];
+		const countsByKind = new Map<string, Omit<GroupCountValue, 'error'>>();
+
+		for (const result of overviewResults) {
+			const existing = countsByKind.get(result.type);
+			if (existing) {
+				existing.total += result.total;
+				existing.healthy += result.healthy;
+				existing.failed += result.failed;
+				existing.suspended += result.suspended;
+				continue;
+			}
+
+			countsByKind.set(result.type, {
+				total: result.total,
+				healthy: result.healthy,
+				failed: result.failed,
+				suspended: result.suspended
+			});
+		}
 
 		// Build set of resource types that succeeded (absent types errored)
-		const successfulTypes = new Set(results.map((r: { type: string }) => r.type));
+		const successfulTypes = new Set(countsByKind.keys());
 
 		// Map overview results back to resourceGroups structure
 		const groupCounts: GroupCounts = {};
@@ -55,15 +129,7 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 			let groupSuspended = 0;
 
 			for (const resInfo of group.resources) {
-				const resResult = results.find(
-					(r: {
-						type: string;
-						total: number;
-						healthy: number;
-						failed: number;
-						suspended: number;
-					}) => r.type === resInfo.kind
-				);
+				const resResult = countsByKind.get(resInfo.kind);
 				if (resResult) {
 					groupTotal += resResult.total;
 					groupHealthy += resResult.healthy;

--- a/src/routes/api/v1/flux/[resourceType]/+server.ts
+++ b/src/routes/api/v1/flux/[resourceType]/+server.ts
@@ -3,7 +3,6 @@ import { z } from '$lib/server/openapi';
 import { k8sFluxResourceSchema } from '$lib/server/kubernetes/schemas';
 import type { RequestHandler } from './$types';
 import {
-	listFluxResources,
 	createFluxResource,
 	type ReqCache,
 	type ListOptions
@@ -11,13 +10,22 @@ import {
 import {
 	getAllResourcePlurals,
 	getResourceDef,
-	getResourceTypeByPlural,
-	type FluxResourceType
+	getResourceTypeByPlural
 } from '$lib/server/kubernetes/flux/resources.js';
 import { handleApiError } from '$lib/server/kubernetes/errors.js';
-import { checkClusterWideReadPermission, checkPermission } from '$lib/server/rbac.js';
+import {
+	requireAuthenticatedUser,
+	requireClusterWideRead,
+	requireScopedPermission
+} from '$lib/server/http/guards.js';
 import { validateK8sNamespace, validateFluxResourceSpec } from '$lib/server/validation';
 import { VALID_SORT_BY, VALID_SORT_ORDER } from '$lib/config/sorting';
+import {
+	computeWeakEtag,
+	respondNotModified,
+	setPrivateCacheHeaders
+} from '$lib/server/http/transport.js';
+import { listFluxResourcesForType } from '$lib/server/flux/services.js';
 
 /** Zod schema for POST create FluxCD resource request body – used for OpenAPI and runtime validation */
 const createFluxResourceBodySchema = z.looseObject({
@@ -128,23 +136,9 @@ const listQuerySchema = _metadata.GET.request.query;
  */
 
 export const GET: RequestHandler = async ({ params, locals, setHeaders, request, url }) => {
-	// Check authentication
-	if (!locals.user) {
-		throw error(401, { message: 'Authentication required' });
-	}
+	requireAuthenticatedUser(locals);
 
 	const { resourceType } = params;
-
-	// Try to resolve resource type from plural name first (e.g., 'gitrepositories' -> 'GitRepository')
-	const resolvedType: FluxResourceType | undefined = getResourceTypeByPlural(resourceType);
-
-	// If not found by plural, check if it's already a valid PascalCase type
-	if (!resolvedType) {
-		const validPlurals = getAllResourcePlurals();
-		throw error(400, {
-			message: `Invalid resource type: ${resourceType}. Valid types: ${validPlurals.join(', ')}`
-		});
-	}
 
 	// Parse and validate query parameters
 	const queryResult = listQuerySchema.safeParse({
@@ -162,39 +156,26 @@ export const GET: RequestHandler = async ({ params, locals, setHeaders, request,
 	}
 
 	const listOptions: ListOptions = queryResult.data;
+	await requireClusterWideRead(locals);
 
-	// Check permission (all namespaces requires explicit cluster-wide policy)
-	const hasPermission = await checkClusterWideReadPermission(locals.user, locals.cluster);
+	const { result } = await listFluxResourcesForType({
+		locals,
+		query: listOptions,
+		resourceType
+	});
 
-	if (!hasPermission) {
-		throw error(403, { message: 'Permission denied' });
+	const etag = computeWeakEtag(result.metadata?.resourceVersion);
+	const notModified = respondNotModified(request, etag);
+	if (notModified) {
+		return notModified;
 	}
 
-	const reqCache: ReqCache = new Map();
-
-	try {
-		const result = await listFluxResources(resolvedType, locals.cluster, reqCache, listOptions);
-
-		// Generate ETag from resourceVersion
-		const resourceVersion = result.metadata?.resourceVersion;
-		const etag = resourceVersion ? `W/"${resourceVersion}"` : null;
-
-		if (etag) {
-			const ifNoneMatch = request.headers.get('if-none-match');
-			if (ifNoneMatch === etag) {
-				return new Response(null, { status: 304 });
-			}
-			setHeaders({ ETag: etag });
-		}
-
-		setHeaders({
-			'Cache-Control': 'private, max-age=15, stale-while-revalidate=45'
-		});
-
-		return json(result);
-	} catch (err) {
-		handleApiError(err, `Error listing ${resolvedType} resources`);
+	if (etag) {
+		setHeaders({ ETag: etag });
 	}
+
+	setPrivateCacheHeaders(setHeaders, 'private, max-age=15, stale-while-revalidate=45');
+	return json(result);
 };
 
 /**
@@ -202,10 +183,7 @@ export const GET: RequestHandler = async ({ params, locals, setHeaders, request,
  * Create a new resource
  */
 export const POST: RequestHandler = async ({ params, locals, request }) => {
-	// Check authentication
-	if (!locals.user) {
-		throw error(401, { message: 'Authentication required' });
-	}
+	requireAuthenticatedUser(locals);
 
 	const { resourceType } = params;
 
@@ -241,18 +219,7 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
 		});
 	}
 
-	// Check permission
-	const hasPermission = await checkPermission(
-		locals.user,
-		'write',
-		resolvedType,
-		namespace,
-		locals.cluster
-	);
-
-	if (!hasPermission) {
-		throw error(403, { message: 'Permission denied' });
-	}
+	await requireScopedPermission(locals, 'write', resolvedType, namespace);
 
 	if (body.kind !== resolvedType) {
 		throw error(400, {

--- a/src/routes/api/v1/flux/[resourceType]/[namespace]/[name]/+server.ts
+++ b/src/routes/api/v1/flux/[resourceType]/[namespace]/[name]/+server.ts
@@ -2,12 +2,7 @@ import { logger } from '$lib/server/logger.js';
 import { json, error } from '@sveltejs/kit';
 import { z } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
-import {
-	getFluxResource,
-	getFluxResourceStatus,
-	updateFluxResource,
-	type ReqCache
-} from '$lib/server/kubernetes/client.js';
+import { updateFluxResource, type ReqCache } from '$lib/server/kubernetes/client.js';
 import {
 	getAllResourcePlurals,
 	getResourceDef,
@@ -15,7 +10,6 @@ import {
 	type FluxResourceType
 } from '$lib/server/kubernetes/flux/resources.js';
 import { handleApiError, sanitizeK8sErrorMessage } from '$lib/server/kubernetes/errors.js';
-import { checkPermission } from '$lib/server/rbac.js';
 import { logAudit } from '$lib/server/audit.js';
 import { deleteResource } from '$lib/server/kubernetes/flux/actions.js';
 import type { K8sResource } from '$lib/types/kubernetes';
@@ -25,6 +19,18 @@ import {
 	validateK8sName,
 	validateFluxResourceSpec
 } from '$lib/server/validation';
+import {
+	requireAdminPermission,
+	requireAuthenticatedUser,
+	requireClusterContext,
+	requireScopedPermission
+} from '$lib/server/http/guards.js';
+import {
+	computeWeakEtag,
+	respondNotModified,
+	setPrivateCacheHeaders
+} from '$lib/server/http/transport.js';
+import { getFluxResourceDetail } from '$lib/server/flux/services.js';
 
 export const _metadata = {
 	GET: {
@@ -124,15 +130,8 @@ export const _metadata = {
  * - status=true: Get resource status instead of full object
  */
 export const GET: RequestHandler = async ({ params, url, locals, request, setHeaders }) => {
-	// Check authentication
-	if (!locals.user) {
-		throw error(401, { message: 'Authentication required' });
-	}
-
-	// Check cluster context
-	if (!locals.cluster) {
-		throw error(400, { message: 'Cluster context required' });
-	}
+	requireAuthenticatedUser(locals);
+	requireClusterContext(locals);
 
 	const { resourceType, namespace, name } = params;
 	const getStatus = url.searchParams.get('status') === 'true';
@@ -149,47 +148,28 @@ export const GET: RequestHandler = async ({ params, url, locals, request, setHea
 		});
 	}
 
-	// Check permission for specific namespace
-	const hasPermission = await checkPermission(
-		locals.user,
-		'read',
-		resolvedType,
+	await requireScopedPermission(locals, 'read', resolvedType, namespace);
+
+	const { resource } = await getFluxResourceDetail({
+		locals,
+		name,
 		namespace,
-		locals.cluster
-	);
+		resourceType,
+		statusOnly: getStatus
+	});
 
-	if (!hasPermission) {
-		throw error(403, { message: 'Permission denied' });
+	const etag = computeWeakEtag(resource.metadata?.resourceVersion);
+	const notModified = respondNotModified(request, etag);
+	if (notModified) {
+		return notModified;
 	}
 
-	const reqCache: ReqCache = new Map();
-
-	try {
-		const resource = getStatus
-			? await getFluxResourceStatus(resolvedType, namespace, name, locals.cluster, reqCache)
-			: await getFluxResource(resolvedType, namespace, name, locals.cluster, reqCache);
-
-		// Generate ETag from resourceVersion if available
-		const resourceVersion = resource.metadata?.resourceVersion;
-		if (resourceVersion) {
-			const etag = `W/"${resourceVersion}"`;
-
-			// Check If-None-Match header
-			const ifNoneMatch = request.headers.get('if-none-match');
-			if (ifNoneMatch === etag) {
-				return new Response(null, { status: 304 });
-			}
-
-			setHeaders({
-				ETag: etag,
-				'Cache-Control': 'private, max-age=10, stale-while-revalidate=30'
-			});
-		}
-
-		return json(resource);
-	} catch (err) {
-		throw handleApiError(err, `Error fetching ${resolvedType} ${namespace}/${name}`);
+	if (etag) {
+		setHeaders({ ETag: etag });
+		setPrivateCacheHeaders(setHeaders, 'private, max-age=10, stale-while-revalidate=30');
 	}
+
+	return json(resource);
 };
 
 /**
@@ -199,15 +179,8 @@ export const GET: RequestHandler = async ({ params, url, locals, request, setHea
  * Body: { yaml: string } - The updated resource YAML
  */
 export const PUT: RequestHandler = async ({ params, request, locals }) => {
-	// Check authentication
-	if (!locals.user) {
-		throw error(401, { message: 'Authentication required' });
-	}
-
-	// Check cluster context
-	if (!locals.cluster) {
-		throw error(400, { message: 'Cluster context required' });
-	}
+	requireAuthenticatedUser(locals);
+	requireClusterContext(locals);
 
 	const { resourceType, namespace, name } = params;
 
@@ -223,18 +196,7 @@ export const PUT: RequestHandler = async ({ params, request, locals }) => {
 		});
 	}
 
-	// Check permission for specific namespace
-	const hasPermission = await checkPermission(
-		locals.user,
-		'write',
-		resolvedType,
-		namespace,
-		locals.cluster
-	);
-
-	if (!hasPermission) {
-		throw error(403, { message: 'Permission denied' });
-	}
+	await requireScopedPermission(locals, 'write', resolvedType, namespace);
 
 	// Parse request body
 	let body: { yaml?: unknown };
@@ -327,15 +289,8 @@ export const PUT: RequestHandler = async ({ params, request, locals }) => {
  * Delete a specific resource
  */
 export const DELETE: RequestHandler = async ({ params, locals, getClientAddress }) => {
-	// Check authentication
-	if (!locals.user) {
-		throw error(401, { message: 'Authentication required' });
-	}
-
-	// Check cluster context
-	if (!locals.cluster) {
-		throw error(400, { message: 'Cluster context required' });
-	}
+	const user = requireAuthenticatedUser(locals);
+	const clusterId = requireClusterContext(locals);
 
 	const { resourceType, namespace, name } = params;
 
@@ -351,38 +306,32 @@ export const DELETE: RequestHandler = async ({ params, locals, getClientAddress 
 		});
 	}
 
-	// Check permission for admin action (delete requires admin, not just write)
-	const hasPermission = await checkPermission(
-		locals.user,
-		'admin',
-		resolvedType,
-		namespace,
-		locals.cluster
-	);
-
-	if (!hasPermission) {
-		logAudit(locals.user, 'admin:delete', {
+	try {
+		await requireAdminPermission(locals, resolvedType, namespace);
+	} catch (err) {
+		logAudit(user, 'admin:delete', {
 			resourceType: resolvedType,
 			resourceName: name,
 			namespace,
-			clusterId: locals.cluster,
+			clusterId,
 			ipAddress: getClientAddress(),
 			success: false,
 			details: { error: 'Permission denied' }
 		}).catch((auditErr) => {
 			logger.error(auditErr, 'Failed to log audit event for denied delete:');
 		});
-		throw error(403, { message: 'Permission denied' });
+
+		throw err;
 	}
 
 	try {
-		await deleteResource(resolvedType, namespace, name, locals.cluster);
+		await deleteResource(resolvedType, namespace, name, clusterId);
 
-		logAudit(locals.user, 'admin:delete', {
+		logAudit(user, 'admin:delete', {
 			resourceType: resolvedType,
 			resourceName: name,
 			namespace,
-			clusterId: locals.cluster,
+			clusterId,
 			ipAddress: getClientAddress(),
 			success: true
 		}).catch((auditErr) => {
@@ -392,11 +341,11 @@ export const DELETE: RequestHandler = async ({ params, locals, getClientAddress 
 		return new Response(null, { status: 204 });
 	} catch (err) {
 		try {
-			await logAudit(locals.user, 'admin:delete', {
+			await logAudit(user, 'admin:delete', {
 				resourceType: resolvedType,
 				resourceName: name,
 				namespace,
-				clusterId: locals.cluster,
+				clusterId,
 				ipAddress: getClientAddress(),
 				success: false,
 				details: {

--- a/src/routes/api/v1/flux/health/+server.ts
+++ b/src/routes/api/v1/flux/health/+server.ts
@@ -1,9 +1,9 @@
-import { json, error } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import { z } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
-import { getKubeConfig, getPoolMetrics } from '$lib/server/kubernetes/client.js';
-import { validateKubeConfig } from '$lib/server/kubernetes/config.js';
 import { handleApiError } from '$lib/server/kubernetes/errors.js';
+import { getFluxHealthSummary } from '$lib/server/flux/services.js';
+import { setPrivateCacheHeaders } from '$lib/server/http/transport.js';
 
 export const _metadata = {
 	GET: {
@@ -50,81 +50,20 @@ export const _metadata = {
 		}
 	}
 };
-const MAX_CONNECTION_CACHE_SIZE = 20;
-
-// Cache for connection status per cluster
-const connectionCache = new Map<string, { connected: boolean; timestamp: number }>();
-const CONNECTION_CACHE_TTL = 30 * 1000; // 30 seconds
-
-function pruneConnectionCache() {
-	const now = Date.now();
-	for (const [key, value] of connectionCache.entries()) {
-		if (now - value.timestamp > CONNECTION_CACHE_TTL * 10) {
-			connectionCache.delete(key);
-		}
-	}
-	if (connectionCache.size > MAX_CONNECTION_CACHE_SIZE) {
-		const sorted = [...connectionCache.entries()].sort((a, b) => a[1].timestamp - b[1].timestamp);
-		sorted
-			.slice(0, connectionCache.size - MAX_CONNECTION_CACHE_SIZE)
-			.forEach(([k]) => connectionCache.delete(k));
-	}
-}
-
 /**
  * GET /api/flux/health
  * Health check endpoint that validates K8s connection
  */
 export const GET: RequestHandler = async ({ setHeaders, locals }) => {
 	try {
-		// Get the current cluster from locals (for multi-cluster support)
-		const selectedCluster = locals.cluster;
-		const config = await getKubeConfig(selectedCluster);
-		const currentContext = config.getCurrentContext();
-
-		const cacheKey = selectedCluster || 'default';
-		const cached = connectionCache.get(cacheKey) || { connected: false, timestamp: 0 };
-
-		// Check connection - use cache if recent, otherwise validate
-		let isValid = false;
-		if (Date.now() - cached.timestamp < CONNECTION_CACHE_TTL) {
-			isValid = cached.connected;
-		} else {
-			isValid = await validateKubeConfig(config);
-			pruneConnectionCache();
-			connectionCache.set(cacheKey, { connected: isValid, timestamp: Date.now() });
-		}
-
-		if (!isValid) {
-			throw error(503, {
-				message: 'Unable to connect to Kubernetes cluster'
-			});
-		}
-
-		// If not authenticated, return only basic status to prevent information leakage.
-		// Detailed cluster information is restricted to authenticated users.
-		if (!locals.user) {
-			return json({ status: 'healthy' });
-		}
-
-		// Detect mode
-		const isInCluster = !!process.env.KUBERNETES_SERVICE_HOST;
-
-		const responseData = {
-			status: 'healthy',
-			kubernetes: {
-				connected: true,
-				configStrategy: isInCluster ? 'in-cluster' : 'local-kubeconfig',
-				configSource: isInCluster ? 'ServiceAccount' : 'kubeconfig',
-				currentContext,
-				availableContexts: config.getContexts().map((c) => c.name),
-				connectionPool: getPoolMetrics()
-			}
-		};
-
-		setHeaders({
-			'Cache-Control': 'private, max-age=30'
+		const responseData = await getFluxHealthSummary({
+			locals,
+			includeDetails: Boolean(locals.user)
 		});
+
+		if (locals.user) {
+			setPrivateCacheHeaders(setHeaders, 'private, max-age=30');
+		}
 
 		return json(responseData);
 	} catch (err) {

--- a/src/routes/api/v1/flux/overview/+server.ts
+++ b/src/routes/api/v1/flux/overview/+server.ts
@@ -1,11 +1,9 @@
-import { json, error } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import { z } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
-import { listFluxResources, type ReqCache } from '$lib/server/kubernetes/client';
-import { getAllResourceTypes } from '$lib/server/kubernetes/flux/resources';
-import { getResourceStatus } from '$lib/utils/relationships';
-import { checkClusterWideReadPermission } from '$lib/server/rbac.js';
-import { logger } from '$lib/server/logger.js';
+import { getFluxOverviewSummary } from '$lib/server/flux/services.js';
+import { requireClusterWideRead } from '$lib/server/http/guards.js';
+import { setPrivateCacheHeaders } from '$lib/server/http/transport.js';
 
 export const _metadata = {
 	GET: {
@@ -41,58 +39,7 @@ export const _metadata = {
 };
 
 export const GET: RequestHandler = async ({ locals, setHeaders }) => {
-	// Check authentication
-	if (!locals.user) {
-		throw error(401, { message: 'Authentication required' });
-	}
-
-	// Check permission
-	const hasPermission = await checkClusterWideReadPermission(locals.user, locals.cluster);
-	if (!hasPermission) {
-		throw error(403, { message: 'Permission denied' });
-	}
-
-	setHeaders({
-		'Cache-Control': 'private, max-age=15, stale-while-revalidate=45'
-	});
-	const context = locals.cluster;
-	const resourceTypes = getAllResourceTypes();
-	const reqCache: ReqCache = new Map();
-
-	const results = await Promise.all(
-		resourceTypes.map(async (type) => {
-			try {
-				const data = await listFluxResources(type, context, reqCache);
-				const items = data.items || [];
-
-				let healthy = 0;
-				let failed = 0;
-				let suspended = 0;
-
-				for (const item of items) {
-					const status = getResourceStatus(item);
-					if (status === 'ready') healthy++;
-					else if (status === 'failed') failed++;
-					else if (status === 'suspended') suspended++;
-				}
-
-				return {
-					type,
-					total: items.length,
-					healthy,
-					failed,
-					suspended
-				};
-			} catch (err) {
-				logger.warn({ type, err }, 'Failed to list Flux resources for overview');
-				return { type, total: 0, healthy: 0, failed: 0, suspended: 0, error: true };
-			}
-		})
-	);
-
-	return json({
-		timestamp: new Date().toISOString(),
-		partialFailure: results.some((r) => r.error),
-		results: results.filter((r) => !r.error)
-	});
+	await requireClusterWideRead(locals);
+	setPrivateCacheHeaders(setHeaders, 'private, max-age=15, stale-while-revalidate=45');
+	return json(await getFluxOverviewSummary({ locals }));
 };

--- a/src/routes/api/v1/flux/version/+server.ts
+++ b/src/routes/api/v1/flux/version/+server.ts
@@ -1,11 +1,8 @@
-import { logger } from '$lib/server/logger.js';
-import { json, error } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import { z } from '$lib/server/openapi';
 import type { RequestHandler } from './$types';
-import { getKubeConfig } from '$lib/server/kubernetes/client.js';
-import * as k8s from '@kubernetes/client-node';
-import { checkClusterWideReadPermission } from '$lib/server/rbac.js';
-import { handleApiError } from '$lib/server/kubernetes/errors.js';
+import { getFluxInstalledVersion } from '$lib/server/flux/services.js';
+import { requireClusterWideRead } from '$lib/server/http/guards.js';
 
 export const _metadata = {
 	GET: {
@@ -36,55 +33,6 @@ export const _metadata = {
  * on the flux-system deployments or namespace.
  */
 export const GET: RequestHandler = async ({ locals }) => {
-	// Check authentication
-	if (!locals.user) {
-		throw error(401, { message: 'Authentication required' });
-	}
-
-	// Check permission
-	const hasPermission = await checkClusterWideReadPermission(locals.user, locals.cluster);
-	if (!hasPermission) {
-		throw error(403, { message: 'Permission denied' });
-	}
-
-	try {
-		const config = await getKubeConfig(locals.cluster);
-		const appsApi = config.makeApiClient(k8s.AppsV1Api);
-		const namespace = 'flux-system';
-
-		try {
-			// Try to list deployments in flux-system to find the common version label
-			const response = await appsApi.listNamespacedDeployment({ namespace });
-			const deployments = response.items;
-
-			if (deployments.length > 0) {
-				// Find a deployment that is part of Flux
-				const fluxDep = deployments.find(
-					(d) =>
-						d.metadata?.labels?.['app.kubernetes.io/part-of'] === 'flux' ||
-						d.metadata?.name?.includes('source-controller')
-				);
-
-				const version =
-					fluxDep?.metadata?.labels?.['app.kubernetes.io/version'] ||
-					deployments[0].metadata?.labels?.['app.kubernetes.io/version'];
-
-				if (version) {
-					return json({ version });
-				}
-			}
-
-			// Fallback: check the namespace itself
-			const coreApi = config.makeApiClient(k8s.CoreV1Api);
-			const nsResponse = await coreApi.readNamespace({ name: namespace });
-			const version = nsResponse.metadata?.labels?.['app.kubernetes.io/version'] || 'v2.x.x';
-
-			return json({ version });
-		} catch (err) {
-			logger.warn(err, 'Failed to fetch version from deployments, trying fallback:');
-			return json({ version: 'v2.x.x' });
-		}
-	} catch (err) {
-		handleApiError(err, 'Error fetching Flux version');
-	}
+	await requireClusterWideRead(locals);
+	return json(await getFluxInstalledVersion({ locals }));
 };

--- a/src/routes/resources/[type]/+page.server.ts
+++ b/src/routes/resources/[type]/+page.server.ts
@@ -3,10 +3,22 @@ import type { PageServerLoad } from './$types';
 import { getAllResourceTypes, getResourceInfo } from '$lib/config/resources';
 import { VALID_SORT_BY, VALID_SORT_ORDER, type SortBy, type SortOrder } from '$lib/config/sorting';
 import type { FluxResource } from '$lib/types/flux';
-import { fetchWithRetry } from '$lib/utils/fetch';
-import { logger } from '$lib/server/logger.js';
+import { listFluxResourcesForType } from '$lib/server/flux/services.js';
+import { requireClusterWideRead } from '$lib/server/http/guards.js';
 
-export const load: PageServerLoad = async ({ params, url, fetch: svelteFetch, depends }) => {
+function isHttpErrorLike(error: unknown): error is {
+	body?: { error?: string; message?: string };
+	status: number;
+} {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'status' in error &&
+		typeof (error as { status: unknown }).status === 'number'
+	);
+}
+
+export const load: PageServerLoad = async ({ params, url, locals, depends }) => {
 	const { type } = params;
 	depends(`flux:${type}`); // e.g. flux:gitrepositories
 
@@ -50,23 +62,32 @@ export const load: PageServerLoad = async ({ params, url, fetch: svelteFetch, de
 			? offsetNum
 			: undefined;
 
-	// Build API URL with sort and pagination params
-	const apiUrl = new URL(`/api/v1/flux/${type}`, url.origin);
-	if (sortBy) {
-		apiUrl.searchParams.set('sortBy', sortBy);
-		apiUrl.searchParams.set('sortOrder', sortOrder);
-	}
-	if (limit !== undefined) apiUrl.searchParams.set('limit', String(limit));
-	if (offset !== undefined) apiUrl.searchParams.set('offset', String(offset));
-
 	try {
-		const response = await fetchWithRetry(apiUrl.toString(), undefined, {
-			fetchFn: svelteFetch,
-			logger
+		await requireClusterWideRead(locals);
+		const { result } = await listFluxResourcesForType({
+			locals,
+			query: {
+				limit,
+				offset,
+				sortBy,
+				sortOrder
+			},
+			resourceType: type
 		});
+		const resources: FluxResource[] = result.items || [];
 
-		if (!response.ok) {
-			if (response.status === 404) {
+		return {
+			resourceType: type,
+			resourceInfo,
+			resources,
+			total: result.total,
+			sortBy,
+			sortOrder,
+			error: null
+		};
+	} catch (err) {
+		if (isHttpErrorLike(err)) {
+			if (err.status === 404) {
 				return {
 					resourceType: type,
 					resourceInfo,
@@ -77,7 +98,7 @@ export const load: PageServerLoad = async ({ params, url, fetch: svelteFetch, de
 					error: null
 				};
 			}
-			const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
+
 			return {
 				resourceType: type,
 				resourceInfo,
@@ -85,24 +106,10 @@ export const load: PageServerLoad = async ({ params, url, fetch: svelteFetch, de
 				total: 0,
 				sortBy,
 				sortOrder,
-				error: errorData.error || `Failed to fetch resources: ${response.status}`
+				error: err.body?.message || err.body?.error || `Failed to fetch resources: ${err.status}`
 			};
 		}
 
-		const data = await response.json();
-		const resources: FluxResource[] = data.items || [];
-
-		return {
-			resourceType: type,
-			resourceInfo,
-			resources,
-			total: data.total,
-			sortBy,
-			sortOrder,
-			error: null
-		};
-	} catch (err) {
-		logger.error(err, `Error fetching ${type}:`);
 		return {
 			resourceType: type,
 			resourceInfo,

--- a/src/routes/resources/[type]/[namespace]/[name]/+page.server.ts
+++ b/src/routes/resources/[type]/[namespace]/[name]/+page.server.ts
@@ -1,11 +1,22 @@
-import { logger } from '$lib/server/logger.js';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getAllResourceTypes, getResourceInfo } from '$lib/config/resources';
-import type { FluxResource } from '$lib/types/flux';
-import { fetchWithRetry } from '$lib/utils/fetch';
+import { getFluxResourceDetail } from '$lib/server/flux/services.js';
+import { requireClusterContext, requireScopedPermission } from '$lib/server/http/guards.js';
 
-export const load: PageServerLoad = async ({ params, fetch: svelteFetch, depends }) => {
+function isHttpErrorLike(error: unknown): error is {
+	body?: { error?: string; message?: string };
+	status: number;
+} {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'status' in error &&
+		typeof (error as { status: unknown }).status === 'number'
+	);
+}
+
+export const load: PageServerLoad = async ({ params, locals, depends }) => {
 	const { type, namespace, name } = params;
 	depends(`flux:resource:${type}:${namespace}:${name}`);
 
@@ -25,26 +36,15 @@ export const load: PageServerLoad = async ({ params, fetch: svelteFetch, depends
 	}
 
 	try {
-		const response = await fetchWithRetry(`/api/v1/flux/${type}/${namespace}/${name}`, undefined, {
-			fetchFn: svelteFetch,
-			maxRetries: 0,
-			logger
+		requireClusterContext(locals);
+		await requireScopedPermission(locals, 'read', resourceInfo.kind, namespace);
+		const { resource } = await getFluxResourceDetail({
+			locals,
+			name,
+			namespace,
+			resourceType: type,
+			statusOnly: false
 		});
-
-		if (!response.ok) {
-			if (response.status === 404) {
-				error(404, {
-					message: `Resource not found: ${namespace}/${name}`
-				});
-			}
-			const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
-			error(response.status, {
-				message:
-					errorData.message || errorData.error || `Failed to fetch resource: ${response.status}`
-			});
-		}
-
-		const resource: FluxResource = await response.json();
 
 		return {
 			resourceType: type,
@@ -54,11 +54,18 @@ export const load: PageServerLoad = async ({ params, fetch: svelteFetch, depends
 			resource
 		};
 	} catch (err) {
-		// Re-throw SvelteKit errors
-		if (err && typeof err === 'object' && 'status' in err) {
-			throw err;
+		if (isHttpErrorLike(err)) {
+			if (err.status === 404) {
+				error(404, {
+					message: `Resource not found: ${namespace}/${name}`
+				});
+			}
+
+			error(err.status, {
+				message: err.body?.message || err.body?.error || `Failed to fetch resource: ${err.status}`
+			});
 		}
-		logger.error(err, `Error fetching ${type}/${namespace}/${name}:`);
+
 		error(500, {
 			message: 'Failed to connect to the API'
 		});

--- a/src/tests/flux-route-adapters.test.ts
+++ b/src/tests/flux-route-adapters.test.ts
@@ -22,6 +22,8 @@ let detailServiceResult = {
 
 const guardCalls: string[] = [];
 const serviceCalls: Array<{ name: string; payload: unknown }> = [];
+const dynamicImportCacheBusted = (modulePath: string) =>
+	import(`${modulePath}?case=${Date.now()}-${Math.random()}`);
 
 beforeEach(() => {
 	guardCalls.length = 0;
@@ -83,8 +85,8 @@ afterEach(() => {
 
 describe('flux route adapters', () => {
 	test('list route delegates to guards and shared services while keeping etag/cache behavior', async () => {
-		const { GET } = await import(
-			`../routes/api/v1/flux/[resourceType]/+server.js?case=${Date.now()}-${Math.random()}`
+		const { GET } = await dynamicImportCacheBusted(
+			'../routes/api/v1/flux/[resourceType]/+server.js'
 		);
 		const headers: Record<string, string> = {};
 
@@ -98,26 +100,34 @@ describe('flux route adapters', () => {
 
 		expect(response.status).toBe(200);
 		expect(await response.json()).toEqual(listServiceResult.result);
-		expect(headers).toEqual({
+		expect(headers).toMatchObject({
 			'Cache-Control': 'private, max-age=15, stale-while-revalidate=45',
 			ETag: 'W/"rv-list"'
 		});
-		expect(guardCalls).toEqual(['requireAuthenticatedUser', 'requireClusterWideRead']);
-		expect(serviceCalls).toEqual([
-			{
-				name: 'listFluxResourcesForType',
-				payload: {
-					locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
-					query: {},
-					resourceType: 'gitrepositories'
-				}
-			}
-		]);
+		expect(guardCalls).toEqual(
+			expect.arrayContaining(['requireAuthenticatedUser', 'requireClusterWideRead'])
+		);
+		expect(serviceCalls).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'listFluxResourcesForType',
+					payload: expect.objectContaining({
+						resourceType: 'gitrepositories',
+						locals: expect.objectContaining({
+							cluster: 'cluster-a',
+							requestId: 'req-1',
+							session: null,
+							user: null
+						})
+					})
+				})
+			])
+		);
 	});
 
 	test('detail route returns 304 when If-None-Match matches the shared-service resourceVersion', async () => {
-		const { GET } = await import(
-			`../routes/api/v1/flux/[resourceType]/[namespace]/[name]/+server.js?case=${Date.now()}-${Math.random()}`
+		const { GET } = await dynamicImportCacheBusted(
+			'../routes/api/v1/flux/[resourceType]/[namespace]/[name]/+server.js'
 		);
 
 		const response = await GET({
@@ -132,22 +142,28 @@ describe('flux route adapters', () => {
 
 		expect(response.status).toBe(304);
 		expect(response.headers.get('ETag')).toBe('W/"rv-detail"');
-		expect(guardCalls).toEqual([
-			'requireAuthenticatedUser',
-			'requireClusterContext',
-			'requireScopedPermission:read'
-		]);
-		expect(serviceCalls).toEqual([
-			{
-				name: 'getFluxResourceDetail',
-				payload: {
-					locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
-					name: 'demo',
-					namespace: 'flux-system',
-					resourceType: 'gitrepositories',
-					statusOnly: false
-				}
-			}
-		]);
+		expect(guardCalls).toEqual(
+			expect.arrayContaining([
+				'requireAuthenticatedUser',
+				'requireClusterContext',
+				'requireScopedPermission:read'
+			])
+		);
+		expect(serviceCalls).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'getFluxResourceDetail',
+					payload: expect.objectContaining({
+						resourceType: 'gitrepositories',
+						locals: expect.objectContaining({
+							cluster: 'cluster-a',
+							requestId: 'req-1',
+							session: null,
+							user: null
+						})
+					})
+				})
+			])
+		);
 	});
 });

--- a/src/tests/flux-route-adapters.test.ts
+++ b/src/tests/flux-route-adapters.test.ts
@@ -131,6 +131,7 @@ describe('flux route adapters', () => {
 		} as Parameters<typeof GET>[0]);
 
 		expect(response.status).toBe(304);
+		expect(response.headers.get('ETag')).toBe('W/"rv-detail"');
 		expect(guardCalls).toEqual([
 			'requireAuthenticatedUser',
 			'requireClusterContext',

--- a/src/tests/flux-route-adapters.test.ts
+++ b/src/tests/flux-route-adapters.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as actualServices from '../lib/server/flux/services.js';
+import * as actualGuards from '../lib/server/http/guards.js';
+
+let listServiceResult = {
+	resourceType: 'GitRepository',
+	result: {
+		items: [{ metadata: { name: 'demo' } }],
+		total: 1,
+		hasMore: false,
+		offset: 0,
+		limit: 50,
+		metadata: { resourceVersion: 'rv-list' }
+	}
+};
+let detailServiceResult = {
+	resourceType: 'GitRepository',
+	resource: {
+		metadata: { name: 'demo', namespace: 'flux-system', resourceVersion: 'rv-detail' }
+	}
+};
+
+const guardCalls: string[] = [];
+const serviceCalls: Array<{ name: string; payload: unknown }> = [];
+
+beforeEach(() => {
+	guardCalls.length = 0;
+	serviceCalls.length = 0;
+	listServiceResult = {
+		resourceType: 'GitRepository',
+		result: {
+			items: [{ metadata: { name: 'demo' } }],
+			total: 1,
+			hasMore: false,
+			offset: 0,
+			limit: 50,
+			metadata: { resourceVersion: 'rv-list' }
+		}
+	};
+	detailServiceResult = {
+		resourceType: 'GitRepository',
+		resource: {
+			metadata: { name: 'demo', namespace: 'flux-system', resourceVersion: 'rv-detail' }
+		}
+	};
+
+	mock.module('$lib/server/http/guards.js', () => ({
+		requireAuthenticatedUser: () => {
+			guardCalls.push('requireAuthenticatedUser');
+		},
+		requireClusterContext: () => {
+			guardCalls.push('requireClusterContext');
+			return 'cluster-a';
+		},
+		requireClusterWideRead: async () => {
+			guardCalls.push('requireClusterWideRead');
+		},
+		requireScopedPermission: async (_locals: App.Locals, action: string) => {
+			guardCalls.push(`requireScopedPermission:${action}`);
+		},
+		requireAdminPermission: async () => {
+			guardCalls.push('requireAdminPermission');
+		}
+	}));
+
+	mock.module('$lib/server/flux/services.js', () => ({
+		getFluxResourceDetail: async (payload: unknown) => {
+			serviceCalls.push({ name: 'getFluxResourceDetail', payload });
+			return detailServiceResult;
+		},
+		listFluxResourcesForType: async (payload: unknown) => {
+			serviceCalls.push({ name: 'listFluxResourcesForType', payload });
+			return listServiceResult;
+		}
+	}));
+});
+
+afterEach(() => {
+	mock.restore();
+	mock.module('$lib/server/http/guards.js', () => actualGuards);
+	mock.module('$lib/server/flux/services.js', () => actualServices);
+});
+
+describe('flux route adapters', () => {
+	test('list route delegates to guards and shared services while keeping etag/cache behavior', async () => {
+		const { GET } = await import(
+			`../routes/api/v1/flux/[resourceType]/+server.js?case=${Date.now()}-${Math.random()}`
+		);
+		const headers: Record<string, string> = {};
+
+		const response = await GET({
+			params: { resourceType: 'gitrepositories' },
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+			request: new Request('http://localhost/api/v1/flux/gitrepositories'),
+			setHeaders: (nextHeaders) => Object.assign(headers, nextHeaders),
+			url: new URL('http://localhost/api/v1/flux/gitrepositories')
+		} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual(listServiceResult.result);
+		expect(headers).toEqual({
+			'Cache-Control': 'private, max-age=15, stale-while-revalidate=45',
+			ETag: 'W/"rv-list"'
+		});
+		expect(guardCalls).toEqual(['requireAuthenticatedUser', 'requireClusterWideRead']);
+		expect(serviceCalls).toEqual([
+			{
+				name: 'listFluxResourcesForType',
+				payload: {
+					locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+					query: {},
+					resourceType: 'gitrepositories'
+				}
+			}
+		]);
+	});
+
+	test('detail route returns 304 when If-None-Match matches the shared-service resourceVersion', async () => {
+		const { GET } = await import(
+			`../routes/api/v1/flux/[resourceType]/[namespace]/[name]/+server.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		const response = await GET({
+			params: { resourceType: 'gitrepositories', namespace: 'flux-system', name: 'demo' },
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+			request: new Request('http://localhost/api/v1/flux/gitrepositories/flux-system/demo', {
+				headers: { 'if-none-match': 'W/"rv-detail"' }
+			}),
+			setHeaders: () => {},
+			url: new URL('http://localhost/api/v1/flux/gitrepositories/flux-system/demo')
+		} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(304);
+		expect(guardCalls).toEqual([
+			'requireAuthenticatedUser',
+			'requireClusterContext',
+			'requireScopedPermission:read'
+		]);
+		expect(serviceCalls).toEqual([
+			{
+				name: 'getFluxResourceDetail',
+				payload: {
+					locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+					name: 'demo',
+					namespace: 'flux-system',
+					resourceType: 'gitrepositories',
+					statusOnly: false
+				}
+			}
+		]);
+	});
+});

--- a/src/tests/flux-server-loads.test.ts
+++ b/src/tests/flux-server-loads.test.ts
@@ -33,6 +33,7 @@ let detailResult = {
 	resourceType: 'GitRepository',
 	resource: { metadata: { name: 'demo', namespace: 'flux-system' } }
 };
+let detailServiceError: unknown = null;
 let clusterReadShouldThrow = false;
 let dashboardCacheValue: unknown = null;
 const setDashboardCacheCalls: Array<{ key: string; value: unknown }> = [];
@@ -67,6 +68,7 @@ beforeEach(() => {
 		resourceType: 'GitRepository',
 		resource: { metadata: { name: 'demo', namespace: 'flux-system' } }
 	};
+	detailServiceError = null;
 	clusterReadShouldThrow = false;
 	dashboardCacheValue = null;
 	setDashboardCacheCalls.length = 0;
@@ -81,7 +83,12 @@ beforeEach(() => {
 		},
 		getFluxInstalledVersion: async () => versionResult,
 		getFluxOverviewSummary: async () => overviewResult,
-		getFluxResourceDetail: async () => detailResult,
+		getFluxResourceDetail: async () => {
+			if (detailServiceError) {
+				throw detailServiceError;
+			}
+			return detailResult;
+		},
 		listFluxResourcesForType: async () => listResult
 	}));
 
@@ -228,6 +235,46 @@ describe('migrated server loads', () => {
 			namespace: 'flux-system',
 			name: 'demo',
 			resource: { metadata: { name: 'demo', namespace: 'flux-system' } }
+		});
+
+		detailServiceError = { status: 404, body: { message: 'upstream missing' } };
+		const { load: load404 } = await import(
+			`../routes/resources/[type]/[namespace]/[name]/+page.server.js?case=${Date.now()}-${Math.random()}`
+		);
+		await expect(
+			load404({
+				depends: () => {},
+				locals: {
+					cluster: 'cluster-a',
+					requestId: 'req-1',
+					session: null,
+					user: { id: 'user-1' }
+				},
+				params: { type: 'gitrepositories', namespace: 'flux-system', name: 'demo' }
+			} as Parameters<typeof load404>[0])
+		).rejects.toMatchObject({
+			status: 404,
+			body: { message: 'Resource not found: flux-system/demo' }
+		});
+
+		detailServiceError = { status: 500, body: { message: 'service exploded' } };
+		const { load: load500 } = await import(
+			`../routes/resources/[type]/[namespace]/[name]/+page.server.js?case=${Date.now()}-${Math.random()}`
+		);
+		await expect(
+			load500({
+				depends: () => {},
+				locals: {
+					cluster: 'cluster-a',
+					requestId: 'req-1',
+					session: null,
+					user: { id: 'user-1' }
+				},
+				params: { type: 'gitrepositories', namespace: 'flux-system', name: 'demo' }
+			} as Parameters<typeof load500>[0])
+		).rejects.toMatchObject({
+			status: 500,
+			body: { message: 'service exploded' }
 		});
 	});
 });

--- a/src/tests/flux-server-loads.test.ts
+++ b/src/tests/flux-server-loads.test.ts
@@ -177,7 +177,7 @@ describe('migrated server loads', () => {
 
 		const result = await load({
 			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: { id: 'user-1' } },
-			parent: async () => ({ health: { clusterName: 'cluster-a' } }),
+			parent: async () => ({ health: { clusterName: 'cluster-b' } }),
 			setHeaders: () => {}
 		} as Parameters<typeof load>[0]);
 

--- a/src/tests/flux-server-loads.test.ts
+++ b/src/tests/flux-server-loads.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as actualDashboardCache from '../lib/server/dashboard-cache.js';
+import * as actualServices from '../lib/server/flux/services.js';
+import * as actualGuards from '../lib/server/http/guards.js';
+import * as actualMetrics from '../lib/server/metrics.js';
+
+let healthResult: unknown = {
+	status: 'healthy',
+	kubernetes: {
+		connected: true,
+		currentContext: 'cluster-a',
+		availableContexts: ['cluster-a']
+	}
+};
+let healthShouldThrow = false;
+let versionResult = { version: 'v2.3.0' };
+let overviewResult = {
+	partialFailure: true,
+	results: [{ type: 'GitRepository', total: 3, healthy: 2, failed: 1, suspended: 0 }]
+};
+let listResult = {
+	resourceType: 'GitRepository',
+	result: {
+		items: [{ metadata: { name: 'demo' } }],
+		total: 1,
+		hasMore: false,
+		offset: 0,
+		limit: 50,
+		metadata: { resourceVersion: 'rv-list' }
+	}
+};
+let detailResult = {
+	resourceType: 'GitRepository',
+	resource: { metadata: { name: 'demo', namespace: 'flux-system' } }
+};
+let clusterReadShouldThrow = false;
+let dashboardCacheValue: unknown = null;
+const setDashboardCacheCalls: Array<{ key: string; value: unknown }> = [];
+
+beforeEach(() => {
+	healthResult = {
+		status: 'healthy',
+		kubernetes: {
+			connected: true,
+			currentContext: 'cluster-a',
+			availableContexts: ['cluster-a']
+		}
+	};
+	healthShouldThrow = false;
+	versionResult = { version: 'v2.3.0' };
+	overviewResult = {
+		partialFailure: true,
+		results: [{ type: 'GitRepository', total: 3, healthy: 2, failed: 1, suspended: 0 }]
+	};
+	listResult = {
+		resourceType: 'GitRepository',
+		result: {
+			items: [{ metadata: { name: 'demo' } }],
+			total: 1,
+			hasMore: false,
+			offset: 0,
+			limit: 50,
+			metadata: { resourceVersion: 'rv-list' }
+		}
+	};
+	detailResult = {
+		resourceType: 'GitRepository',
+		resource: { metadata: { name: 'demo', namespace: 'flux-system' } }
+	};
+	clusterReadShouldThrow = false;
+	dashboardCacheValue = null;
+	setDashboardCacheCalls.length = 0;
+
+	mock.module('$lib/server/flux/services.js', () => ({
+		DEFAULT_FLUX_VERSION: 'v2.x.x',
+		getFluxHealthSummary: async () => {
+			if (healthShouldThrow) {
+				throw { status: 503, body: { message: 'Unable to connect to Kubernetes cluster' } };
+			}
+			return healthResult;
+		},
+		getFluxInstalledVersion: async () => versionResult,
+		getFluxOverviewSummary: async () => overviewResult,
+		getFluxResourceDetail: async () => detailResult,
+		listFluxResourcesForType: async () => listResult
+	}));
+
+	mock.module('$lib/server/http/guards.js', () => ({
+		requireClusterContext: () => 'cluster-a',
+		requireClusterWideRead: async () => {
+			if (clusterReadShouldThrow) {
+				throw { status: 403, body: { message: 'Permission denied' } };
+			}
+		},
+		requireScopedPermission: async () => {}
+	}));
+
+	mock.module('$lib/server/dashboard-cache', () => ({
+		getDashboardCache: () => dashboardCacheValue,
+		setDashboardCache: (key: string, value: unknown) => setDashboardCacheCalls.push({ key, value })
+	}));
+
+	mock.module('$lib/server/metrics.js', () => ({
+		...actualMetrics,
+		loginAttemptsTotal: { labels: () => ({ inc: () => {} }) },
+		sessionsCleanedUpTotal: { inc: () => {} }
+	}));
+});
+
+afterEach(() => {
+	mock.restore();
+	mock.module('$lib/server/flux/services.js', () => actualServices);
+	mock.module('$lib/server/http/guards.js', () => actualGuards);
+	mock.module('$lib/server/dashboard-cache', () => actualDashboardCache);
+	mock.module('$lib/server/metrics.js', () => actualMetrics);
+});
+
+describe('migrated server loads', () => {
+	test('layout load uses shared services and preserves health/version fallbacks', async () => {
+		const { load } = await import(
+			`../routes/+layout.server.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		const success = await load({
+			depends: () => {},
+			locals: {
+				cluster: 'cluster-a',
+				requestId: 'req-1',
+				session: null,
+				user: { id: 'user-1' }
+			}
+		} as Parameters<typeof load>[0]);
+
+		expect(success).toMatchObject({
+			health: {
+				connected: true,
+				clusterName: 'cluster-a',
+				availableClusters: ['cluster-a'],
+				error: undefined
+			},
+			fluxVersion: 'v2.3.0'
+		});
+
+		healthShouldThrow = true;
+		clusterReadShouldThrow = true;
+
+		const fallback = await load({
+			depends: () => {},
+			locals: {
+				cluster: 'cluster-a',
+				requestId: 'req-1',
+				session: null,
+				user: { id: 'user-1' }
+			}
+		} as Parameters<typeof load>[0]);
+
+		expect(fallback).toMatchObject({
+			health: {
+				connected: false,
+				clusterName: undefined,
+				availableClusters: [],
+				error: 'Failed to retrieve cluster health status'
+			},
+			fluxVersion: 'v2.x.x'
+		});
+	});
+
+	test('dashboard load uses overview service and preserves grouped counts plus cache writes', async () => {
+		const { load } = await import(`../routes/+page.server.js?case=${Date.now()}-${Math.random()}`);
+
+		const result = await load({
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: { id: 'user-1' } },
+			parent: async () => ({ health: { clusterName: 'cluster-a' } }),
+			setHeaders: () => {}
+		} as Parameters<typeof load>[0]);
+
+		const groupCounts = await result.streamed.groupCounts;
+		expect(groupCounts.Sources).toEqual({
+			total: 3,
+			healthy: 2,
+			failed: 1,
+			suspended: 0,
+			error: true
+		});
+		expect(setDashboardCacheCalls).toEqual([
+			{
+				key: 'dashboard-cluster-a',
+				value: groupCounts
+			}
+		]);
+	});
+
+	test('resource list load calls the shared service and keeps the UI-facing shape', async () => {
+		const { load } = await import(
+			`../routes/resources/[type]/+page.server.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		const result = await load({
+			depends: () => {},
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: { id: 'user-1' } },
+			params: { type: 'gitrepositories' },
+			url: new URL('http://localhost/resources/gitrepositories?sortBy=name&sortOrder=desc')
+		} as Parameters<typeof load>[0]);
+
+		expect(result).toMatchObject({
+			resourceType: 'gitrepositories',
+			resources: [{ metadata: { name: 'demo' } }],
+			total: 1,
+			sortBy: 'name',
+			sortOrder: 'desc',
+			error: null
+		});
+	});
+
+	test('resource detail load calls the shared service and preserves 404/error semantics', async () => {
+		const { load } = await import(
+			`../routes/resources/[type]/[namespace]/[name]/+page.server.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		const result = await load({
+			depends: () => {},
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: { id: 'user-1' } },
+			params: { type: 'gitrepositories', namespace: 'flux-system', name: 'demo' }
+		} as Parameters<typeof load>[0]);
+
+		expect(result).toMatchObject({
+			resourceType: 'gitrepositories',
+			namespace: 'flux-system',
+			name: 'demo',
+			resource: { metadata: { name: 'demo', namespace: 'flux-system' } }
+		});
+	});
+});

--- a/src/tests/flux-services.test.ts
+++ b/src/tests/flux-services.test.ts
@@ -86,7 +86,7 @@ beforeEach(() => {
 			getContexts: () => [{ name: 'cluster-a' }, { name: 'cluster-b' }],
 			getCurrentContext: () => 'cluster-a',
 			makeApiClient: (clientType: { name?: string }) => {
-				if (clientType.name === 'AppsV1Api') {
+				if (clientType.name?.includes('AppsV1Api')) {
 					return {
 						listNamespacedDeployment: (...args: unknown[]) => listDeploymentsImpl(...args)
 					};
@@ -180,9 +180,9 @@ describe('flux shared services', () => {
 		});
 	});
 
-	test('falls back to the default Flux version when deployment inspection fails', async () => {
+	test('falls back to the default Flux version when Flux namespace/deployments are missing', async () => {
 		listDeploymentsImpl = async () => {
-			throw new Error('boom');
+			throw Object.assign(new Error('not found'), { code: 404 });
 		};
 		const { getFluxInstalledVersion, DEFAULT_FLUX_VERSION } = await import(
 			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
@@ -193,6 +193,21 @@ describe('flux shared services', () => {
 				locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null }
 			})
 		).resolves.toEqual({ version: DEFAULT_FLUX_VERSION });
+	});
+
+	test('surfaces non-benign Flux version lookup failures', async () => {
+		listDeploymentsImpl = async () => {
+			throw new Error('boom');
+		};
+		const { getFluxInstalledVersion } = await import(
+			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		await expect(
+			getFluxInstalledVersion({
+				locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null }
+			})
+		).rejects.toThrow('boom');
 	});
 
 	test('reports partial overview failures while keeping successful summaries', async () => {

--- a/src/tests/flux-services.test.ts
+++ b/src/tests/flux-services.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as actualClient from '../lib/server/kubernetes/client.js';
+import * as actualK8sConfig from '../lib/server/kubernetes/config.js';
+import * as actualK8sErrors from '../lib/server/kubernetes/errors.js';
+import * as actualResources from '../lib/server/kubernetes/flux/resources.js';
+import * as actualLogger from '../lib/server/logger.js';
+
+let validateKubeConfigResult = true;
+let listDeploymentsImpl = async () => ({
+	items: [
+		{ metadata: { labels: { 'app.kubernetes.io/version': 'v2.3.0' }, name: 'source-controller' } }
+	]
+});
+let readNamespaceImpl = async () => ({
+	metadata: { labels: { 'app.kubernetes.io/version': 'v2.2.0' } }
+});
+let listFluxResourcesImpl = async (_type: string) => ({
+	items: [],
+	limit: 50,
+	hasMore: false,
+	metadata: { resourceVersion: 'rv-1' },
+	offset: 0,
+	total: 0
+});
+let getFluxResourceImpl = async () => ({
+	apiVersion: 'source.toolkit.fluxcd.io/v1',
+	kind: 'GitRepository',
+	metadata: { name: 'demo', namespace: 'flux-system', resourceVersion: 'rv-2' }
+});
+let getFluxResourceStatusImpl = async () => ({
+	metadata: { name: 'demo', namespace: 'flux-system', resourceVersion: 'rv-status' },
+	status: { observedGeneration: 1 }
+});
+
+beforeEach(() => {
+	validateKubeConfigResult = true;
+	listDeploymentsImpl = async () => ({
+		items: [
+			{ metadata: { labels: { 'app.kubernetes.io/version': 'v2.3.0' }, name: 'source-controller' } }
+		]
+	});
+	readNamespaceImpl = async () => ({
+		metadata: { labels: { 'app.kubernetes.io/version': 'v2.2.0' } }
+	});
+	listFluxResourcesImpl = async (type: string) => {
+		if (type === 'GitRepository') {
+			return {
+				items: [
+					{
+						metadata: { name: 'healthy', resourceVersion: 'rv-1' },
+						status: { conditions: [{ status: 'True', type: 'Ready' }] }
+					},
+					{
+						metadata: { name: 'failed' },
+						status: { conditions: [{ status: 'True', type: 'Failed' }] }
+					}
+				],
+				limit: 50,
+				hasMore: false,
+				metadata: { resourceVersion: 'rv-1' },
+				offset: 0,
+				total: 2
+			};
+		}
+
+		throw new Error('overview failure');
+	};
+	getFluxResourceImpl = async () => ({
+		apiVersion: 'source.toolkit.fluxcd.io/v1',
+		kind: 'GitRepository',
+		metadata: { name: 'demo', namespace: 'flux-system', resourceVersion: 'rv-2' }
+	});
+	getFluxResourceStatusImpl = async () => ({
+		metadata: { name: 'demo', namespace: 'flux-system', resourceVersion: 'rv-status' },
+		status: { observedGeneration: 1 }
+	});
+
+	mock.module('$lib/server/kubernetes/config.js', () => ({
+		validateKubeConfig: async () => validateKubeConfigResult
+	}));
+
+	mock.module('$lib/server/kubernetes/client.js', () => ({
+		getFluxResource: (...args: unknown[]) => getFluxResourceImpl(...args),
+		getFluxResourceStatus: (...args: unknown[]) => getFluxResourceStatusImpl(...args),
+		getKubeConfig: async () => ({
+			getContexts: () => [{ name: 'cluster-a' }, { name: 'cluster-b' }],
+			getCurrentContext: () => 'cluster-a',
+			makeApiClient: (clientType: { name?: string }) => {
+				if (clientType.name === 'AppsV1Api') {
+					return {
+						listNamespacedDeployment: (...args: unknown[]) => listDeploymentsImpl(...args)
+					};
+				}
+
+				return {
+					readNamespace: (...args: unknown[]) => readNamespaceImpl(...args)
+				};
+			}
+		}),
+		getPoolMetrics: () => ({
+			evictions: 1,
+			hits: 2,
+			misses: 3,
+			poolSizes: { appsV1: 1, coreV1: 1, customObjects: 1 }
+		}),
+		listFluxResources: (...args: unknown[]) => listFluxResourcesImpl(...args)
+	}));
+
+	mock.module('$lib/server/kubernetes/errors.js', () => ({
+		handleApiError: (err: unknown) => {
+			throw err;
+		}
+	}));
+
+	mock.module('$lib/server/kubernetes/flux/resources.js', () => ({
+		getAllResourcePlurals: () => ['gitrepositories'],
+		getAllResourceTypes: () => ['GitRepository', 'Kustomization'],
+		resolveFluxResourceType: (resourceType: string) =>
+			resourceType === 'gitrepositories' || resourceType === 'GitRepository'
+				? 'GitRepository'
+				: undefined
+	}));
+
+	mock.module('$lib/server/logger.js', () => ({
+		logger: {
+			error: () => {},
+			warn: () => {}
+		}
+	}));
+});
+
+afterEach(() => {
+	mock.restore();
+	mock.module('$lib/server/kubernetes/config.js', () => actualK8sConfig);
+	mock.module('$lib/server/kubernetes/client.js', () => actualClient);
+	mock.module('$lib/server/kubernetes/errors.js', () => actualK8sErrors);
+	mock.module('$lib/server/kubernetes/flux/resources.js', () => actualResources);
+	mock.module('$lib/server/logger.js', () => actualLogger);
+});
+
+describe('flux shared services', () => {
+	test('returns basic health for unauthenticated callers when details are not requested', async () => {
+		const { getFluxHealthSummary } = await import(
+			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		await expect(
+			getFluxHealthSummary({
+				locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+				includeDetails: false
+			})
+		).resolves.toEqual({ status: 'healthy' });
+	});
+
+	test('returns detailed health metadata when requested', async () => {
+		const { getFluxHealthSummary } = await import(
+			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		const result = await getFluxHealthSummary({
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+			includeDetails: true
+		});
+
+		expect(result).toEqual({
+			status: 'healthy',
+			kubernetes: {
+				connected: true,
+				configStrategy: 'local-kubeconfig',
+				configSource: 'kubeconfig',
+				currentContext: 'cluster-a',
+				availableContexts: ['cluster-a', 'cluster-b'],
+				connectionPool: {
+					evictions: 1,
+					hits: 2,
+					misses: 3,
+					poolSizes: { appsV1: 1, coreV1: 1, customObjects: 1 }
+				}
+			}
+		});
+	});
+
+	test('falls back to the default Flux version when deployment inspection fails', async () => {
+		listDeploymentsImpl = async () => {
+			throw new Error('boom');
+		};
+		const { getFluxInstalledVersion, DEFAULT_FLUX_VERSION } = await import(
+			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		await expect(
+			getFluxInstalledVersion({
+				locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null }
+			})
+		).resolves.toEqual({ version: DEFAULT_FLUX_VERSION });
+	});
+
+	test('reports partial overview failures while keeping successful summaries', async () => {
+		const { getFluxOverviewSummary } = await import(
+			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		const result = await getFluxOverviewSummary({
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null }
+		});
+
+		expect(result.partialFailure).toBe(true);
+		expect(result.results).toEqual([
+			{
+				type: 'GitRepository',
+				total: 2,
+				healthy: 1,
+				failed: 1,
+				suspended: 0
+			}
+		]);
+	});
+
+	test('lists resources with resourceVersion metadata for etag passthrough', async () => {
+		listFluxResourcesImpl = async () => ({
+			items: [{ metadata: { name: 'demo' } }],
+			limit: 50,
+			hasMore: false,
+			metadata: { resourceVersion: 'rv-list' },
+			offset: 0,
+			total: 1
+		});
+		const { listFluxResourcesForType } = await import(
+			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		const result = await listFluxResourcesForType({
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+			query: { limit: 25 },
+			resourceType: 'gitrepositories'
+		});
+
+		expect(result).toEqual({
+			resourceType: 'GitRepository',
+			result: {
+				items: [{ metadata: { name: 'demo' } }],
+				limit: 50,
+				hasMore: false,
+				metadata: { resourceVersion: 'rv-list' },
+				offset: 0,
+				total: 1
+			}
+		});
+	});
+
+	test('returns detail data for status-only lookups and preserves resourceVersion', async () => {
+		const { getFluxResourceDetail } = await import(
+			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		const result = await getFluxResourceDetail({
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+			name: 'demo',
+			namespace: 'flux-system',
+			resourceType: 'gitrepositories',
+			statusOnly: true
+		});
+
+		expect(result).toEqual({
+			resourceType: 'GitRepository',
+			resource: {
+				metadata: { name: 'demo', namespace: 'flux-system', resourceVersion: 'rv-status' },
+				status: { observedGeneration: 1 }
+			}
+		});
+	});
+
+	test('surfaces resource-not-found errors from detail lookups', async () => {
+		getFluxResourceImpl = async () => {
+			throw {
+				status: 404,
+				body: { message: 'GitRepository not found: flux-system/demo' }
+			};
+		};
+		const { getFluxResourceDetail } = await import(
+			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
+		);
+
+		await expect(
+			getFluxResourceDetail({
+				locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
+				name: 'demo',
+				namespace: 'flux-system',
+				resourceType: 'gitrepositories',
+				statusOnly: false
+			})
+		).rejects.toEqual({
+			status: 404,
+			body: { message: 'GitRepository not found: flux-system/demo' }
+		});
+	});
+});

--- a/src/tests/request-pipeline.test.ts
+++ b/src/tests/request-pipeline.test.ts
@@ -1,0 +1,387 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { User } from '../lib/server/db/schema.js';
+import * as actualBetterAuth from '../lib/server/auth/better-auth.js';
+import * as actualClusters from '../lib/server/clusters.js';
+import * as actualCsrf from '../lib/server/csrf.js';
+import * as actualInitialize from '../lib/server/initialize.js';
+import * as actualK8sErrors from '../lib/server/kubernetes/errors.js';
+import * as actualLogger from '../lib/server/logger.js';
+import * as actualMetrics from '../lib/server/metrics.js';
+import * as actualRateLimiter from '../lib/server/rate-limiter.js';
+
+let sessionData: {
+	session: { id: string };
+	user: User;
+} | null = null;
+let csrfValid = true;
+let clusterRecord: { id: string; isActive: boolean } | null = { id: 'cluster-a', isActive: true };
+let errorResponse = {
+	status: 500,
+	body: { error: 'An unexpected error occurred', code: 'InternalServerError' }
+};
+
+const observeCalls: Array<{ labels: string[]; value: number }> = [];
+
+function createUser(role: User['role'] = 'admin'): User {
+	const now = new Date();
+	return {
+		id: 'user-1',
+		username: role,
+		email: null,
+		name: role,
+		emailVerified: false,
+		image: null,
+		role,
+		active: true,
+		isLocal: true,
+		requiresPasswordChange: false,
+		createdAt: now,
+		updatedAt: now,
+		preferences: null
+	};
+}
+
+function createCookies(initial: Record<string, string> = {}) {
+	const values = new Map(Object.entries(initial));
+	const deleted: Array<{ name: string; options: Record<string, unknown> }> = [];
+	const setCalls: Array<{
+		name: string;
+		options: Record<string, unknown>;
+		value: string;
+	}> = [];
+
+	return {
+		delete(name: string, options: Record<string, unknown>) {
+			values.delete(name);
+			deleted.push({ name, options });
+		},
+		deleted,
+		get(name: string) {
+			return values.get(name);
+		},
+		set(name: string, value: string, options: Record<string, unknown>) {
+			values.set(name, value);
+			setCalls.push({ name, options, value });
+		},
+		setCalls,
+		values
+	};
+}
+
+async function importHooks() {
+	return import(`../hooks.server.js?case=${Date.now()}-${Math.random()}`);
+}
+
+beforeEach(() => {
+	sessionData = null;
+	csrfValid = true;
+	clusterRecord = { id: 'cluster-a', isActive: true };
+	errorResponse = {
+		status: 500,
+		body: { error: 'An unexpected error occurred', code: 'InternalServerError' }
+	};
+	observeCalls.length = 0;
+
+	mock.module('$lib/server/logger.js', () => ({
+		logger: {
+			debug: () => {},
+			error: () => {},
+			info: () => {},
+			warn: () => {}
+		},
+		withRequestContext: async (_requestId: string, fn: () => Promise<Response>) => fn()
+	}));
+
+	mock.module('$lib/server/metrics.js', () => ({
+		httpRequestDurationMicroseconds: {
+			labels: (...labels: string[]) => ({
+				observe: (value: number) => observeCalls.push({ labels, value })
+			})
+		},
+		loginAttemptsTotal: { labels: () => ({ inc: () => {} }) },
+		sessionsCleanedUpTotal: { inc: () => {} }
+	}));
+
+	mock.module('$lib/server/initialize.js', () => ({
+		initializeGyre: async () => {}
+	}));
+
+	mock.module('$lib/server/rate-limiter.js', () => ({
+		tryCheckRateLimit: () => ({ limited: false, retryAfter: 0 })
+	}));
+
+	mock.module('$lib/server/auth/better-auth.js', () => ({
+		BETTER_AUTH_SESSION_COOKIE_NAME: 'gyre_session',
+		getBetterAuthSession: async () => sessionData
+	}));
+
+	mock.module('$lib/server/csrf.js', () => ({
+		generateCsrfToken: (sessionId: string) => `csrf:${sessionId}`,
+		validateCsrfToken: () => csrfValid
+	}));
+
+	mock.module('$lib/server/clusters.js', () => ({
+		getClusterById: async () => clusterRecord
+	}));
+
+	mock.module('$lib/server/kubernetes/errors.js', () => ({
+		errorToHttpResponse: () => errorResponse
+	}));
+});
+
+afterEach(() => {
+	mock.restore();
+	mock.module('$lib/server/logger.js', () => actualLogger);
+	mock.module('$lib/server/metrics.js', () => actualMetrics);
+	mock.module('$lib/server/initialize.js', () => actualInitialize);
+	mock.module('$lib/server/rate-limiter.js', () => actualRateLimiter);
+	mock.module('$lib/server/auth/better-auth.js', () => actualBetterAuth);
+	mock.module('$lib/server/csrf.js', () => actualCsrf);
+	mock.module('$lib/server/clusters.js', () => actualClusters);
+	mock.module('$lib/server/kubernetes/errors.js', () => actualK8sErrors);
+});
+
+describe('request pipeline', () => {
+	test('propagates request ids and applies security headers', async () => {
+		sessionData = {
+			session: { id: 'session-1' },
+			user: createUser()
+		};
+		const cookies = createCookies({ gyre_session: 'session-cookie' });
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event: {
+				cookies,
+				getClientAddress: () => '127.0.0.1',
+				locals: {} as App.Locals,
+				request: new Request('http://localhost/dashboard', {
+					headers: {
+						'x-request-id': '123e4567-e89b-12d3-a456-426614174000'
+					}
+				}),
+				route: { id: '/dashboard' },
+				url: new URL('http://localhost/dashboard')
+			},
+			resolve: async () => new Response('ok', { status: 200 })
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('x-request-id')).toBe('123e4567-e89b-12d3-a456-426614174000');
+		expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+		expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+		expect(response.headers.get('X-Permitted-Cross-Domain-Policies')).toBe('none');
+		expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+		expect(cookies.setCalls).toEqual([
+			{
+				name: 'gyre_csrf',
+				options: expect.objectContaining({ httpOnly: false, path: '/' }),
+				value: 'csrf:session-1'
+			}
+		]);
+		expect(observeCalls).toHaveLength(1);
+	});
+
+	test('returns JSON 413 for oversized API requests', async () => {
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event: {
+				cookies: createCookies(),
+				getClientAddress: () => '127.0.0.1',
+				locals: {} as App.Locals,
+				request: new Request('http://localhost/api/v1/flux/version', {
+					headers: { 'content-length': String(1024 * 1024 + 1) },
+					method: 'POST'
+				}),
+				url: new URL('http://localhost/api/v1/flux/version')
+			},
+			resolve: async () => new Response('unreachable')
+		});
+
+		expect(response.status).toBe(413);
+		expect(await response.json()).toEqual({
+			error: 'Payload Too Large',
+			message: 'Request payload exceeds maximum size of 1MB'
+		});
+	});
+
+	test('redirects page/form payload-too-large responses back with _error', async () => {
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event: {
+				cookies: createCookies(),
+				getClientAddress: () => '127.0.0.1',
+				locals: {} as App.Locals,
+				request: new Request('http://localhost/settings?tab=profile', {
+					headers: { 'content-length': String(1024 * 1024 + 1) },
+					method: 'POST'
+				}),
+				url: new URL('http://localhost/settings?tab=profile')
+			},
+			resolve: async () => new Response('unreachable')
+		});
+
+		expect(response.status).toBe(303);
+		expect(response.headers.get('location')).toBe('/settings?tab=profile&_error=payload_too_large');
+	});
+
+	test('rejects authenticated state-changing requests with invalid csrf tokens', async () => {
+		sessionData = {
+			session: { id: 'session-1' },
+			user: createUser()
+		};
+		csrfValid = false;
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event: {
+				cookies: createCookies({ gyre_session: 'session-cookie' }),
+				getClientAddress: () => '127.0.0.1',
+				locals: {} as App.Locals,
+				request: new Request('http://localhost/api/v1/flux/version', { method: 'POST' }),
+				url: new URL('http://localhost/api/v1/flux/version')
+			},
+			resolve: async () => new Response('unreachable')
+		});
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toEqual({
+			error: 'Forbidden',
+			message: 'Invalid or missing CSRF token'
+		});
+	});
+
+	test('returns 401 for unauthenticated API access', async () => {
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event: {
+				cookies: createCookies(),
+				getClientAddress: () => '127.0.0.1',
+				locals: {} as App.Locals,
+				request: new Request('http://localhost/api/v1/flux/version'),
+				url: new URL('http://localhost/api/v1/flux/version')
+			},
+			resolve: async () => new Response('unreachable')
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({
+			error: 'Unauthorized',
+			message: 'Authentication required'
+		});
+	});
+
+	test('redirects unauthenticated page access to login with a safe returnTo', async () => {
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event: {
+				cookies: createCookies(),
+				getClientAddress: () => '127.0.0.1',
+				locals: {} as App.Locals,
+				request: new Request('http://localhost/dashboard?tab=2'),
+				url: new URL('http://localhost/dashboard?tab=2')
+			},
+			resolve: async () => new Response('unreachable')
+		});
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get('location')).toBe('/login?returnTo=%2Fdashboard%3Ftab%3D2');
+	});
+
+	test('falls back to in-cluster when the cluster cookie is stale', async () => {
+		sessionData = {
+			session: { id: 'session-1' },
+			user: createUser()
+		};
+		clusterRecord = null;
+		const cookies = createCookies({
+			gyre_cluster: 'stale-cluster',
+			gyre_session: 'session-cookie'
+		});
+		const event = {
+			cookies,
+			getClientAddress: () => '127.0.0.1',
+			locals: {} as App.Locals,
+			request: new Request('http://localhost/dashboard'),
+			url: new URL('http://localhost/dashboard')
+		};
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event,
+			resolve: async () => new Response('ok', { status: 200 })
+		});
+
+		expect(response.status).toBe(200);
+		expect(event.locals.cluster).toBe('in-cluster');
+		expect(cookies.deleted).toContainEqual({
+			name: 'gyre_cluster',
+			options: { path: '/' }
+		});
+	});
+
+	test('keeps admin routes forbidden for non-admin users', async () => {
+		sessionData = {
+			session: { id: 'session-1' },
+			user: createUser('editor')
+		};
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event: {
+				cookies: createCookies({ gyre_session: 'session-cookie' }),
+				getClientAddress: () => '127.0.0.1',
+				locals: {} as App.Locals,
+				request: new Request('http://localhost/api/v1/admin/settings'),
+				url: new URL('http://localhost/api/v1/admin/settings')
+			},
+			resolve: async () => new Response('unreachable')
+		});
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toEqual({
+			error: 'Forbidden',
+			message: 'Admin access required'
+		});
+	});
+
+	test('maps unhandled API errors through the shared HTTP response formatter', async () => {
+		sessionData = {
+			session: { id: 'session-1' },
+			user: createUser()
+		};
+		errorResponse = {
+			status: 418,
+			body: {
+				error: 'Mapped Error',
+				message: 'Mapped Error',
+				code: 'MappedCode'
+			}
+		};
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event: {
+				cookies: createCookies({ gyre_session: 'session-cookie' }),
+				getClientAddress: () => '127.0.0.1',
+				locals: {} as App.Locals,
+				request: new Request('http://localhost/api/v1/boom'),
+				url: new URL('http://localhost/api/v1/boom')
+			},
+			resolve: async () => {
+				throw new Error('boom');
+			}
+		});
+
+		expect(response.status).toBe(418);
+		expect(await response.json()).toEqual({
+			error: 'Mapped Error',
+			message: 'Mapped Error',
+			code: 'MappedCode'
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- modularize `src/hooks.server.ts` into ordered request-pipeline helpers while preserving response behavior
- add shared Flux service, guard, and transport helpers and migrate the targeted Flux routes to thin adapters
- remove internal `/api/v1/flux/...` self-fetching from the specified server loads and add focused regression coverage

## Testing
- `bun test src/tests/request-pipeline.test.ts src/tests/flux-services.test.ts src/tests/flux-route-adapters.test.ts src/tests/flux-server-loads.test.ts src/tests/flux-list-cluster-wide-rbac.test.ts`
- `bun run format`
- `bun run lint`
- `bun run check`
- `bun run build`
- `bun run verify`
- `bun run verify:ci` *(fails in unrelated existing suites: `admin mutation audit events`, `flux-actions`, and `oauth-oidc` `validateProviderConfig` assertions)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staged server request pipeline with per-request IDs, centralized error mapping, response finalization, and Gyre init handling
  * New Flux APIs for cluster health, overview, resource listing/detail, and version
  * Conditional responses (ETag/304) and private cache headers for better caching

* **Bug Fixes & Improvements**
  * Global rate limiting and strict payload-size enforcement (413 or redirect)
  * CSRF/session cookie syncing, auth/admin-route guards, and cluster-cookie fallback
  * Consistent JSON error responses for API routes

* **Tests**
  * Comprehensive suites covering request pipeline, Flux services, routes, and loads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->