### PR TITLE
fix(server): unify cluster identity and cache scopes

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -9,7 +9,8 @@ declare global {
 		}
 		interface Locals {
 			requestId: string;
-			cluster: string | undefined;
+			/** Canonical cluster ID: "in-cluster" or an uploaded clusters.id value. */
+			cluster: import('$lib/clusters/identity').ClusterId | undefined;
 			user: import('$lib/server/db/schema').User | null;
 			session: import('$lib/server/db/schema').Session | null;
 		}

--- a/src/lib/clusters/identity.ts
+++ b/src/lib/clusters/identity.ts
@@ -1,0 +1,25 @@
+export const IN_CLUSTER_ID = 'in-cluster';
+
+export type ClusterId = string;
+
+export interface ClusterOption {
+	id: string;
+	name: string;
+	description?: string | null;
+	source: 'in-cluster' | 'uploaded';
+	isActive: boolean;
+	currentContext?: string | null;
+	connected?: boolean;
+}
+
+export function normalizeClusterId(value?: string | null): string {
+	const normalized = value?.trim();
+	if (!normalized || normalized === 'default' || normalized === IN_CLUSTER_ID) {
+		return IN_CLUSTER_ID;
+	}
+	return normalized;
+}
+
+export function isInClusterId(value: string): boolean {
+	return normalizeClusterId(value) === IN_CLUSTER_ID;
+}

--- a/src/lib/components/dashboard/ClusterConnectivityStatus.svelte
+++ b/src/lib/components/dashboard/ClusterConnectivityStatus.svelte
@@ -6,7 +6,7 @@
 		isLoading: boolean;
 		health: {
 			connected: boolean;
-			clusterName?: string;
+			currentClusterName: string;
 			error?: string;
 		};
 	}
@@ -48,7 +48,7 @@
 				<div class="min-w-0">
 					<p class="font-display text-xl leading-none font-extrabold text-foreground">Active</p>
 					<p class="mt-1.5 font-mono text-[11px] font-bold break-all text-muted-foreground">
-						{health.clusterName || 'Local-Cluster'}
+						{health.currentClusterName}
 					</p>
 				</div>
 			{:else}

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import type { ClusterOption } from '$lib/clusters/identity.js';
 	import { getResourceInfo } from '$lib/config/resources';
 	import ThemeToggle from './ThemeToggle.svelte';
 	import NotificationBell from './NotificationBell.svelte';
@@ -13,8 +14,9 @@
 	interface Props {
 		health?: {
 			connected: boolean;
-			clusterName?: string;
-			availableClusters?: string[];
+			currentClusterId: string;
+			currentClusterName: string;
+			availableClusters?: ClusterOption[];
 		};
 		fluxVersion?: string;
 		user?: {
@@ -25,7 +27,11 @@
 		} | null;
 	}
 
-	let { health = { connected: false }, fluxVersion = 'v2.x.x', user = null }: Props = $props();
+	let {
+		health = { connected: false, currentClusterId: 'in-cluster', currentClusterName: 'In-cluster' },
+		fluxVersion = 'v2.x.x',
+		user = null
+	}: Props = $props();
 
 	// Build breadcrumbs from current path
 	const breadcrumbs = $derived.by(() => {
@@ -155,7 +161,7 @@
 
 		<!-- Cluster Selector -->
 		<ClusterSwitcher
-			current={health?.clusterName}
+			currentId={health?.currentClusterId}
 			available={health?.availableClusters}
 			connected={health?.connected}
 		/>

--- a/src/lib/components/layout/AppHeader.svelte
+++ b/src/lib/components/layout/AppHeader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import type { ClusterOption } from '$lib/clusters/identity.js';
+	import { IN_CLUSTER_ID, type ClusterOption } from '$lib/clusters/identity.js';
 	import { getResourceInfo } from '$lib/config/resources';
 	import ThemeToggle from './ThemeToggle.svelte';
 	import NotificationBell from './NotificationBell.svelte';
@@ -28,7 +28,7 @@
 	}
 
 	let {
-		health = { connected: false, currentClusterId: 'in-cluster', currentClusterName: 'In-cluster' },
+		health = { connected: false, currentClusterId: IN_CLUSTER_ID, currentClusterName: 'In-cluster' },
 		fluxVersion = 'v2.x.x',
 		user = null
 	}: Props = $props();

--- a/src/lib/components/layout/ClusterSwitcher.svelte
+++ b/src/lib/components/layout/ClusterSwitcher.svelte
@@ -1,37 +1,39 @@
 <script lang="ts">
 	/* eslint-disable @typescript-eslint/no-unused-vars */
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import { IN_CLUSTER_ID, type ClusterOption } from '$lib/clusters/identity.js';
 	import { clusterStore } from '$lib/stores/cluster.svelte';
 	import { eventsStore } from '$lib/stores/events.svelte';
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import { cn } from '$lib/utils';
 
 	interface Props {
-		current?: string;
-		available?: string[];
+		currentId?: string;
+		available?: ClusterOption[];
 		connected?: boolean;
 	}
 
-	let { current, available, connected = true }: Props = $props();
+	let { currentId, available, connected = true }: Props = $props();
 
-	const currentCluster = $derived(current || clusterStore.current || 'in-cluster');
+	const currentCluster = $derived(currentId || clusterStore.current || IN_CLUSTER_ID);
 	// Merge prop data with store data, preferring store if it has data
 	const availableClusters = $derived(
 		clusterStore.available.length > 0 ? clusterStore.available : (available ?? [])
 	);
+	const selectedCluster = $derived(
+		availableClusters.find((cluster) => cluster.id === currentCluster) ?? null
+	);
 
-	function selectCluster(name: string) {
-		if (name === currentCluster) return;
-		clusterStore.setCluster(name);
+	function selectCluster(clusterId: string) {
+		if (clusterId === currentCluster) return;
+		clusterStore.setCluster(clusterId);
 	}
 </script>
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger
 		class="group flex items-center gap-1.5 rounded-md border border-transparent bg-secondary/50 px-2 py-1 text-xs font-medium transition-all hover:border-border hover:bg-secondary/80 sm:gap-2 sm:px-3 sm:py-1.5"
-		aria-label={`Current cluster: ${
-			currentCluster === 'in-cluster' ? 'In-cluster' : currentCluster
-		}. Click to switch cluster`}
+		aria-label={`Current cluster: ${selectedCluster?.name ?? currentCluster}. Click to switch cluster`}
 	>
 		<div
 			aria-hidden="true"
@@ -42,7 +44,7 @@
 		></div>
 		<span
 			class="xs:max-w-[100px] max-w-[60px] truncate font-mono text-[9px] tracking-tight sm:max-w-[150px] sm:text-[10px]"
-			>{currentCluster === 'in-cluster' ? 'In-cluster' : currentCluster}</span
+			>{selectedCluster?.name ?? currentCluster}</span
 		>
 		{#if eventsStore.clusterUnreadCounts[currentCluster] > 0}
 			<span
@@ -83,22 +85,24 @@
 				{/each}
 			</div>
 			<p class="mt-2 text-center text-[8px] text-muted-foreground/40">
-				Fetching cluster contexts...
+				Fetching clusters...
 			</p>
 		{:else}
-			{#each availableClusters as cluster (cluster)}
+			{#each availableClusters as cluster (cluster.id)}
 				<DropdownMenu.Item
-					onSelect={() => selectCluster(cluster)}
+					onSelect={() => selectCluster(cluster.id)}
 					class={cn(
 						'mb-0.5 cursor-pointer gap-3 rounded-xl px-3 py-3 transition-colors last:mb-0',
-						cluster === currentCluster ? 'bg-primary/5 hover:bg-primary/10' : 'hover:bg-accent/50'
+						cluster.id === currentCluster
+							? 'bg-primary/5 hover:bg-primary/10'
+							: 'hover:bg-accent/50'
 					)}
 				>
 					<div
 						aria-hidden="true"
 						class={cn(
 							'h-1.5 w-1.5 rounded-full transition-all duration-300',
-							cluster === currentCluster
+							cluster.id === currentCluster
 								? 'scale-150 bg-green-500 ring-4 ring-green-500/20'
 								: 'bg-muted-foreground/20'
 						)}
@@ -107,23 +111,29 @@
 						<span
 							class={cn(
 								'truncate font-mono text-[11px]',
-								cluster === currentCluster ? 'font-bold text-foreground' : 'text-muted-foreground'
-							)}>{cluster === 'in-cluster' ? 'In-cluster' : cluster}</span
+								cluster.id === currentCluster
+									? 'font-bold text-foreground'
+									: 'text-muted-foreground'
+							)}>{cluster.name}</span
 						>
-						{#if cluster === currentCluster}
+						{#if cluster.id === currentCluster}
 							<span class="text-[8px] font-black tracking-widest text-green-500/60 uppercase"
 								>Active Context</span
 							>
+						{:else if cluster.description}
+							<span class="truncate text-[9px] text-muted-foreground/60">
+								{cluster.description}
+							</span>
 						{/if}
 					</div>
-					{#if eventsStore.clusterUnreadCounts[cluster] > 0}
+					{#if eventsStore.clusterUnreadCounts[cluster.id] > 0}
 						<span
 							class="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white shadow-sm"
 						>
-							{eventsStore.clusterUnreadCounts[cluster]}
+							{eventsStore.clusterUnreadCounts[cluster.id]}
 						</span>
 					{/if}
-					{#if cluster === currentCluster}
+					{#if cluster.id === currentCluster}
 						<Icon name="check" size={12} class="text-green-500" />
 					{/if}
 				</DropdownMenu.Item>

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -786,6 +786,7 @@ import type { UserPreferences } from '$lib/types/user';
  * Shape user object for public consumption (e.g., in layout data)
  */
 export function serializeUser(user: User | null): {
+	id: string;
 	username: string;
 	role: string;
 	email: string | null;
@@ -794,6 +795,7 @@ export function serializeUser(user: User | null): {
 } | null {
 	if (!user) return null;
 	return {
+		id: user.id,
 		username: user.username,
 		role: user.role,
 		email: user.email,

--- a/src/lib/server/clusters.ts
+++ b/src/lib/server/clusters.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger.js';
+import { IN_CLUSTER_ID, type ClusterOption } from '$lib/clusters/identity.js';
 import { eq, desc, or, sql } from 'drizzle-orm';
 import { getDbSync } from './db/index.js';
 import { getPaginatedItems, sanitizeSearchInput } from './db/utils.js';
@@ -221,6 +222,37 @@ export async function getAllClusters(): Promise<(typeof clusters.$inferSelect)[]
 	return db.query.clusters.findMany({
 		orderBy: [desc(clusters.createdAt)]
 	});
+}
+
+/**
+ * Get selectable cluster identities for UI/API selection.
+ * Kubeconfig context names are diagnostic metadata only; uploaded clusters are
+ * selected by their stable clusters.id values.
+ */
+export async function getSelectableClusters(
+	_selectedClusterId: string,
+	currentContext?: string | null
+): Promise<ClusterOption[]> {
+	const uploadedClusters = (await getAllClusters()).filter((cluster) => cluster.isActive);
+
+	return [
+		{
+			id: IN_CLUSTER_ID,
+			name: 'In-cluster',
+			description: 'Runtime Kubernetes configuration',
+			source: 'in-cluster',
+			isActive: true,
+			currentContext
+		},
+		...uploadedClusters.map((cluster) => ({
+			id: cluster.id,
+			name: cluster.name,
+			description: cluster.description,
+			source: 'uploaded' as const,
+			isActive: cluster.isActive,
+			currentContext: null
+		}))
+	];
 }
 
 /**

--- a/src/lib/server/clusters.ts
+++ b/src/lib/server/clusters.ts
@@ -230,7 +230,6 @@ export async function getAllClusters(): Promise<(typeof clusters.$inferSelect)[]
  * selected by their stable clusters.id values.
  */
 export async function getSelectableClusters(
-	_selectedClusterId: string,
 	currentContext?: string | null
 ): Promise<ClusterOption[]> {
 	const uploadedClusters = (await getAllClusters()).filter((cluster) => cluster.isActive);

--- a/src/lib/server/dashboard-cache.ts
+++ b/src/lib/server/dashboard-cache.ts
@@ -3,8 +3,17 @@ import { DASHBOARD_CACHE_TTL_MS } from '$lib/server/config/constants';
 const MAX_DASHBOARD_CACHE_SIZE = 50;
 
 type DashboardEntry = { data: unknown; timestamp: number };
+export interface DashboardCacheKeyParts {
+	userId: string;
+	role: string;
+	clusterId: string;
+}
 
 const cache = new Map<string, DashboardEntry>();
+
+export function getDashboardCacheKey({ userId, role, clusterId }: DashboardCacheKeyParts): string {
+	return `dashboard:user:${userId}:role:${role}:cluster:${clusterId}`;
+}
 
 function prune(upcomingKey: string) {
 	const now = Date.now();
@@ -36,10 +45,16 @@ export function setDashboardCache(key: string, data: unknown) {
 	cache.set(key, { data, timestamp: Date.now() });
 }
 
-export function invalidateDashboardCache(clusterName?: string) {
-	if (clusterName !== undefined) {
-		cache.delete(`dashboard-${clusterName}`);
-	} else {
+export function invalidateDashboardCache(clusterId?: string) {
+	if (clusterId === undefined) {
 		cache.clear();
+		return;
+	}
+
+	const suffix = `:cluster:${clusterId}`;
+	for (const key of cache.keys()) {
+		if (key.endsWith(suffix)) {
+			cache.delete(key);
+		}
 	}
 }

--- a/src/lib/server/events.ts
+++ b/src/lib/server/events.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger.js';
+import { IN_CLUSTER_ID } from '$lib/clusters/identity.js';
 import { listFluxResources } from './kubernetes/client.js';
 import type { FluxResourceType } from './kubernetes/flux/resources.js';
 import type { FluxResource, K8sCondition } from './kubernetes/flux/types.js';
@@ -123,7 +124,7 @@ export async function closeAllEventStreams() {
  * @param clusterId - The cluster to watch
  * @param subscriber - Callback for events
  */
-export function subscribe(subscriber: Subscriber, clusterId: string = 'in-cluster'): () => void {
+export function subscribe(subscriber: Subscriber, clusterId: string = IN_CLUSTER_ID): () => void {
 	// Prevent new subscriptions during shutdown
 	if (isShuttingDown) {
 		logger.warn({ clusterId }, '[EventBus] Rejecting new subscription: shutting down');

--- a/src/lib/server/events.ts
+++ b/src/lib/server/events.ts
@@ -257,7 +257,7 @@ async function poll(context: ClusterContext) {
 				// Pass clusterId to listFluxResources to get resources from the correct cluster
 				const resourceList = await listFluxResources(
 					resourceType,
-					context.clusterId === 'in-cluster' ? undefined : context.clusterId
+					context.clusterId === IN_CLUSTER_ID ? undefined : context.clusterId
 				);
 
 				if (!context.isActive) return;

--- a/src/lib/server/flux/services.ts
+++ b/src/lib/server/flux/services.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 import * as k8s from '@kubernetes/client-node';
-import { IN_CLUSTER_ID, normalizeClusterId } from '$lib/clusters/identity.js';
+import { normalizeClusterId } from '$lib/clusters/identity.js';
 import {
 	getFluxResource,
 	getFluxResourceStatus,
@@ -104,7 +104,7 @@ export async function getFluxHealthSummary({
 		const config = await getKubeConfig(selectedCluster);
 		const currentContext = config.getCurrentContext();
 
-		const cacheKey = selectedCluster ?? IN_CLUSTER_ID;
+		const cacheKey = selectedCluster;
 		const cached = connectionCache.get(cacheKey) || { connected: false, timestamp: 0 };
 
 		let isValid = false;

--- a/src/lib/server/flux/services.ts
+++ b/src/lib/server/flux/services.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import * as k8s from '@kubernetes/client-node';
+import { IN_CLUSTER_ID, normalizeClusterId } from '$lib/clusters/identity.js';
 import {
 	getFluxResource,
 	getFluxResourceStatus,
@@ -23,7 +24,6 @@ export const DEFAULT_FLUX_VERSION = 'v2.x.x';
 
 const MAX_CONNECTION_CACHE_SIZE = 20;
 const CONNECTION_CACHE_TTL = 30 * 1000;
-const NO_CLUSTER_SELECTED_CACHE_KEY = '__NO_CLUSTER_SELECTED__';
 
 const connectionCache = new Map<string, { connected: boolean; timestamp: number }>();
 
@@ -100,11 +100,11 @@ export async function getFluxHealthSummary({
 	includeDetails: boolean;
 }) {
 	try {
-		const selectedCluster = locals.cluster;
+		const selectedCluster = normalizeClusterId(locals.cluster);
 		const config = await getKubeConfig(selectedCluster);
 		const currentContext = config.getCurrentContext();
 
-		const cacheKey = selectedCluster ?? NO_CLUSTER_SELECTED_CACHE_KEY;
+		const cacheKey = selectedCluster ?? IN_CLUSTER_ID;
 		const cached = connectionCache.get(cacheKey) || { connected: false, timestamp: 0 };
 
 		let isValid = false;

--- a/src/lib/server/kubernetes/client.ts
+++ b/src/lib/server/kubernetes/client.ts
@@ -526,7 +526,7 @@ export async function getCustomObjectsApi(
 ): Promise<k8s.CustomObjectsApi> {
 	const key = normalizeClusterId(context);
 	return getOrCreate(customObjectsPool, `${key}:${timeoutMs}`, async () => {
-		const config = await getKubeConfig(context, reqCache);
+		const config = await getKubeConfig(key, reqCache);
 		return makeApiClientWithTimeout(config, k8s.CustomObjectsApi, timeoutMs);
 	});
 }
@@ -543,7 +543,7 @@ export async function getCoreV1Api(
 ): Promise<k8s.CoreV1Api> {
 	const key = normalizeClusterId(context);
 	return getOrCreate(coreV1Pool, `${key}:${timeoutMs}`, async () => {
-		const config = await getKubeConfig(context, reqCache);
+		const config = await getKubeConfig(key, reqCache);
 		return makeApiClientWithTimeout(config, k8s.CoreV1Api, timeoutMs);
 	});
 }
@@ -560,7 +560,7 @@ export async function getAppsV1Api(
 ): Promise<k8s.AppsV1Api> {
 	const key = normalizeClusterId(context);
 	return getOrCreate(appsV1Pool, `${key}:${timeoutMs}`, async () => {
-		const config = await getKubeConfig(context, reqCache);
+		const config = await getKubeConfig(key, reqCache);
 		return makeApiClientWithTimeout(config, k8s.AppsV1Api, timeoutMs);
 	});
 }

--- a/src/lib/server/kubernetes/client.ts
+++ b/src/lib/server/kubernetes/client.ts
@@ -1,4 +1,5 @@
 import { logger } from '../logger.js';
+import { IN_CLUSTER_ID, normalizeClusterId } from '$lib/clusters/identity.js';
 import * as k8s from '@kubernetes/client-node';
 import * as http from 'http';
 import * as https from 'https';
@@ -233,7 +234,7 @@ let baseConfig: k8s.KubeConfig | null = null;
 export type ReqCache = Map<string, Promise<k8s.KubeConfig>>;
 
 // ---------------------------------------------------------------------------
-// Connection pool — singleton API clients per cluster context
+// Connection pool — singleton API clients per canonical cluster ID
 // ---------------------------------------------------------------------------
 
 const POOL_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -307,14 +308,31 @@ export function getPoolMetrics() {
 	};
 }
 
-/** Evicts all pooled clients. Exposed via POST /api/v1/admin/k8s/clear-client-pool. */
-export function clearClientPool() {
-	customObjectsPool.clear();
-	coreV1Pool.clear();
-	appsV1Pool.clear();
-	poolMetricsState.hits = 0;
-	poolMetricsState.misses = 0;
-	poolMetricsState.evictions = 0;
+function clearPoolByPrefix<T>(pool: Map<string, PoolEntry<T>>, prefix: string) {
+	for (const key of pool.keys()) {
+		if (key.startsWith(prefix)) {
+			pool.delete(key);
+			poolMetricsState.evictions++;
+		}
+	}
+}
+
+/** Evicts pooled clients. Exposed via POST /api/v1/admin/k8s/clear-client-pool. */
+export function clearClientPool(clusterId?: string) {
+	if (clusterId === undefined) {
+		customObjectsPool.clear();
+		coreV1Pool.clear();
+		appsV1Pool.clear();
+		poolMetricsState.hits = 0;
+		poolMetricsState.misses = 0;
+		poolMetricsState.evictions = 0;
+		return;
+	}
+
+	const prefix = `${normalizeClusterId(clusterId)}:`;
+	clearPoolByPrefix(customObjectsPool, prefix);
+	clearPoolByPrefix(coreV1Pool, prefix);
+	clearPoolByPrefix(appsV1Pool, prefix);
 }
 
 /**
@@ -365,7 +383,7 @@ export function auditLogSecretAccess(
 ): void {
 	const timestamp = new Date().toISOString();
 	const resourceId = name ? `${namespace}/${name}` : namespace;
-	const msg = `[AUDIT] ${operation.toUpperCase()} ${resourceType} ${resourceId} (context: ${context || 'in-cluster'}) at ${timestamp}`;
+	const msg = `[AUDIT] ${operation.toUpperCase()} ${resourceType} ${resourceId} (context: ${normalizeClusterId(context)}) at ${timestamp}`;
 
 	// Use warn level for sensitive resource access to ensure it's logged to files
 	logger.warn(msg);
@@ -432,15 +450,15 @@ async function getOrCreate<T>(
 }
 
 /**
- * Get or create KubeConfig for a specific cluster or context.
+ * Get or create KubeConfig for a specific canonical cluster ID.
  * Only caches successful configs; failed promises are not cached to allow retries.
- * @param clusterIdOrContext - Optional cluster ID (UUID) or context name
+ * @param clusterId - Optional cluster ID. undefined/default/in-cluster select the runtime config.
  */
 export async function getKubeConfig(
-	clusterIdOrContext?: string,
+	clusterId?: string,
 	reqCache?: ReqCache
 ): Promise<k8s.KubeConfig> {
-	const key = clusterIdOrContext || 'in-cluster';
+	const key = normalizeClusterId(clusterId);
 
 	// Check cache for successful configs only
 	if (reqCache && reqCache.has(key)) {
@@ -451,20 +469,15 @@ export async function getKubeConfig(
 	}
 
 	const loadConfig = async () => {
-		// 1. Load the base configuration if not already loaded
-		if (!baseConfig) {
-			baseConfig = loadKubeConfig();
-		}
-
 		let config: k8s.KubeConfig;
 
-		// 2. Determine if it's a cluster ID (UUID), a context name, or default
-		// Improved UUID validation per RFC 4122 (version in 3rd group, variant in 4th group)
-		const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[3-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-		const isUuid = uuidRegex.test(key);
-
-		if (isUuid) {
-			// Load from database
+		if (key === IN_CLUSTER_ID) {
+			if (!baseConfig) {
+				baseConfig = loadKubeConfig();
+			}
+			config = new k8s.KubeConfig();
+			config.loadFromString(baseConfig.exportConfig());
+		} else {
 			const kubeconfigYaml = await getClusterKubeconfig(key);
 			if (!kubeconfigYaml) {
 				throw new Error(`Cluster with ID "${key}" not found or has no valid configuration`);
@@ -472,27 +485,8 @@ export async function getKubeConfig(
 			config = new k8s.KubeConfig();
 			config.loadFromString(kubeconfigYaml);
 			logger.debug(`✓ Loaded Kubernetes configuration from database for cluster: ${key}`);
-		} else if (key !== 'in-cluster' && key !== 'default') {
-			// It's a context name - check if it exists in the base config
-			const availableContexts = baseConfig.getContexts().map((c) => c.name);
-			if (availableContexts.includes(key)) {
-				// Create a clone of the base config and switch context
-				config = new k8s.KubeConfig();
-				config.loadFromString(baseConfig.exportConfig());
-				config.setCurrentContext(key);
-				logger.debug(`✓ Switched to Kubernetes context: ${key}`);
-			} else {
-				throw new Error(
-					`Context "${key}" not found in kubeconfig. Available: ${availableContexts.join(', ')}`
-				);
-			}
-		} else {
-			// Default context
-			config = new k8s.KubeConfig();
-			config.loadFromString(baseConfig.exportConfig());
 		}
 
-		// 3. Return configuration
 		return config;
 	};
 
@@ -523,14 +517,15 @@ export async function getKubeConfig(
 /**
  * Create CustomObjectsApi client, reusing a pooled instance when possible.
  * getKubeConfig is invoked inside the factory so it is only called on cache misses.
- * @param context - Optional cluster ID or context name
+ * @param context - Optional canonical cluster ID
  */
 export async function getCustomObjectsApi(
 	context?: string,
 	reqCache?: ReqCache,
 	timeoutMs = OPERATION_TIMEOUTS.list
 ): Promise<k8s.CustomObjectsApi> {
-	return getOrCreate(customObjectsPool, `${context || 'in-cluster'}:${timeoutMs}`, async () => {
+	const key = normalizeClusterId(context);
+	return getOrCreate(customObjectsPool, `${key}:${timeoutMs}`, async () => {
 		const config = await getKubeConfig(context, reqCache);
 		return makeApiClientWithTimeout(config, k8s.CustomObjectsApi, timeoutMs);
 	});
@@ -539,14 +534,15 @@ export async function getCustomObjectsApi(
 /**
  * Create CoreV1Api client, reusing a pooled instance when possible.
  * getKubeConfig is invoked inside the factory so it is only called on cache misses.
- * @param context - Optional cluster ID or context name
+ * @param context - Optional canonical cluster ID
  */
 export async function getCoreV1Api(
 	context?: string,
 	reqCache?: ReqCache,
 	timeoutMs = OPERATION_TIMEOUTS.get
 ): Promise<k8s.CoreV1Api> {
-	return getOrCreate(coreV1Pool, `${context || 'in-cluster'}:${timeoutMs}`, async () => {
+	const key = normalizeClusterId(context);
+	return getOrCreate(coreV1Pool, `${key}:${timeoutMs}`, async () => {
 		const config = await getKubeConfig(context, reqCache);
 		return makeApiClientWithTimeout(config, k8s.CoreV1Api, timeoutMs);
 	});
@@ -555,14 +551,15 @@ export async function getCoreV1Api(
 /**
  * Create AppsV1Api client, reusing a pooled instance when possible.
  * getKubeConfig is invoked inside the factory so it is only called on cache misses.
- * @param context - Optional cluster ID or context name
+ * @param context - Optional canonical cluster ID
  */
 export async function getAppsV1Api(
 	context?: string,
 	reqCache?: ReqCache,
 	timeoutMs = OPERATION_TIMEOUTS.get
 ): Promise<k8s.AppsV1Api> {
-	return getOrCreate(appsV1Pool, `${context || 'in-cluster'}:${timeoutMs}`, async () => {
+	const key = normalizeClusterId(context);
+	return getOrCreate(appsV1Pool, `${key}:${timeoutMs}`, async () => {
 		const config = await getKubeConfig(context, reqCache);
 		return makeApiClientWithTimeout(config, k8s.AppsV1Api, timeoutMs);
 	});

--- a/src/lib/server/kubernetes/flux/history.ts
+++ b/src/lib/server/kubernetes/flux/history.ts
@@ -1,4 +1,4 @@
-import { IN_CLUSTER_ID } from '$lib/clusters/identity.js';
+import { normalizeClusterId } from '$lib/clusters/identity.js';
 import { logger } from '../../logger.js';
 import { getCustomObjectsApi } from '../client.js';
 import type { FluxResourceType } from './resources.js';
@@ -23,7 +23,7 @@ export async function getResourceHistory(
 	context?: string
 ): Promise<ResourceRevision[]> {
 	// Use the new reconciliation history system for all resources
-	const clusterId = context || IN_CLUSTER_ID;
+	const clusterId = normalizeClusterId(context);
 	const history = await getReconciliationHistory(type, namespace, name, clusterId);
 
 	// Transform to the expected format for backward compatibility
@@ -54,7 +54,7 @@ export async function rollbackResource(
 	context?: string,
 	dryRun?: boolean
 ): Promise<{ patch: object; historyEntry: { id: string; revision: string | null } } | void> {
-	const clusterId = context || IN_CLUSTER_ID;
+	const clusterId = normalizeClusterId(context);
 
 	// 1. Fetch history entry to get spec snapshot
 	const history = await getReconciliationHistory(type, namespace, name, clusterId);

--- a/src/lib/server/kubernetes/flux/history.ts
+++ b/src/lib/server/kubernetes/flux/history.ts
@@ -1,3 +1,4 @@
+import { IN_CLUSTER_ID } from '$lib/clusters/identity.js';
 import { logger } from '../../logger.js';
 import { getCustomObjectsApi } from '../client.js';
 import type { FluxResourceType } from './resources.js';
@@ -22,7 +23,7 @@ export async function getResourceHistory(
 	context?: string
 ): Promise<ResourceRevision[]> {
 	// Use the new reconciliation history system for all resources
-	const clusterId = context || 'in-cluster';
+	const clusterId = context || IN_CLUSTER_ID;
 	const history = await getReconciliationHistory(type, namespace, name, clusterId);
 
 	// Transform to the expected format for backward compatibility
@@ -53,7 +54,7 @@ export async function rollbackResource(
 	context?: string,
 	dryRun?: boolean
 ): Promise<{ patch: object; historyEntry: { id: string; revision: string | null } } | void> {
-	const clusterId = context || 'in-cluster';
+	const clusterId = context || IN_CLUSTER_ID;
 
 	// 1. Fetch history entry to get spec snapshot
 	const history = await getReconciliationHistory(type, namespace, name, clusterId);

--- a/src/lib/server/request/access.ts
+++ b/src/lib/server/request/access.ts
@@ -1,4 +1,5 @@
 import { ADMIN_ROUTE_PREFIXES } from '$lib/server/config.js';
+import { IN_CLUSTER_ID } from '$lib/clusters/identity.js';
 import { getClusterById } from '$lib/server/clusters.js';
 import { isPublicRoute } from '$lib/isPublicRoute.js';
 import type { RequestEvent } from '@sveltejs/kit';
@@ -42,11 +43,11 @@ export async function resolveClusterContext(
 ): Promise<void> {
 	const cluster = event.cookies.get('gyre_cluster');
 	if (!cluster) {
-		event.locals.cluster = 'in-cluster';
+		event.locals.cluster = IN_CLUSTER_ID;
 		return;
 	}
 
-	if (cluster === 'in-cluster') {
+	if (cluster === IN_CLUSTER_ID) {
 		event.locals.cluster = cluster;
 		return;
 	}
@@ -54,7 +55,7 @@ export async function resolveClusterContext(
 	const clusterRecord = await getClusterById(cluster);
 	if (!clusterRecord || !clusterRecord.isActive) {
 		event.cookies.delete('gyre_cluster', { path: '/' });
-		event.locals.cluster = 'in-cluster';
+		event.locals.cluster = IN_CLUSTER_ID;
 		return;
 	}
 

--- a/src/lib/server/settings.ts
+++ b/src/lib/server/settings.ts
@@ -6,7 +6,6 @@
 import { getDb } from './db';
 import { appSettings } from './db/schema';
 import { eq } from 'drizzle-orm';
-import { SETTINGS_CACHE_TTL_MS } from './config/constants.js';
 
 // Settings keys
 export const SETTINGS_KEYS = {
@@ -43,16 +42,8 @@ const ENV_OVERRIDES: Record<string, string> = {
 	[SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS]: 'GYRE_AUDIT_LOG_RETENTION_DAYS'
 };
 
-// In-memory cache with TTL
-interface CacheEntry {
-	value: string;
-	timestamp: number;
-}
-
-const cache = new Map<string, CacheEntry>();
-
 /**
- * Get a setting value with env var override and caching support.
+ * Get a setting value with env var override.
  * @param key - Setting key
  * @returns Setting value (env var > DB > default)
  */
@@ -63,24 +54,13 @@ export async function getSetting(key: string): Promise<string> {
 		return process.env[envVar]!;
 	}
 
-	// Check cache
-	const cached = cache.get(key);
-	if (cached && Date.now() - cached.timestamp < SETTINGS_CACHE_TTL_MS) {
-		return cached.value;
-	}
-
 	// Query database
 	const db = await getDb();
 	const setting = await db.query.appSettings.findFirst({
 		where: eq(appSettings.key, key)
 	});
 
-	const value = setting?.value ?? getDefaultValue(key);
-
-	// Update cache
-	cache.set(key, { value, timestamp: Date.now() });
-
-	return value;
+	return setting?.value ?? getDefaultValue(key);
 }
 
 /**
@@ -104,9 +84,6 @@ export async function setSetting(key: string, value: string): Promise<void> {
 			target: appSettings.key,
 			set: { value, updatedAt: new Date() }
 		});
-
-	// Invalidate cache
-	cache.delete(key);
 }
 
 /**

--- a/src/lib/stores/cluster.svelte.ts
+++ b/src/lib/stores/cluster.svelte.ts
@@ -1,12 +1,13 @@
 import { browser } from '$app/environment';
+import { IN_CLUSTER_ID, normalizeClusterId, type ClusterOption } from '$lib/clusters/identity.js';
 import Cookies from 'js-cookie';
 
 /**
  * Cluster Store using Svelte 5's $state
  */
 class ClusterStore {
-	current = $state<string | undefined>(undefined);
-	available = $state<string[]>([]);
+	current = $state<string>(IN_CLUSTER_ID);
+	available = $state<ClusterOption[]>([]);
 	loaded = $state<boolean>(false);
 	error = $state<string | null>(null);
 
@@ -14,16 +15,15 @@ class ClusterStore {
 		// Initialize from cookie if in browser
 		if (browser) {
 			const value = Cookies.get('gyre_cluster');
-			if (value) {
-				this.current = value;
-			}
+			this.current = normalizeClusterId(value);
 		}
 	}
 
-	setCluster(name: string) {
-		this.current = name;
+	setCluster(id: string) {
+		const normalizedId = normalizeClusterId(id);
+		this.current = normalizedId;
 		if (browser) {
-			Cookies.set('gyre_cluster', name, {
+			Cookies.set('gyre_cluster', normalizedId, {
 				expires: 30,
 				path: '/',
 				secure: true,
@@ -34,16 +34,17 @@ class ClusterStore {
 		}
 	}
 
-	setAvailable(clusters: string[]) {
-		this.available = clusters;
-		this.loaded = true;
-		this.error = null;
+	setCurrent(id: string) {
+		this.current = normalizeClusterId(id);
 	}
 
-	setError(message: string) {
-		this.error = message;
+	setAvailable(clusters: ClusterOption[]) {
+		this.available = clusters;
 		this.loaded = true;
-		this.available = [];
+	}
+
+	setError(message: string | null) {
+		this.error = message;
 	}
 }
 

--- a/src/lib/stores/events.svelte.ts
+++ b/src/lib/stores/events.svelte.ts
@@ -65,6 +65,15 @@ export interface NotificationMessage {
 type EventCallback = (event: ResourceEvent) => void;
 type StatusCallback = (status: ConnectionStatus) => void;
 
+function hashStorageUserIdentity(value: string): string {
+	let hash = 0xcbf29ce484222325n;
+	for (const byte of new TextEncoder().encode(value)) {
+		hash ^= BigInt(byte);
+		hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+	}
+	return hash.toString(16).padStart(16, '0');
+}
+
 class RealtimeStore {
 	private eventSource: EventSource | null = null;
 	private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -112,7 +121,9 @@ class RealtimeStore {
 
 	private getStorageKeys() {
 		const clusterId = normalizeClusterId(this.storageClusterId);
-		const userScope = this.storageUserIdentity ?? 'anonymous';
+		const userScope = this.storageUserIdentity
+			? hashStorageUserIdentity(this.storageUserIdentity)
+			: 'anonymous';
 		return {
 			notifications: `gyre_notifications_${clusterId}_${userScope}`,
 			state: `gyre_notification_state_${clusterId}_${userScope}`

--- a/src/lib/stores/events.svelte.ts
+++ b/src/lib/stores/events.svelte.ts
@@ -3,6 +3,7 @@
  * Falls back to polling if SSE is not available
  */
 
+import { IN_CLUSTER_ID, normalizeClusterId } from '$lib/clusters/identity.js';
 import { preferences } from './preferences.svelte';
 import { clusterStore } from './cluster.svelte';
 import { logger } from '$lib/utils/logger.js';
@@ -64,14 +65,6 @@ export interface NotificationMessage {
 type EventCallback = (event: ResourceEvent) => void;
 type StatusCallback = (status: ConnectionStatus) => void;
 
-function getStorageKeys() {
-	const cluster = clusterStore.current ?? 'default';
-	return {
-		notifications: `gyre_notifications_${cluster}`,
-		state: `gyre_notification_state_${cluster}`
-	};
-}
-
 class RealtimeStore {
 	private eventSource: EventSource | null = null;
 	private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -88,6 +81,8 @@ class RealtimeStore {
 
 	// Tracks the server process session; used to detect server restarts and clear stale state
 	private lastServerSessionId: string | null = null;
+	private storageClusterId = $state<string>(normalizeClusterId(clusterStore.current));
+	private storageUserIdentity = $state<string | null>(null);
 
 	// Reactive state using Svelte 5 runes
 	status = $state<ConnectionStatus>('disconnected');
@@ -115,8 +110,38 @@ class RealtimeStore {
 		}
 	}
 
+	private getStorageKeys() {
+		const clusterId = normalizeClusterId(this.storageClusterId);
+		const userScope = this.storageUserIdentity ?? 'anonymous';
+		return {
+			notifications: `gyre_notifications_${clusterId}_${userScope}`,
+			state: `gyre_notification_state_${clusterId}_${userScope}`
+		};
+	}
+
+	setStorageScope({
+		clusterId,
+		userIdentity
+	}: {
+		clusterId?: string | null;
+		userIdentity?: string | null;
+	}) {
+		const nextClusterId = normalizeClusterId(clusterId ?? this.storageClusterId);
+		const nextUserIdentity = userIdentity ?? null;
+		if (nextClusterId === this.storageClusterId && nextUserIdentity === this.storageUserIdentity) {
+			return;
+		}
+
+		this.storageClusterId = nextClusterId;
+		this.storageUserIdentity = nextUserIdentity;
+		this.notifications = [];
+		this.lastNotificationState.clear();
+		this.lastServerSessionId = null;
+		this.loadFromStorage();
+	}
+
 	private loadFromStorage() {
-		const keys = getStorageKeys();
+		const keys = this.getStorageKeys();
 		try {
 			// Load notifications for the current cluster
 			const storedNotifications = localStorage.getItem(keys.notifications);
@@ -125,7 +150,7 @@ class RealtimeStore {
 				// Convert timestamp strings back to Date objects and ensure clusterId exists
 				this.notifications = parsed.map((n: NotificationMessage) => ({
 					...n,
-					clusterId: n.clusterId || 'in-cluster',
+					clusterId: n.clusterId || IN_CLUSTER_ID,
 					timestamp: new Date(n.timestamp)
 				}));
 			}
@@ -189,7 +214,7 @@ class RealtimeStore {
 	private saveToStorage() {
 		if (typeof window === 'undefined') return;
 
-		const keys = getStorageKeys();
+		const keys = this.getStorageKeys();
 		try {
 			// Save only the most recent notifications to avoid localStorage quota issues.
 			const toSave = this.notifications.slice(0, MAX_NOTIFICATIONS);
@@ -406,7 +431,7 @@ class RealtimeStore {
 			return;
 		}
 
-		const clusterId = event.clusterId || 'in-cluster';
+		const clusterId = event.clusterId || IN_CLUSTER_ID;
 		const resourceKey = `${clusterId}/${event.resourceType}/${event.resource.metadata.namespace}/${event.resource.metadata.name}`;
 		const readyCondition = event.resource.status?.conditions?.find((c) => c.type === 'Ready');
 

--- a/src/lib/stores/resourceCache.svelte.ts
+++ b/src/lib/stores/resourceCache.svelte.ts
@@ -1,4 +1,6 @@
+import { IN_CLUSTER_ID, normalizeClusterId } from '$lib/clusters/identity.js';
 import { eventsStore } from './events.svelte';
+import { clusterStore } from './cluster.svelte';
 import { resolveResourceRouteType } from '$lib/config/resources';
 import type { FluxResource } from '$lib/types/flux';
 import { fetchWithRetry } from '$lib/utils/fetch';
@@ -18,6 +20,10 @@ class ResourceCacheStore {
 	private listCache = $state<Record<string, CacheEntry<FluxResource[]>>>({});
 	private ttl = 30000;
 
+	private getCurrentClusterId(): string {
+		return normalizeClusterId(clusterStore.current ?? IN_CLUSTER_ID);
+	}
+
 	private normalizeType(type: string): string {
 		return resolveResourceRouteType(type) ?? type;
 	}
@@ -34,25 +40,37 @@ class ResourceCacheStore {
 
 			const { name, namespace } = event.resource.metadata;
 			const type = event.resourceType;
+			const clusterId = normalizeClusterId(event.clusterId ?? IN_CLUSTER_ID);
 
 			// Invalidate specific resource
-			this.invalidateResource(type, namespace, name);
+			this.invalidateResource(type, namespace, name, clusterId);
 
 			// Invalidate global list and namespace-specific list
-			this.invalidateList(type);
+			this.invalidateList(type, undefined, clusterId);
 			if (namespace) {
-				this.invalidateList(type, namespace);
+				this.invalidateList(type, namespace, clusterId);
 			}
 		});
 	}
 
-	private getResourceKey(type: string, namespace: string, name: string): string {
-		return `${this.normalizeType(type)}:${namespace}:${name}`;
+	private getResourceKey(
+		type: string,
+		namespace: string,
+		name: string,
+		clusterId = this.getCurrentClusterId()
+	): string {
+		return `${clusterId}:${this.normalizeType(type)}:${namespace}:${name}`;
 	}
 
-	private getListKey(type: string, namespace?: string): string {
+	private getListKey(
+		type: string,
+		namespace?: string,
+		clusterId = this.getCurrentClusterId()
+	): string {
 		const normalizedType = this.normalizeType(type);
-		return namespace ? `${normalizedType}:${namespace}` : normalizedType;
+		return namespace
+			? `${clusterId}:${normalizedType}:${namespace}`
+			: `${clusterId}:${normalizedType}`;
 	}
 
 	private getCachedResourceEntry(type: string, namespace: string, name: string) {
@@ -134,13 +152,13 @@ class ResourceCacheStore {
 		});
 	}
 
-	invalidateResource(type: string, namespace: string, name: string) {
-		const key = this.getResourceKey(type, namespace, name);
+	invalidateResource(type: string, namespace: string, name: string, clusterId?: string) {
+		const key = this.getResourceKey(type, namespace, name, clusterId);
 		delete this.resourceCache[key];
 	}
 
-	invalidateList(type: string, namespace?: string) {
-		const key = this.getListKey(type, namespace);
+	invalidateList(type: string, namespace?: string, clusterId?: string) {
+		const key = this.getListKey(type, namespace, clusterId);
 		delete this.listCache[key];
 	}
 

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,6 +1,8 @@
 import type { LayoutServerLoad } from './$types';
 import pkg from '../../package.json';
+import { IN_CLUSTER_ID, type ClusterOption } from '$lib/clusters/identity.js';
 import { serializeUser } from '$lib/server/auth';
+import { getSelectableClusters } from '$lib/server/clusters.js';
 import {
 	DEFAULT_FLUX_VERSION,
 	getFluxHealthSummary,
@@ -20,30 +22,50 @@ function isHttpErrorLike(error: unknown): error is { status: number } {
 export const load: LayoutServerLoad = async ({ locals, depends }) => {
 	depends('gyre:layout');
 
+	const selectedClusterId = locals.cluster ?? IN_CLUSTER_ID;
 	let health: {
 		connected: boolean;
-		clusterName?: string;
-		availableClusters: string[];
+		currentClusterId: string;
+		currentClusterName: string;
+		availableClusters: ClusterOption[];
 		error?: string;
 	};
+	let currentContext: string | null = null;
+	let availableClusters: ClusterOption[] = [];
 
 	try {
 		const healthData = await getFluxHealthSummary({
 			locals,
 			includeDetails: Boolean(locals.user)
 		});
+		currentContext = healthData.kubernetes?.currentContext ?? null;
+		availableClusters = await getSelectableClusters(selectedClusterId, currentContext);
+		const connected = healthData.kubernetes?.connected ?? healthData.status === 'healthy';
+		availableClusters = availableClusters.map((cluster) => ({
+			...cluster,
+			connected: cluster.id === selectedClusterId ? connected : cluster.connected
+		}));
+		const selectedCluster = availableClusters.find((cluster) => cluster.id === selectedClusterId);
 
 		health = {
-			connected: healthData.kubernetes?.connected ?? false,
-			clusterName: healthData.kubernetes?.currentContext ?? undefined,
-			availableClusters: healthData.kubernetes?.availableContexts ?? [],
+			connected,
+			currentClusterId: selectedClusterId,
+			currentClusterName: selectedCluster?.name ?? selectedClusterId,
+			availableClusters,
 			error: undefined
 		};
 	} catch (error) {
+		try {
+			availableClusters = await getSelectableClusters(selectedClusterId, currentContext);
+		} catch {
+			availableClusters = [];
+		}
+		const selectedCluster = availableClusters.find((cluster) => cluster.id === selectedClusterId);
 		health = {
 			connected: false,
-			clusterName: undefined,
-			availableClusters: [],
+			currentClusterId: selectedClusterId,
+			currentClusterName: selectedCluster?.name ?? selectedClusterId,
+			availableClusters,
 			error: isHttpErrorLike(error)
 				? 'Failed to retrieve cluster health status'
 				: error instanceof Error

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -39,11 +39,11 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 			includeDetails: Boolean(locals.user)
 		});
 		currentContext = healthData.kubernetes?.currentContext ?? null;
-		availableClusters = await getSelectableClusters(selectedClusterId, currentContext);
+		availableClusters = await getSelectableClusters(currentContext);
 		const connected = healthData.kubernetes?.connected ?? healthData.status === 'healthy';
 		availableClusters = availableClusters.map((cluster) => ({
 			...cluster,
-			connected: cluster.id === selectedClusterId ? connected : cluster.connected
+			connected: cluster.id === selectedClusterId ? connected : false
 		}));
 		const selectedCluster = availableClusters.find((cluster) => cluster.id === selectedClusterId);
 
@@ -56,7 +56,11 @@ export const load: LayoutServerLoad = async ({ locals, depends }) => {
 		};
 	} catch (error) {
 		try {
-			availableClusters = await getSelectableClusters(selectedClusterId, currentContext);
+			availableClusters = await getSelectableClusters(currentContext);
+			availableClusters = availableClusters.map((cluster) => ({
+				...cluster,
+				connected: false
+			}));
 		} catch {
 			availableClusters = [];
 		}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import './layout.css';
+	import { IN_CLUSTER_ID, type ClusterOption } from '$lib/clusters/identity.js';
 	import AppSidebar from '$lib/components/layout/AppSidebar.svelte';
 	import AppHeader from '$lib/components/layout/AppHeader.svelte';
 	import CommandPalette from '$lib/components/CommandPalette.svelte';
@@ -15,13 +16,15 @@
 		data: {
 			health: {
 				connected: boolean;
-				clusterName?: string;
-				availableClusters: string[];
+				currentClusterId: string;
+				currentClusterName: string;
+				availableClusters: ClusterOption[];
 				error?: string;
 			};
 			fluxVersion: string;
 			gyreVersion: string;
 			user: {
+				id: string;
 				username: string;
 				role: string;
 				email?: string | null;
@@ -39,22 +42,28 @@
 
 	// Sync cluster store and preferences with layout data
 	$effect(() => {
-		if (data.health.error) {
-			clusterStore.setError(data.health.error);
-		} else if (data.health.availableClusters && data.health.availableClusters.length > 0) {
+		if (data.health.availableClusters) {
 			clusterStore.setAvailable(data.health.availableClusters);
-		} else {
-			clusterStore.setError('No available clusters found');
 		}
+		clusterStore.setCurrent(data.health.currentClusterId || IN_CLUSTER_ID);
+		clusterStore.setError(data.health.error ?? null);
 
-		if (data.health.clusterName) {
-			clusterStore.current = data.health.clusterName;
-		}
 		if (data.user?.preferences?.notifications) {
 			preferences.setNotifications(data.user.preferences.notifications);
 		} else {
 			preferences.setNotifications(undefined);
 		}
+
+		eventsStore.setStorageScope({
+			clusterId: data.health.currentClusterId || IN_CLUSTER_ID,
+			userIdentity: data.user
+				? JSON.stringify({
+						id: data.user.id,
+						role: data.user.role,
+						username: data.user.username
+					})
+				: null
+		});
 	});
 
 	// Connect to SSE when cluster is connected

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,8 +1,13 @@
 import type { PageServerLoad } from './$types';
 import { isHttpError } from '@sveltejs/kit';
+import { IN_CLUSTER_ID } from '$lib/clusters/identity.js';
 import { resourceGroups } from '$lib/config/resources';
 import { DASHBOARD_CACHE_TTL_MS } from '$lib/server/config/constants';
-import { getDashboardCache, setDashboardCache } from '$lib/server/dashboard-cache';
+import {
+	getDashboardCache,
+	getDashboardCacheKey,
+	setDashboardCache
+} from '$lib/server/dashboard-cache';
 import { getFluxOverviewSummary } from '$lib/server/flux/services.js';
 import { requireClusterWideRead } from '$lib/server/http/guards.js';
 import { AuthorizationError } from '$lib/server/kubernetes/errors.js';
@@ -63,7 +68,7 @@ function isPermissionErrorLike(error: unknown): boolean {
 export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 	// Get health data from parent layout
 	const parentData = await parent();
-	const requestedCluster = locals.cluster ?? '__NO_CLUSTER_SELECTED__';
+	const requestedCluster = locals.cluster ?? IN_CLUSTER_ID;
 
 	// Function to fetch data (can be returned as a promise to be streamed)
 	const fetchGroupCounts = async () => {
@@ -76,8 +81,17 @@ export const load: PageServerLoad = async ({ locals, parent, setHeaders }) => {
 			return EMPTY_GROUP_COUNTS;
 		}
 
-		// Create cache key based on the requested cluster identifier, not health metadata.
-		const cacheKey = `dashboard-${requestedCluster}`;
+		const user = locals.user;
+		if (!user) {
+			return EMPTY_GROUP_COUNTS;
+		}
+
+		// Scope cache by user, role, and canonical cluster ID.
+		const cacheKey = getDashboardCacheKey({
+			userId: user.id,
+			role: user.role,
+			clusterId: requestedCluster
+		});
 		const cached = getDashboardCache(cacheKey);
 
 		// Return cached data if still valid

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,8 @@
 		data: {
 			health: {
 				connected: boolean;
-				clusterName?: string;
+				currentClusterId: string;
+				currentClusterName: string;
 				error?: string;
 			};
 			streamed: {

--- a/src/routes/admin/clusters/+page.server.ts
+++ b/src/routes/admin/clusters/+page.server.ts
@@ -12,6 +12,8 @@ import {
 } from '$lib/server/clusters';
 import { isAdmin } from '$lib/server/rbac';
 import { logClusterChange } from '$lib/server/audit';
+import { invalidateDashboardCache } from '$lib/server/dashboard-cache';
+import { clearClientPool } from '$lib/server/kubernetes/client.js';
 import { REQUEST_LIMITS, formatSize } from '$lib/server/request-limits';
 
 /**
@@ -225,6 +227,8 @@ export const actions: Actions = {
 			const updated = await updateCluster(clusterId, { isActive });
 
 			if (updated) {
+				clearClientPool(clusterId);
+				invalidateDashboardCache(clusterId);
 				await logClusterChange(locals.user, 'update', updated.name, { clusterId, isActive });
 			}
 
@@ -257,6 +261,8 @@ export const actions: Actions = {
 			}
 
 			await deleteCluster(clusterId);
+			clearClientPool(clusterId);
+			invalidateDashboardCache(clusterId);
 
 			await logClusterChange(locals.user, 'delete', existing.name, { clusterId });
 

--- a/src/routes/api/v1/events/+server.ts
+++ b/src/routes/api/v1/events/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { error } from '@sveltejs/kit';
+import { IN_CLUSTER_ID } from '$lib/clusters/identity.js';
 import { subscribe, type SSEEvent } from '$lib/server/events.js';
 import { checkClusterWideReadPermission } from '$lib/server/rbac.js';
 import { sseConnectionLimiter } from '$lib/server/rate-limiter.js';
@@ -68,7 +69,7 @@ export const GET: RequestHandler = async ({ request, locals, getClientAddress })
 
 	const { release } = connectionResult;
 
-	const clusterId = locals.cluster ?? 'in-cluster';
+	const clusterId = locals.cluster ?? IN_CLUSTER_ID;
 
 	// Shared cleanup ref so both start() and cancel() can invoke the same teardown.
 	// start() is called synchronously during ReadableStream construction, so

--- a/src/routes/api/v1/events/+server.ts
+++ b/src/routes/api/v1/events/+server.ts
@@ -37,8 +37,10 @@ export const GET: RequestHandler = async ({ request, locals, getClientAddress })
 		return error(401, { message: 'Authentication required' });
 	}
 
+	const clusterId = locals.cluster ?? IN_CLUSTER_ID;
+
 	// Check permission
-	const hasPermission = await checkClusterWideReadPermission(locals.user, locals.cluster);
+	const hasPermission = await checkClusterWideReadPermission(locals.user, clusterId);
 	if (!hasPermission) {
 		return error(403, { message: 'Permission denied' });
 	}
@@ -68,9 +70,6 @@ export const GET: RequestHandler = async ({ request, locals, getClientAddress })
 	}
 
 	const { release } = connectionResult;
-
-	const clusterId = locals.cluster ?? IN_CLUSTER_ID;
-
 	// Shared cleanup ref so both start() and cancel() can invoke the same teardown.
 	// start() is called synchronously during ReadableStream construction, so
 	// cleanupRef is always populated before cancel() can fire.

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -39,7 +39,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	}
 
 	return {
-		mode: locals.cluster ? 'in-cluster' : 'local',
+		mode: process.env.KUBERNETES_SERVICE_HOST ? 'in-cluster' : 'local',
 		providers,
 		localLoginEnabled
 	};

--- a/src/tests/admin-auth-providers-guard.test.ts
+++ b/src/tests/admin-auth-providers-guard.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { User } from '../lib/server/db/schema.js';
 
 const permissionChecks: unknown[][] = [];
@@ -36,6 +36,10 @@ function createUser(role: User['role'] = 'editor'): User {
 
 beforeEach(() => {
 	permissionChecks.length = 0;
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 describe('admin auth providers explicit in-handler guard', () => {

--- a/src/tests/admin-security-audit-events.test.ts
+++ b/src/tests/admin-security-audit-events.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { User } from '../lib/server/db/schema.js';
 
 const auditCalls: Array<[User | null, string, Record<string, unknown> | undefined]> = [];
@@ -180,6 +180,10 @@ beforeEach(() => {
 	dbState.findFirstQueue.length = 0;
 	dbState.updates.length = 0;
 	dbState.deleteRuns = 0;
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 describe('admin mutation audit events', () => {

--- a/src/tests/audit-cleanup.test.ts
+++ b/src/tests/audit-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 spyOn(console, 'log').mockImplementation(() => {});
 
@@ -185,6 +185,10 @@ describe('cleanupOldAuditLogs', () => {
 		const remaining = db.select().from(auditLogs).all();
 		expect(remaining).toHaveLength(0);
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/auth-seed-providers.test.ts
+++ b/src/tests/auth-seed-providers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 interface State {
 	inserted: Record<string, unknown>[];
@@ -101,6 +101,10 @@ afterEach(() => {
 		process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET =
 			originalEnv.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET;
 	}
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 describe('seedAuthProviders', () => {

--- a/src/tests/bulk-actions.test.ts
+++ b/src/tests/bulk-actions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 import type { FluxResource } from '../lib/types/flux.js';
 import type { BatchOperationResponse } from '../lib/components/flux/bulk-actions.js';
 
@@ -175,4 +175,8 @@ describe('partitionBatchOperationResult', () => {
 			{ type: 'Kustomization', namespace: 'default', name: 'app-b' }
 		]);
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });

--- a/src/tests/change-password-route.test.ts
+++ b/src/tests/change-password-route.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { INVALID_SPAN_CONTEXT, trace } from '@opentelemetry/api';
 import type { Cookies } from '@sveltejs/kit';
 import type { User } from '../lib/server/db/schema.js';
@@ -118,6 +118,10 @@ function buildEvent(): ChangePasswordEvent {
 
 	return event;
 }
+
+afterAll(() => {
+	mock.restore();
+});
 
 beforeEach(() => {
 	Object.assign(authState, createAuthState());

--- a/src/tests/clusters-encryption.test.ts
+++ b/src/tests/clusters-encryption.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach, beforeEach, mock } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import { Database } from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
@@ -117,6 +117,10 @@ describe('Cluster Kubeconfig Encryption', () => {
 			expect(() => _decryptKubeconfig('not-v2')).toThrow('v2');
 		});
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/events.test.ts
+++ b/src/tests/events.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, spyOn } from 'bun:test';
+import { afterAll, describe, expect, mock, spyOn, test } from 'bun:test';
 
 // Suppress console noise - must be before imports
 spyOn(console, 'log').mockImplementation(() => {});
@@ -43,6 +43,10 @@ mock.module('../lib/server/logger.js', () => ({
 
 import { subscribe, closeAllEventStreams, setEventBusShuttingDown } from '../lib/server/events.js';
 import type { SSEEvent } from '../lib/server/events.js';
+
+afterAll(() => {
+	mock.restore();
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/tests/filtering.test.ts
+++ b/src/tests/filtering.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 
 mock.module('$app/environment', () => ({ dev: false }));
 mock.module('$env/dynamic/public', () => ({ env: {} }));
@@ -66,6 +66,10 @@ describe('searchParamsToFilters', () => {
 		const result = searchParamsToFilters(new URLSearchParams());
 		expect(result.useRegex).toBe(defaultFilterState.useRegex);
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/flux-list-cluster-wide-rbac.test.ts
+++ b/src/tests/flux-list-cluster-wide-rbac.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { User } from '../lib/server/db/schema.js';
 
 const clusterWideChecks: unknown[][] = [];
@@ -63,6 +63,10 @@ beforeEach(() => {
 	scopedChecks.length = 0;
 	allowClusterWide = true;
 	allowScoped = true;
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 describe('flux [resourceType] RBAC boundaries', () => {

--- a/src/tests/flux-server-loads.test.ts
+++ b/src/tests/flux-server-loads.test.ts
@@ -57,7 +57,7 @@ let selectableClusters = [
 		isActive: true,
 		currentContext: null
 	}
-];
+] as const;
 const setDashboardCacheCalls: Array<{ key: string; value: unknown }> = [];
 const requireClusterWideReadCalls: string[] = [];
 
@@ -114,7 +114,7 @@ beforeEach(() => {
 			id: IN_CLUSTER_ID,
 			name: 'In-cluster',
 			description: 'Runtime Kubernetes configuration',
-			source: 'in-cluster',
+			source: 'in-cluster' as const,
 			isActive: true,
 			currentContext: 'dev-context'
 		},
@@ -122,11 +122,11 @@ beforeEach(() => {
 			id: 'cluster-a',
 			name: 'Uploaded Cluster A',
 			description: 'Uploaded kubeconfig',
-			source: 'uploaded',
+			source: 'uploaded' as const,
 			isActive: true,
 			currentContext: null
 		}
-	];
+	] as const;
 
 	mock.module('$lib/server/flux/services.js', () => ({
 		DEFAULT_FLUX_VERSION: 'v2.x.x',
@@ -148,9 +148,9 @@ beforeEach(() => {
 	}));
 
 	mock.module('$lib/server/http/guards.js', () => ({
-		requireClusterContext: () => 'cluster-a',
-		requireClusterWideRead: async () => {
-			requireClusterWideReadCalls.push('cluster-a');
+		requireClusterContext: (locals: { cluster: string }) => locals.cluster,
+		requireClusterWideRead: async (locals: { cluster: string }) => {
+			requireClusterWideReadCalls.push(locals.cluster);
 			if (clusterReadShouldThrow) {
 				throw { status: 403, body: { message: 'Permission denied' } };
 			}

--- a/src/tests/flux-server-loads.test.ts
+++ b/src/tests/flux-server-loads.test.ts
@@ -61,6 +61,24 @@ let selectableClusters = [
 const setDashboardCacheCalls: Array<{ key: string; value: unknown }> = [];
 const requireClusterWideReadCalls: string[] = [];
 
+function getExpectedSelectableClustersContext() {
+	if (healthShouldThrow) {
+		return null;
+	}
+
+	const kubernetes = (healthResult as { kubernetes?: { currentContext?: string | null } })
+		.kubernetes;
+	return kubernetes?.currentContext ?? null;
+}
+
+function requireClusterContextMock(locals: App.Locals) {
+	if (!locals.cluster) {
+		throw { status: 400, body: { message: 'Cluster context required' } };
+	}
+
+	return locals.cluster;
+}
+
 function createUser() {
 	return {
 		id: 'user-1',
@@ -148,18 +166,36 @@ beforeEach(() => {
 	}));
 
 	mock.module('$lib/server/http/guards.js', () => ({
-		requireClusterContext: (locals: { cluster: string }) => locals.cluster,
-		requireClusterWideRead: async (locals: { cluster: string }) => {
-			requireClusterWideReadCalls.push(locals.cluster);
+		requireClusterContext: (locals: App.Locals) => requireClusterContextMock(locals),
+		requireClusterWideRead: async (locals: App.Locals) => {
+			const clusterId = requireClusterContextMock(locals);
+			if (!locals.user) {
+				throw { status: 403, body: { message: 'Permission denied' } };
+			}
+			requireClusterWideReadCalls.push(clusterId);
 			if (clusterReadShouldThrow) {
 				throw { status: 403, body: { message: 'Permission denied' } };
 			}
 		},
-		requireScopedPermission: async () => {}
+		requireScopedPermission: async (locals: App.Locals) => {
+			requireClusterContextMock(locals);
+			if (!locals.user) {
+				throw { status: 403, body: { message: 'Permission denied' } };
+			}
+		}
 	}));
 
 	mock.module('$lib/server/clusters.js', () => ({
-		getSelectableClusters: async () => selectableClusters
+		getSelectableClusters: async (currentContext?: string | null) => {
+			const expectedContext = getExpectedSelectableClustersContext();
+			if (currentContext !== expectedContext) {
+				throw new Error(
+					`Expected getSelectableClusters currentContext ${String(expectedContext)}, received ${String(currentContext)}`
+				);
+			}
+
+			return selectableClusters;
+		}
 	}));
 
 	mock.module('$lib/server/dashboard-cache', () => ({

--- a/src/tests/flux-server-loads.test.ts
+++ b/src/tests/flux-server-loads.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { IN_CLUSTER_ID } from '../lib/clusters/identity.js';
 import * as actualDashboardCache from '../lib/server/dashboard-cache.js';
+import * as actualClusters from '../lib/server/clusters.js';
 import * as actualServices from '../lib/server/flux/services.js';
 import * as actualGuards from '../lib/server/http/guards.js';
 import * as actualMetrics from '../lib/server/metrics.js';
@@ -8,8 +10,8 @@ let healthResult: unknown = {
 	status: 'healthy',
 	kubernetes: {
 		connected: true,
-		currentContext: 'cluster-a',
-		availableContexts: ['cluster-a']
+		currentContext: 'dev-context',
+		availableContexts: ['dev-context']
 	}
 };
 let healthShouldThrow = false;
@@ -36,15 +38,47 @@ let detailResult = {
 let detailServiceError: unknown = null;
 let clusterReadShouldThrow = false;
 let dashboardCacheValue: unknown = null;
+const getDashboardCacheCalls: string[] = [];
+const getDashboardCacheKeyCalls: Array<{ clusterId: string; role: string; userId: string }> = [];
+let selectableClusters = [
+	{
+		id: IN_CLUSTER_ID,
+		name: 'In-cluster',
+		description: 'Runtime Kubernetes configuration',
+		source: 'in-cluster' as const,
+		isActive: true,
+		currentContext: 'dev-context'
+	},
+	{
+		id: 'cluster-a',
+		name: 'Uploaded Cluster A',
+		description: 'Uploaded kubeconfig',
+		source: 'uploaded' as const,
+		isActive: true,
+		currentContext: null
+	}
+];
 const setDashboardCacheCalls: Array<{ key: string; value: unknown }> = [];
+const requireClusterWideReadCalls: string[] = [];
+
+function createUser() {
+	return {
+		id: 'user-1',
+		username: 'alice',
+		role: 'admin',
+		email: null,
+		isLocal: true,
+		preferences: null
+	};
+}
 
 beforeEach(() => {
 	healthResult = {
 		status: 'healthy',
 		kubernetes: {
 			connected: true,
-			currentContext: 'cluster-a',
-			availableContexts: ['cluster-a']
+			currentContext: 'dev-context',
+			availableContexts: ['dev-context']
 		}
 	};
 	healthShouldThrow = false;
@@ -71,7 +105,28 @@ beforeEach(() => {
 	detailServiceError = null;
 	clusterReadShouldThrow = false;
 	dashboardCacheValue = null;
+	getDashboardCacheCalls.length = 0;
+	getDashboardCacheKeyCalls.length = 0;
+	requireClusterWideReadCalls.length = 0;
 	setDashboardCacheCalls.length = 0;
+	selectableClusters = [
+		{
+			id: IN_CLUSTER_ID,
+			name: 'In-cluster',
+			description: 'Runtime Kubernetes configuration',
+			source: 'in-cluster',
+			isActive: true,
+			currentContext: 'dev-context'
+		},
+		{
+			id: 'cluster-a',
+			name: 'Uploaded Cluster A',
+			description: 'Uploaded kubeconfig',
+			source: 'uploaded',
+			isActive: true,
+			currentContext: null
+		}
+	];
 
 	mock.module('$lib/server/flux/services.js', () => ({
 		DEFAULT_FLUX_VERSION: 'v2.x.x',
@@ -95,6 +150,7 @@ beforeEach(() => {
 	mock.module('$lib/server/http/guards.js', () => ({
 		requireClusterContext: () => 'cluster-a',
 		requireClusterWideRead: async () => {
+			requireClusterWideReadCalls.push('cluster-a');
 			if (clusterReadShouldThrow) {
 				throw { status: 403, body: { message: 'Permission denied' } };
 			}
@@ -102,8 +158,19 @@ beforeEach(() => {
 		requireScopedPermission: async () => {}
 	}));
 
+	mock.module('$lib/server/clusters.js', () => ({
+		getSelectableClusters: async () => selectableClusters
+	}));
+
 	mock.module('$lib/server/dashboard-cache', () => ({
-		getDashboardCache: () => dashboardCacheValue,
+		getDashboardCache: (key: string) => {
+			getDashboardCacheCalls.push(key);
+			return dashboardCacheValue;
+		},
+		getDashboardCacheKey: (parts: { clusterId: string; role: string; userId: string }) => {
+			getDashboardCacheKeyCalls.push(parts);
+			return `dashboard:user:${parts.userId}:role:${parts.role}:cluster:${parts.clusterId}`;
+		},
 		setDashboardCache: (key: string, value: unknown) => setDashboardCacheCalls.push({ key, value })
 	}));
 
@@ -117,6 +184,7 @@ beforeEach(() => {
 afterEach(() => {
 	mock.restore();
 	mock.module('$lib/server/flux/services.js', () => actualServices);
+	mock.module('$lib/server/clusters.js', () => actualClusters);
 	mock.module('$lib/server/http/guards.js', () => actualGuards);
 	mock.module('$lib/server/dashboard-cache', () => actualDashboardCache);
 	mock.module('$lib/server/metrics.js', () => actualMetrics);
@@ -134,15 +202,26 @@ describe('migrated server loads', () => {
 				cluster: 'cluster-a',
 				requestId: 'req-1',
 				session: null,
-				user: { id: 'user-1' }
+				user: createUser()
 			}
 		} as Parameters<typeof load>[0]);
 
 		expect(success).toMatchObject({
 			health: {
 				connected: true,
-				clusterName: 'cluster-a',
-				availableClusters: ['cluster-a'],
+				currentClusterId: 'cluster-a',
+				currentClusterName: 'Uploaded Cluster A',
+				availableClusters: [
+					{
+						id: IN_CLUSTER_ID,
+						name: 'In-cluster'
+					},
+					{
+						id: 'cluster-a',
+						name: 'Uploaded Cluster A',
+						connected: true
+					}
+				],
 				error: undefined
 			},
 			fluxVersion: 'v2.3.0'
@@ -157,15 +236,25 @@ describe('migrated server loads', () => {
 				cluster: 'cluster-a',
 				requestId: 'req-1',
 				session: null,
-				user: { id: 'user-1' }
+				user: createUser()
 			}
 		} as Parameters<typeof load>[0]);
 
 		expect(fallback).toMatchObject({
 			health: {
 				connected: false,
-				clusterName: undefined,
-				availableClusters: [],
+				currentClusterId: 'cluster-a',
+				currentClusterName: 'Uploaded Cluster A',
+				availableClusters: [
+					{
+						id: IN_CLUSTER_ID,
+						name: 'In-cluster'
+					},
+					{
+						id: 'cluster-a',
+						name: 'Uploaded Cluster A'
+					}
+				],
 				error: 'Failed to retrieve cluster health status'
 			},
 			fluxVersion: 'v2.x.x'
@@ -176,8 +265,20 @@ describe('migrated server loads', () => {
 		const { load } = await import(`../routes/+page.server.js?case=${Date.now()}-${Math.random()}`);
 
 		const result = await load({
-			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: { id: 'user-1' } },
-			parent: async () => ({ health: { clusterName: 'cluster-b' } }),
+			locals: {
+				cluster: 'cluster-a',
+				requestId: 'req-1',
+				session: null,
+				user: createUser()
+			},
+			parent: async () => ({
+				health: {
+					connected: true,
+					currentClusterId: 'cluster-b',
+					currentClusterName: 'Uploaded Cluster B',
+					availableClusters: []
+				}
+			}),
 			setHeaders: () => {}
 		} as Parameters<typeof load>[0]);
 
@@ -191,10 +292,44 @@ describe('migrated server loads', () => {
 		});
 		expect(setDashboardCacheCalls).toEqual([
 			{
-				key: 'dashboard-cluster-a',
+				key: 'dashboard:user:user-1:role:admin:cluster:cluster-a',
 				value: groupCounts
 			}
 		]);
+		expect(getDashboardCacheKeyCalls).toEqual([
+			{ userId: 'user-1', role: 'admin', clusterId: 'cluster-a' }
+		]);
+		expect(getDashboardCacheCalls).toEqual(['dashboard:user:user-1:role:admin:cluster:cluster-a']);
+		expect(requireClusterWideReadCalls).toEqual(['cluster-a']);
+	});
+
+	test('dashboard load does not access cache before permission checks fail', async () => {
+		clusterReadShouldThrow = true;
+		const { load } = await import(`../routes/+page.server.js?case=${Date.now()}-${Math.random()}`);
+
+		const result = await load({
+			locals: {
+				cluster: 'cluster-a',
+				requestId: 'req-1',
+				session: null,
+				user: createUser()
+			},
+			parent: async () => ({
+				health: {
+					connected: true,
+					currentClusterId: 'cluster-a',
+					currentClusterName: 'Uploaded Cluster A',
+					availableClusters: []
+				}
+			}),
+			setHeaders: () => {}
+		} as Parameters<typeof load>[0]);
+
+		expect(await result.streamed.groupCounts).toEqual({});
+		expect(getDashboardCacheKeyCalls).toEqual([]);
+		expect(getDashboardCacheCalls).toEqual([]);
+		expect(setDashboardCacheCalls).toEqual([]);
+		expect(requireClusterWideReadCalls).toEqual(['cluster-a']);
 	});
 
 	test('resource list load calls the shared service and keeps the UI-facing shape', async () => {
@@ -204,7 +339,7 @@ describe('migrated server loads', () => {
 
 		const result = await load({
 			depends: () => {},
-			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: { id: 'user-1' } },
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: createUser() },
 			params: { type: 'gitrepositories' },
 			url: new URL('http://localhost/resources/gitrepositories?sortBy=name&sortOrder=desc')
 		} as Parameters<typeof load>[0]);
@@ -226,7 +361,7 @@ describe('migrated server loads', () => {
 
 		const result = await load({
 			depends: () => {},
-			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: { id: 'user-1' } },
+			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: createUser() },
 			params: { type: 'gitrepositories', namespace: 'flux-system', name: 'demo' }
 		} as Parameters<typeof load>[0]);
 
@@ -248,7 +383,7 @@ describe('migrated server loads', () => {
 					cluster: 'cluster-a',
 					requestId: 'req-1',
 					session: null,
-					user: { id: 'user-1' }
+					user: createUser()
 				},
 				params: { type: 'gitrepositories', namespace: 'flux-system', name: 'demo' }
 			} as Parameters<typeof load404>[0])
@@ -268,7 +403,7 @@ describe('migrated server loads', () => {
 					cluster: 'cluster-a',
 					requestId: 'req-1',
 					session: null,
-					user: { id: 'user-1' }
+					user: createUser()
 				},
 				params: { type: 'gitrepositories', namespace: 'flux-system', name: 'demo' }
 			} as Parameters<typeof load500>[0])

--- a/src/tests/flux-services.test.ts
+++ b/src/tests/flux-services.test.ts
@@ -83,8 +83,8 @@ beforeEach(() => {
 		getFluxResource: (...args: unknown[]) => getFluxResourceImpl(...args),
 		getFluxResourceStatus: (...args: unknown[]) => getFluxResourceStatusImpl(...args),
 		getKubeConfig: async () => ({
-			getContexts: () => [{ name: 'cluster-a' }, { name: 'cluster-b' }],
-			getCurrentContext: () => 'cluster-a',
+			getContexts: () => [{ name: 'dev-context' }, { name: 'staging-context' }],
+			getCurrentContext: () => 'dev-context',
 			makeApiClient: (clientType: { name?: string }) => {
 				if (clientType.name?.includes('AppsV1Api')) {
 					return {
@@ -168,8 +168,8 @@ describe('flux shared services', () => {
 				connected: true,
 				configStrategy: 'local-kubeconfig',
 				configSource: 'kubeconfig',
-				currentContext: 'cluster-a',
-				availableContexts: ['cluster-a', 'cluster-b'],
+				currentContext: 'dev-context',
+				availableContexts: ['dev-context', 'staging-context'],
 				connectionPool: {
 					evictions: 1,
 					hits: 2,

--- a/src/tests/login-route.test.ts
+++ b/src/tests/login-route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { INVALID_SPAN_CONTEXT, trace } from '@opentelemetry/api';
 import type { Cookies } from '@sveltejs/kit';
 import type { User } from '../lib/server/db/schema.js';
@@ -140,6 +140,10 @@ function buildEvent(): LoginEvent {
 		isRemoteRequest: false
 	} satisfies LoginEvent;
 }
+
+afterAll(() => {
+	mock.restore();
+});
 
 beforeEach(() => {
 	Object.assign(routeState, createRouteState());

--- a/src/tests/request-pipeline.test.ts
+++ b/src/tests/request-pipeline.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { IN_CLUSTER_ID } from '../lib/clusters/identity.js';
 import type { User } from '../lib/server/db/schema.js';
 import * as actualBetterAuth from '../lib/server/auth/better-auth.js';
 import * as actualClusters from '../lib/server/clusters.js';
@@ -15,6 +16,7 @@ let sessionData: {
 } | null = null;
 let csrfValid = true;
 let clusterRecord: { id: string; isActive: boolean } | null = { id: 'cluster-a', isActive: true };
+const getClusterByIdCalls: string[] = [];
 let errorResponse = {
 	status: 500,
 	body: { error: 'An unexpected error occurred', code: 'InternalServerError' }
@@ -76,6 +78,7 @@ beforeEach(() => {
 	sessionData = null;
 	csrfValid = true;
 	clusterRecord = { id: 'cluster-a', isActive: true };
+	getClusterByIdCalls.length = 0;
 	errorResponse = {
 		status: 500,
 		body: { error: 'An unexpected error occurred', code: 'InternalServerError' }
@@ -121,7 +124,10 @@ beforeEach(() => {
 	}));
 
 	mock.module('$lib/server/clusters.js', () => ({
-		getClusterById: async () => clusterRecord
+		getClusterById: async (id: string) => {
+			getClusterByIdCalls.push(id);
+			return clusterRecord;
+		}
 	}));
 
 	mock.module('$lib/server/kubernetes/errors.js', () => ({
@@ -317,7 +323,93 @@ describe('request pipeline', () => {
 		});
 
 		expect(response.status).toBe(200);
-		expect(event.locals.cluster).toBe('in-cluster');
+		expect(event.locals.cluster).toBe(IN_CLUSTER_ID);
+		expect(cookies.deleted).toContainEqual({
+			name: 'gyre_cluster',
+			options: { path: '/' }
+		});
+	});
+
+	test('defaults to in-cluster when the cluster cookie is missing', async () => {
+		sessionData = {
+			session: { id: 'session-1' },
+			user: createUser()
+		};
+		const event = {
+			cookies: createCookies({ gyre_session: 'session-cookie' }),
+			getClientAddress: () => '127.0.0.1',
+			locals: {} as App.Locals,
+			request: new Request('http://localhost/dashboard'),
+			url: new URL('http://localhost/dashboard')
+		};
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event,
+			resolve: async () => new Response('ok', { status: 200 })
+		});
+
+		expect(response.status).toBe(200);
+		expect(event.locals.cluster).toBe(IN_CLUSTER_ID);
+		expect(getClusterByIdCalls).toEqual([]);
+	});
+
+	test('keeps a valid uploaded cluster id selected', async () => {
+		sessionData = {
+			session: { id: 'session-1' },
+			user: createUser()
+		};
+		clusterRecord = { id: 'cluster-a', isActive: true };
+		const event = {
+			cookies: createCookies({
+				gyre_cluster: 'cluster-a',
+				gyre_session: 'session-cookie'
+			}),
+			getClientAddress: () => '127.0.0.1',
+			locals: {} as App.Locals,
+			request: new Request('http://localhost/dashboard'),
+			url: new URL('http://localhost/dashboard')
+		};
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event,
+			resolve: async () => new Response('ok', { status: 200 })
+		});
+
+		expect(response.status).toBe(200);
+		expect(event.locals.cluster).toBe('cluster-a');
+		expect(getClusterByIdCalls).toEqual(['cluster-a']);
+		expect(event.cookies.deleted).toEqual([]);
+	});
+
+	test('treats context-name-like cookies as stale unless they match an active cluster id', async () => {
+		sessionData = {
+			session: { id: 'session-1' },
+			user: createUser()
+		};
+		clusterRecord = null;
+		const cookies = createCookies({
+			gyre_cluster: 'kind-kind',
+			gyre_session: 'session-cookie'
+		});
+		const event = {
+			cookies,
+			getClientAddress: () => '127.0.0.1',
+			locals: {} as App.Locals,
+			request: new Request('http://localhost/dashboard'),
+			url: new URL('http://localhost/dashboard')
+		};
+		const { handle } = await importHooks();
+
+		const response = await handle({
+			event,
+			resolve: async () => new Response('ok', { status: 200 })
+		});
+
+		expect(response.status).toBe(200);
+		expect(getClusterByIdCalls).toEqual(['kind-kind']);
+		expect(event.locals.cluster).toBe(IN_CLUSTER_ID);
 		expect(cookies.deleted).toContainEqual({
 			name: 'gyre_cluster',
 			options: { path: '/' }

--- a/src/tests/resource-health.test.ts
+++ b/src/tests/resource-health.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 
 // Mock SvelteKit virtual modules before importing anything that depends on them
 mock.module('$app/environment', () => ({ dev: false }));
@@ -120,6 +120,10 @@ describe('getResourceHealth', () => {
 		const conditions = [makeCondition('SomeOtherCondition', 'True')];
 		expect(getResourceHealth(conditions)).toBe('unknown');
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/search.test.ts
+++ b/src/tests/search.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 
 // Mock SvelteKit virtual modules before importing anything that depends on them
 mock.module('$app/environment', () => ({ dev: false }));
@@ -129,6 +129,10 @@ describe('advancedSearch', () => {
 		// Both should return the same logical result
 		expect(r1[0].metadata.name).toBe(r2[0].metadata.name);
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/server-load-self-fetch-boundary.test.ts
+++ b/src/tests/server-load-self-fetch-boundary.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROUTES_DIR = join(process.cwd(), 'src', 'routes');
+const SERVER_LOAD_FILE_PATTERN = /^\+(page|layout)\.server\.ts$/;
+const DISALLOWED_SELF_FETCH_PATTERNS = [
+	"fetch('/api/",
+	'fetch("/api/',
+	"event.fetch('/api/",
+	'event.fetch("/api/'
+];
+
+function collectServerLoadFiles(dir: string): string[] {
+	const files: string[] = [];
+
+	for (const entry of readdirSync(dir)) {
+		const fullPath = join(dir, entry);
+		const stats = statSync(fullPath);
+		if (stats.isDirectory()) {
+			files.push(...collectServerLoadFiles(fullPath));
+			continue;
+		}
+		if (SERVER_LOAD_FILE_PATTERN.test(entry)) {
+			files.push(fullPath);
+		}
+	}
+
+	return files;
+}
+
+describe('server load self-fetch boundary', () => {
+	test('server loads do not fetch internal API routes over HTTP', () => {
+		const offendingFiles = collectServerLoadFiles(ROUTES_DIR).flatMap((filePath) => {
+			const source = readFileSync(filePath, 'utf8');
+			const matches = DISALLOWED_SELF_FETCH_PATTERNS.filter((pattern) => source.includes(pattern));
+			return matches.length > 0 ? [`${filePath}: ${matches.join(', ')}`] : [];
+		});
+
+		expect(offendingFiles).toEqual([]);
+	});
+});

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -19,11 +19,6 @@ mock.module('../lib/server/db/index.js', () => ({
 	schema
 }));
 
-// Use a real-ish TTL (100ms) so we can test both cache hit and TTL expiry
-mock.module('../lib/server/config/constants.js', () => ({
-	SETTINGS_CACHE_TTL_MS: 100
-}));
-
 import {
 	getSetting,
 	setSetting,
@@ -65,14 +60,7 @@ function unsetEnv(key: string) {
 	delete process.env[key];
 }
 
-// Track a global time offset so we can expire the cache between tests
-let timeOffset = 0;
-const realDateNow = Date.now.bind(Date);
-Date.now = () => realDateNow() + timeOffset;
-
 beforeEach(() => {
-	// Advance time past the 100ms TTL to expire all module-level cache entries
-	timeOffset += 200;
 	state.db = setupInMemoryDb();
 	savedEnv = {};
 	// Ensure env overrides are cleared before each test
@@ -105,10 +93,9 @@ describe('getSetting', () => {
 		expect(value).toBe('true'); // env var wins
 	});
 
-	test('cache hit within TTL avoids DB call', async () => {
+	test('direct DB updates are visible on the next read in the same process', async () => {
 		const key = SETTINGS_KEYS.AUTH_ALLOW_SIGNUP;
 
-		// Insert a value and prime the cache via getSetting
 		await state
 			.db!.insert(schema.appSettings)
 			.values({ key, value: 'cached-value', updatedAt: new Date() })
@@ -117,46 +104,13 @@ describe('getSetting', () => {
 		const val1 = await getSetting(key);
 		expect(val1).toBe('cached-value');
 
-		// Update DB directly (bypassing setSetting which would clear cache)
 		await state
 			.db!.update(schema.appSettings)
 			.set({ value: 'new-db-value', updatedAt: new Date() })
 			.where(eq(schema.appSettings.key, key));
 
-		// Second call should still return the cached value (TTL is 100ms, not expired yet)
 		const val2 = await getSetting(key);
-		expect(val2).toBe('cached-value');
-	});
-
-	test('cache miss after TTL re-reads from DB', async () => {
-		const key = SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST;
-
-		await state
-			.db!.insert(schema.appSettings)
-			.values({ key, value: '["initial.com"]', updatedAt: new Date() })
-			.onConflictDoNothing();
-
-		const val1 = await getSetting(key);
-		expect(val1).toBe('["initial.com"]');
-
-		// Update DB directly (without invalidating cache)
-		await state
-			.db!.update(schema.appSettings)
-			.set({ value: '["updated.com"]', updatedAt: new Date() })
-			.where(eq(schema.appSettings.key, key));
-
-		// Advance Date.now past the 100ms TTL
-		// Note: originalNow captures the already-patched global test Date.now.
-		// This is intentional nesting on top of the global Date.now test patch
-		// so future readers understand the capture/restore behavior when calling getSetting.
-		const originalNow = Date.now;
-		Date.now = () => originalNow() + 200;
-		try {
-			const val2 = await getSetting(key);
-			expect(val2).toBe('["updated.com"]'); // Cache expired, re-reads from DB
-		} finally {
-			Date.now = originalNow;
-		}
+		expect(val2).toBe('new-db-value');
 	});
 
 	test('DB miss falls back to DEFAULTS map', async () => {
@@ -190,18 +144,15 @@ describe('setSetting', () => {
 		expect(row?.value).toBe('60');
 	});
 
-	test('invalidates cache so subsequent getSetting reads fresh from DB', async () => {
+	test('subsequent getSetting reads updated values after setSetting', async () => {
 		const key = SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED;
 
-		// Prime the cache
 		await setSetting(key, 'true');
 		const val1 = await getSetting(key);
 		expect(val1).toBe('true');
 
-		// setSetting again with new value — must invalidate cache
 		await setSetting(key, 'false');
 
-		// getSetting must return the updated DB value, not the cached one
 		const val2 = await getSetting(key);
 		expect(val2).toBe('false');
 	});
@@ -285,7 +236,6 @@ describe('getAuthSettings', () => {
 
 		try {
 			unsetEnv('GYRE_AUTH_ALLOW_SIGNUP');
-			timeOffset += 200; // ensure cached values from prior reads are expired
 			const settings = await getAuthSettings();
 			expect(settings.allowSignup).toBe(false);
 		} finally {

--- a/src/tests/user-preferences-route.test.ts
+++ b/src/tests/user-preferences-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { eq } from 'drizzle-orm';
@@ -169,4 +169,8 @@ describe('user preferences route', () => {
 			}
 		});
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });


### PR DESCRIPTION
Fixes #433

## Summary
- unify cluster selection around canonical cluster IDs (`in-cluster` or uploaded `clusters.id`)
- scope dashboard/browser caches by canonical cluster and user identity
- remove the stale per-process settings cache so settings are always read from shared DB state
- add regressions for request cluster resolution, dashboard cache scoping, and server-load self-fetch boundaries

## Checks
- `bun run format` ✅
- `bun run lint` ✅
- `bun run check` ✅
- `bun test` ❌ blocked by pre-existing unrelated failures in the repo-wide suite (legacy mock-leak/assertion drift in encryption/CSRF/role-mapping/flux action tests)
- `bun run build` ✅
- `bun run verify` not run after `bun test` failed
- `bun run verify:ci` not run after `bun test` failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer cluster options with selectable clusters and explicit current-cluster fields
  * Serialized user payload now includes user ID

* **Improvements**
  * Canonical cluster ID handling and normalization applied app-wide
  * Cluster-scoped caching and client pool isolation
  * UI now prefers cluster names and shows explicit current cluster
  * Removed in-memory settings cache

* **Tests**
  * Added global mock cleanup hooks and a new server-load validation test
<!-- end of auto-generated comment: release notes by coderabbit.ai -->