### PR TITLE
Fail closed on startup and admin settings

### DIFF
--- a/charts/gyre/templates/deployment.yaml
+++ b/charts/gyre/templates/deployment.yaml
@@ -8,8 +8,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     type: Recreate  # Required for PVC with ReadWriteOnce
-  {{- if and .Values.config.additionalConfig (hasKey .Values.config.additionalConfig "BODY_SIZE_LIMIT") }}
-  {{- fail "config.additionalConfig.BODY_SIZE_LIMIT is reserved; use config.bodySizeLimit to avoid duplicate ownership." }}
+  {{- $reservedAdditionalConfig := list "DATABASE_URL" "NODE_ENV" "ORIGIN" "BODY_SIZE_LIMIT" "GYRE_POLL_INTERVAL_MS" "GYRE_HEARTBEAT_INTERVAL_MS" "GYRE_DASHBOARD_CACHE_TTL_MS" "GYRE_SETTLING_PERIOD_MS" "GYRE_ENCRYPTION_KEY" "AUTH_ENCRYPTION_KEY" "BACKUP_ENCRYPTION_KEY" "GYRE_METRICS_TOKEN" "GYRE_AUTH_LOCAL_LOGIN_ENABLED" "GYRE_AUTH_ALLOW_SIGNUP" "GYRE_AUTH_DOMAIN_ALLOWLIST" "GYRE_AUTH_PROVIDERS" }}
+  {{- range $key, $_ := .Values.config.additionalConfig }}
+  {{- if or (has $key $reservedAdditionalConfig) (regexMatch "^GYRE_AUTH_PROVIDER_.*_CLIENT_SECRET$" $key) }}
+  {{- fail (printf "config.additionalConfig.%s is reserved; use the matching chart value or secret setting to avoid duplicate ownership." $key) }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:
@@ -177,6 +180,9 @@ spec:
         {{- $seen := dict }}
         {{- range $provider := .Values.auth.providers }}
         {{- $providerKey := regexReplaceAll "[^A-Z0-9]" ($provider.name | upper) "_" }}
+        {{- if has (printf "GYRE_AUTH_PROVIDER_%s_CLIENT_SECRET" $providerKey) $reservedAdditionalConfig }}
+        {{- fail (printf "Auth provider %q produces reserved env var GYRE_AUTH_PROVIDER_%s_CLIENT_SECRET. Rename the provider." $provider.name $providerKey) }}
+        {{- end }}
         {{- if hasKey $seen $providerKey }}
         {{- fail (printf "Auth provider %q collides with %q for GYRE_AUTH_PROVIDER_%s_CLIENT_SECRET. Rename one provider so the sanitized secret key stays unique." $provider.name (index $seen $providerKey) $providerKey) }}
         {{- end }}

--- a/charts/gyre/templates/deployment.yaml
+++ b/charts/gyre/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     type: Recreate  # Required for PVC with ReadWriteOnce
-  {{- $reservedAdditionalConfig := list "DATABASE_URL" "NODE_ENV" "ORIGIN" "BODY_SIZE_LIMIT" "GYRE_POLL_INTERVAL_MS" "GYRE_HEARTBEAT_INTERVAL_MS" "GYRE_DASHBOARD_CACHE_TTL_MS" "GYRE_SETTLING_PERIOD_MS" "GYRE_ENCRYPTION_KEY" "AUTH_ENCRYPTION_KEY" "BACKUP_ENCRYPTION_KEY" "GYRE_METRICS_TOKEN" "GYRE_AUTH_LOCAL_LOGIN_ENABLED" "GYRE_AUTH_ALLOW_SIGNUP" "GYRE_AUTH_DOMAIN_ALLOWLIST" "GYRE_AUTH_PROVIDERS" }}
+  {{- $reservedAdditionalConfig := list "DATABASE_URL" "NODE_ENV" "ORIGIN" "BETTER_AUTH_URL" "BODY_SIZE_LIMIT" "GYRE_POLL_INTERVAL_MS" "GYRE_HEARTBEAT_INTERVAL_MS" "GYRE_DASHBOARD_CACHE_TTL_MS" "GYRE_SETTLING_PERIOD_MS" "GYRE_ENCRYPTION_KEY" "AUTH_ENCRYPTION_KEY" "BACKUP_ENCRYPTION_KEY" "GYRE_METRICS_TOKEN" "GYRE_AUTH_LOCAL_LOGIN_ENABLED" "GYRE_AUTH_ALLOW_SIGNUP" "GYRE_AUTH_DOMAIN_ALLOWLIST" "GYRE_AUTH_PROVIDERS" }}
   {{- range $key, $_ := .Values.config.additionalConfig }}
   {{- if or (has $key $reservedAdditionalConfig) (regexMatch "^GYRE_AUTH_PROVIDER_.*_CLIENT_SECRET$" $key) }}
   {{- fail (printf "config.additionalConfig.%s is reserved; use the matching chart value or secret setting to avoid duplicate ownership." $key) }}

--- a/charts/gyre/templates/deployment.yaml
+++ b/charts/gyre/templates/deployment.yaml
@@ -180,9 +180,6 @@ spec:
         {{- $seen := dict }}
         {{- range $provider := .Values.auth.providers }}
         {{- $providerKey := regexReplaceAll "[^A-Z0-9]" ($provider.name | upper) "_" }}
-        {{- if has (printf "GYRE_AUTH_PROVIDER_%s_CLIENT_SECRET" $providerKey) $reservedAdditionalConfig }}
-        {{- fail (printf "Auth provider %q produces reserved env var GYRE_AUTH_PROVIDER_%s_CLIENT_SECRET. Rename the provider." $provider.name $providerKey) }}
-        {{- end }}
         {{- if hasKey $seen $providerKey }}
         {{- fail (printf "Auth provider %q collides with %q for GYRE_AUTH_PROVIDER_%s_CLIENT_SECRET. Rename one provider so the sanitized secret key stays unique." $provider.name (index $seen $providerKey) $providerKey) }}
         {{- end }}

--- a/charts/gyre/values.yaml
+++ b/charts/gyre/values.yaml
@@ -110,7 +110,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /api/v1/health
+    path: /api/v1/ready
     port: 3000
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/documentation/docs/api/README.md
+++ b/documentation/docs/api/README.md
@@ -16,6 +16,17 @@ Content-Type: `application/json`
 
 Compatibility note: unversioned `/api/*` paths are internally rewritten to `/api/v1/*` for backward compatibility (`src/hooks.ts`). The documented contract is `/api/v1/*`.
 
+## Process Health and Readiness
+
+```http
+GET /api/v1/health
+GET /api/v1/ready
+```
+
+`/api/v1/health` is a lightweight liveness endpoint and returns `200 { "status": "ok" }` when the process can answer HTTP requests.
+
+`/api/v1/ready` reports initialization readiness. It returns `200 { "status": "ready" }` after startup initialization completes, `503 { "status": "initializing", "message": "Gyre initialization has not completed" }` while startup is still in progress, and `503 { "status": "failed", "message": "Gyre initialization failed" }` after a fatal initialization error.
+
 ## Authentication
 
 ### Login
@@ -162,6 +173,8 @@ POST /api/v1/admin/backups/restore
 
 POST /api/v1/admin/k8s/clear-client-pool
 ```
+
+`PATCH /api/v1/admin/settings` is all-or-nothing. Unknown fields, invalid value types, invalid `auditRetentionDays`, and non-string `domainAllowlist` entries return `400` without persisting any setting. Settings locked by environment variables return `409` and name the locked field and owning env var instead of being silently ignored.
 
 ## User Preferences
 

--- a/documentation/docs/installation/helm-reference.md
+++ b/documentation/docs/installation/helm-reference.md
@@ -101,6 +101,8 @@ This guide provides a detailed reference for all configuration options available
 | `readinessProbe.initialDelaySeconds` | Initial delay | `10`    |
 | `readinessProbe.periodSeconds`       | Check period  | `10`    |
 
+The default liveness probe uses `/api/v1/health`. The default readiness probe uses `/api/v1/ready`, which stays unavailable until Gyre initialization completes and remains unavailable after fatal startup failures.
+
 ## RBAC
 
 | Parameter                 | Description           | Default |
@@ -172,7 +174,7 @@ Helm config keys map to these runtime env vars:
 | `config.bodySizeLimit`       | `BODY_SIZE_LIMIT`               |
 | `config.additionalConfig`    | Pass-through key/value env vars |
 
-`config.additionalConfig.BODY_SIZE_LIMIT` is reserved and rejected at render time. Use `config.bodySizeLimit` instead.
+`config.additionalConfig` is rejected at render time when it contains chart-owned env vars. Reserved names include `DATABASE_URL`, `NODE_ENV`, `ORIGIN`, `BODY_SIZE_LIMIT`, polling/cache interval vars, encryption key vars, `GYRE_METRICS_TOKEN`, auth settings vars, `GYRE_AUTH_PROVIDERS`, and any `GYRE_AUTH_PROVIDER_*_CLIENT_SECRET` key. Use the matching chart value or secret setting instead.
 
 ## Encryption Configuration
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -17,16 +17,17 @@ import { enforceGlobalRateLimit } from '$lib/server/request/rate-limit.js';
 import { enforceRequestSizeLimits } from '$lib/server/request/request-size.js';
 import { hydrateSessionLocals } from '$lib/server/request/session.js';
 
+const initializationBypassRoutes = new Set([
+	'/api/health',
+	'/api/v1/health',
+	'/api/ready',
+	'/api/v1/ready'
+]);
+
 export const handle: Handle = async ({ event, resolve }) => {
 	const context = assignRequestContext(event);
 
 	return withRequestContext(context.requestId, async () => {
-		const initializationBypassRoutes = new Set([
-			'/api/health',
-			'/api/v1/health',
-			'/api/ready',
-			'/api/v1/ready'
-		]);
 		const bypassInitialization = initializationBypassRoutes.has(event.url.pathname);
 		const requestSizeResponse = await enforceRequestSizeLimits(event);
 		if (requestSizeResponse) {
@@ -42,8 +43,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 			try {
 				await ensureGyreInitialized();
 			} catch (err) {
-				logger.error(err, 'Failed to ensure Gyre is initialized during request handling');
 				const status = getGyreInitializationStatus();
+				if (status.state !== 'failed') {
+					logger.error(err, 'Failed to ensure Gyre is initialized during request handling');
+				}
 				const message =
 					status.state === 'failed'
 						? 'Gyre initialization failed'

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,7 +8,11 @@ import {
 import { assignRequestContext, finalizeResponse } from '$lib/server/request/context.js';
 import { enforceCsrfProtection } from '$lib/server/request/csrf.js';
 import { normalizeHandleError, resolveRouteAndMapErrors } from '$lib/server/request/errors.js';
-import { ensureGyreInitialized, isGyreInitialized } from '$lib/server/request/initialization.js';
+import {
+	ensureGyreInitialized,
+	getGyreInitializationStatus,
+	isGyreInitialized
+} from '$lib/server/request/initialization.js';
 import { enforceGlobalRateLimit } from '$lib/server/request/rate-limit.js';
 import { enforceRequestSizeLimits } from '$lib/server/request/request-size.js';
 import { hydrateSessionLocals } from '$lib/server/request/session.js';
@@ -17,6 +21,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 	const context = assignRequestContext(event);
 
 	return withRequestContext(context.requestId, async () => {
+		const initializationBypassRoutes = new Set([
+			'/api/health',
+			'/api/v1/health',
+			'/api/ready',
+			'/api/v1/ready'
+		]);
+		const bypassInitialization = initializationBypassRoutes.has(event.url.pathname);
 		const requestSizeResponse = await enforceRequestSizeLimits(event);
 		if (requestSizeResponse) {
 			return finalizeResponse(event, requestSizeResponse, context);
@@ -27,23 +38,30 @@ export const handle: Handle = async ({ event, resolve }) => {
 			return finalizeResponse(event, rateLimitResponse, context);
 		}
 
-		try {
-			await ensureGyreInitialized();
-		} catch (err) {
-			logger.error(err, 'Failed to ensure Gyre is initialized during request handling');
-			const serviceUnavailableResponse = event.url.pathname.startsWith('/api/')
-				? new Response(
-						JSON.stringify({
-							error: 'Service Unavailable',
-							message: 'Gyre is still initializing'
-						}),
-						{
-							status: 503,
-							headers: { 'Content-Type': 'application/json' }
-						}
-					)
-				: new Response('Service Unavailable', { status: 503 });
-			return finalizeResponse(event, serviceUnavailableResponse, context);
+		if (!bypassInitialization) {
+			try {
+				await ensureGyreInitialized();
+			} catch (err) {
+				logger.error(err, 'Failed to ensure Gyre is initialized during request handling');
+				const status = getGyreInitializationStatus();
+				const message =
+					status.state === 'failed'
+						? 'Gyre initialization failed'
+						: 'Gyre initialization has not completed';
+				const serviceUnavailableResponse = event.url.pathname.startsWith('/api/')
+					? new Response(
+							JSON.stringify({
+								error: 'Service Unavailable',
+								message
+							}),
+							{
+								status: 503,
+								headers: { 'Content-Type': 'application/json' }
+							}
+						)
+					: new Response('Service Unavailable', { status: 503 });
+				return finalizeResponse(event, serviceUnavailableResponse, context);
+			}
 		}
 
 		const response = await resolveRouteAndMapErrors(event, async () => {

--- a/src/lib/server/auth/bootstrap-admin.ts
+++ b/src/lib/server/auth/bootstrap-admin.ts
@@ -65,7 +65,7 @@ export async function hasUsers(): Promise<boolean> {
  * - Local development: Uses ADMIN_PASSWORD env var or generates a password
  */
 export async function createDefaultAdminIfNeeded(options?: {
-	persistSetupToken?: (password: string) => void;
+	persistSetupToken?: (password: string) => string | void;
 }): Promise<{
 	password: string | null;
 	mode: string;
@@ -115,8 +115,9 @@ export async function createDefaultAdminIfNeeded(options?: {
 	const password = process.env.ADMIN_PASSWORD || generateStrongPassword();
 	if (process.env.ADMIN_PASSWORD) warnIfWeakAdminPassword(process.env.ADMIN_PASSWORD);
 
+	let persistedSetupTokenFile: string | undefined;
 	try {
-		options?.persistSetupToken?.(password);
+		persistedSetupTokenFile = options?.persistSetupToken?.(password) ?? undefined;
 	} catch (error) {
 		logger.error(
 			error,
@@ -125,30 +126,38 @@ export async function createDefaultAdminIfNeeded(options?: {
 		throw error;
 	}
 	pendingSetupCleanup = true;
+	if (persistedSetupTokenFile) {
+		setSetupTokenFile(persistedSetupTokenFile);
+	}
 
-	const db = getDbSync();
-	const passwordHash = await hashPassword(password);
-	const newUser: NewUser = {
-		id: generateUserId(),
-		username: 'admin',
-		name: 'admin',
-		role: 'admin',
-		email: 'admin@gyre.local',
-		active: true,
-		requiresPasswordChange: true
-	};
-	db.transaction((tx) => {
-		tx.insert(users).values(newUser).run();
-		tx.insert(accounts)
-			.values({
-				id: generateUserId(),
-				providerId: 'credential',
-				accountId: newUser.id,
-				userId: newUser.id,
-				password: passwordHash
-			})
-			.run();
-	});
+	try {
+		const db = getDbSync();
+		const passwordHash = await hashPassword(password);
+		const newUser: NewUser = {
+			id: generateUserId(),
+			username: 'admin',
+			name: 'admin',
+			role: 'admin',
+			email: 'admin@gyre.local',
+			active: true,
+			requiresPasswordChange: true
+		};
+		db.transaction((tx) => {
+			tx.insert(users).values(newUser).run();
+			tx.insert(accounts)
+				.values({
+					id: generateUserId(),
+					providerId: 'credential',
+					accountId: newUser.id,
+					userId: newUser.id,
+					password: passwordHash
+				})
+				.run();
+		});
+	} catch (error) {
+		cleanupSetupTokenFile();
+		throw error;
+	}
 
 	return { password, mode: 'local' };
 }

--- a/src/lib/server/auth/bootstrap-admin.ts
+++ b/src/lib/server/auth/bootstrap-admin.ts
@@ -79,41 +79,51 @@ export async function createDefaultAdminIfNeeded(options?: {
 	// In-cluster mode: Use K8s secret
 	if (isInClusterMode()) {
 		const password = await loadOrCreateInClusterAdmin();
-		if (password) {
-			const db = getDbSync();
-			const newUser: NewUser = {
-				id: generateUserId(),
-				username: 'admin',
-				name: 'admin',
-				role: 'admin',
-				email: 'admin@gyre.local',
-				active: true,
-				requiresPasswordChange: false
-			};
-			db.transaction((tx) => {
-				tx.insert(users).values(newUser).run();
-				// Keep a credential account row for symmetry with local mode while
-				// leaving the Kubernetes secret as the sole password source of truth.
-				tx.insert(accounts)
-					.values({
-						id: generateUserId(),
-						providerId: 'credential',
-						accountId: newUser.id,
-						userId: newUser.id,
-						password: null
-					})
-					.run();
-			});
-			return { password, mode: 'in-cluster' };
+		if (!password) {
+			throw new Error(
+				'Initial admin secret could not be loaded or created. Fix the in-cluster secret name, namespace, or RBAC permissions and restart Gyre.'
+			);
 		}
-		return { password: null, mode: 'in-cluster' };
+		const db = getDbSync();
+		const newUser: NewUser = {
+			id: generateUserId(),
+			username: 'admin',
+			name: 'admin',
+			role: 'admin',
+			email: 'admin@gyre.local',
+			active: true,
+			requiresPasswordChange: false
+		};
+		db.transaction((tx) => {
+			tx.insert(users).values(newUser).run();
+			// Keep a credential account row for symmetry with local mode while
+			// leaving the Kubernetes secret as the sole password source of truth.
+			tx.insert(accounts)
+				.values({
+					id: generateUserId(),
+					providerId: 'credential',
+					accountId: newUser.id,
+					userId: newUser.id,
+					password: null
+				})
+				.run();
+		});
+		return { password, mode: 'in-cluster' };
 	}
 
 	// Local development mode: Use env var or generate password
 	const password = process.env.ADMIN_PASSWORD || generateStrongPassword();
 	if (process.env.ADMIN_PASSWORD) warnIfWeakAdminPassword(process.env.ADMIN_PASSWORD);
 
-	options?.persistSetupToken?.(password);
+	try {
+		options?.persistSetupToken?.(password);
+	} catch (error) {
+		logger.error(
+			error,
+			'Failed to persist local setup token before admin creation. Fix filesystem permissions for the local setup token path and restart Gyre.'
+		);
+		throw error;
+	}
 	pendingSetupCleanup = true;
 
 	const db = getDbSync();

--- a/src/lib/server/auth/in-cluster-admin.ts
+++ b/src/lib/server/auth/in-cluster-admin.ts
@@ -136,7 +136,10 @@ export async function loadOrCreateInClusterAdmin(): Promise<string | null> {
 
 		return password;
 	} catch (error) {
-		logger.error(error, 'Failed to setup in-cluster admin:');
+		logger.error(
+			error,
+			'Failed to setup in-cluster admin. Fix the gyre-initial-admin-secret name, namespace, or Kubernetes RBAC permissions and restart Gyre:'
+		);
 		throw error;
 	}
 }

--- a/src/lib/server/auth/seed-providers.ts
+++ b/src/lib/server/auth/seed-providers.ts
@@ -61,12 +61,11 @@ export async function seedAuthProviders(): Promise<{ created: number; skipped: n
 	try {
 		providersConfig = JSON.parse(providersJson);
 		if (!Array.isArray(providersConfig)) {
-			logger.error('GYRE_AUTH_PROVIDERS must be a JSON array');
-			return { created: 0, skipped: 0 };
+			throw new Error('GYRE_AUTH_PROVIDERS must be a JSON array');
 		}
 	} catch (error) {
 		logger.error(error, 'Failed to parse GYRE_AUTH_PROVIDERS:');
-		return { created: 0, skipped: 0 };
+		throw error instanceof Error ? error : new Error('Failed to parse GYRE_AUTH_PROVIDERS');
 	}
 
 	// Pre-validate all providers and prepare DB records before touching the database
@@ -81,26 +80,17 @@ export async function seedAuthProviders(): Promise<{ created: number; skipped: n
 			config !== null &&
 			Object.prototype.hasOwnProperty.call(config, 'clientSecret')
 		) {
-			logger.warn(
-				{
-					issues: [
-						'clientSecret: inline clientSecret is not allowed; use GYRE_AUTH_PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET env var'
-					]
-				},
-				`Skipping provider at index ${i}: validation failed`
+			throw new Error(
+				`Provider at index ${i} has forbidden inline clientSecret; use GYRE_AUTH_PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET env var`
 			);
-			skipped++;
-			continue;
 		}
 
 		const parseResult = ProviderSeedConfigSchema.safeParse(config);
 		if (!parseResult.success) {
-			logger.warn(
-				{ issues: parseResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`) },
-				`Skipping provider at index ${i}: validation failed`
+			const issues = parseResult.error.issues.map(
+				(issue) => `${issue.path.join('.')}: ${issue.message}`
 			);
-			skipped++;
-			continue;
+			throw new Error(`Provider at index ${i} failed validation: ${issues.join('; ')}`);
 		}
 		const validatedConfig: ProviderSeedConfig = parseResult.data;
 
@@ -109,102 +99,81 @@ export async function seedAuthProviders(): Promise<{ created: number; skipped: n
 		const envSecretKey = `GYRE_AUTH_PROVIDER_${sanitizedName}_CLIENT_SECRET`;
 		const collidingProviderName = secretEnvKeyToProviderName.get(envSecretKey);
 		if (collidingProviderName) {
-			logger.warn(
-				{
-					providerName: validatedConfig.name,
-					collidingProviderName,
-					envSecretKey
-				},
-				`Skipping provider "${validatedConfig.name}": env secret key collision with provider "${collidingProviderName}"`
+			throw new Error(
+				`Provider "${validatedConfig.name}" env secret key ${envSecretKey} collides with provider "${collidingProviderName}"`
 			);
-			skipped++;
-			continue;
 		}
 		secretEnvKeyToProviderName.set(envSecretKey, validatedConfig.name);
 		const clientSecret = process.env[envSecretKey];
 
 		if (!clientSecret || clientSecret.trim() === '') {
-			logger.error(
-				`Skipping provider "${validatedConfig.name}": missing required env var ${envSecretKey}`
+			throw new Error(
+				`Provider "${validatedConfig.name}" missing required env var ${envSecretKey}`
 			);
-			skipped++;
-			continue;
 		}
 
-		try {
-			// Encrypt client secret
-			const clientSecretEncrypted = encryptSecret(clientSecret);
+		// Encrypt client secret
+		const clientSecretEncrypted = encryptSecret(clientSecret);
 
-			// Generate provider ID
-			const providerId = `provider-${randomBytes(8).toString('hex')}`;
+		// Generate provider ID
+		const providerId = `provider-${randomBytes(8).toString('hex')}`;
 
-			// Normalize and validate roleMapping
-			let roleMapping: string | null = null;
-			if (validatedConfig.roleMapping != null) {
-				let parsed: unknown;
-				if (typeof validatedConfig.roleMapping === 'string') {
-					try {
-						parsed = JSON.parse(validatedConfig.roleMapping);
-					} catch {
-						throw new Error(
-							`Provider "${validatedConfig.name}" has invalid roleMapping: not valid JSON`
-						);
-					}
-					if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-						throw new Error(
-							`Provider "${validatedConfig.name}" has invalid roleMapping: must be a JSON object`
-						);
-					}
-				} else if (
-					typeof validatedConfig.roleMapping === 'object' &&
-					!Array.isArray(validatedConfig.roleMapping)
-				) {
-					parsed = validatedConfig.roleMapping;
-				} else {
+		// Normalize and validate roleMapping
+		let roleMapping: string | null = null;
+		if (validatedConfig.roleMapping != null) {
+			let parsed: unknown;
+			if (typeof validatedConfig.roleMapping === 'string') {
+				try {
+					parsed = JSON.parse(validatedConfig.roleMapping);
+				} catch {
 					throw new Error(
-						`Provider "${validatedConfig.name}" has invalid roleMapping: must be a plain object or JSON string`
+						`Provider "${validatedConfig.name}" has invalid roleMapping: not valid JSON`
 					);
 				}
-				const rawMapping = parsed as Record<string, unknown>;
-				const validated: Record<string, string[]> = {};
-				for (const [key, val] of Object.entries(rawMapping)) {
-					if (!Array.isArray(val) || !val.every((item) => typeof item === 'string')) {
-						throw new Error(
-							`Provider "${validatedConfig.name}" has invalid roleMapping: values must be string[] for key "${key}"`
-						);
-					}
-					validated[key] = val;
+				if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+					throw new Error(
+						`Provider "${validatedConfig.name}" has invalid roleMapping: must be a JSON object`
+					);
 				}
-				roleMapping = JSON.stringify(validated);
+			} else {
+				parsed = validatedConfig.roleMapping;
 			}
-
-			validProviders.push({
-				id: providerId,
-				name: validatedConfig.name,
-				type: validatedConfig.type,
-				enabled: validatedConfig.enabled ?? true,
-				clientId: validatedConfig.clientId,
-				clientSecretEncrypted,
-				issuerUrl: validatedConfig.issuerUrl || null,
-				authorizationUrl: validatedConfig.authorizationUrl || null,
-				tokenUrl: validatedConfig.tokenUrl || null,
-				userInfoUrl: validatedConfig.userInfoUrl || null,
-				jwksUrl: validatedConfig.jwksUrl || null,
-				autoProvision: validatedConfig.autoProvision ?? true,
-				defaultRole: validatedConfig.defaultRole || 'viewer',
-				roleMapping,
-				roleClaim: validatedConfig.roleClaim || 'groups',
-				usernameClaim: validatedConfig.usernameClaim || 'preferred_username',
-				emailClaim: validatedConfig.emailClaim || 'email',
-				usePkce: validatedConfig.usePkce ?? true,
-				scopes: validatedConfig.scopes || 'openid profile email',
-				createdAt: new Date(),
-				updatedAt: new Date()
-			});
-		} catch (error) {
-			logger.error(error, `Failed to prepare provider "${validatedConfig.name}":`);
-			skipped++;
+			const rawMapping = parsed as Record<string, unknown>;
+			const validated: Record<string, string[]> = {};
+			for (const [key, val] of Object.entries(rawMapping)) {
+				if (!Array.isArray(val) || !val.every((item) => typeof item === 'string')) {
+					throw new Error(
+						`Provider "${validatedConfig.name}" has invalid roleMapping: values must be string[] for key "${key}"`
+					);
+				}
+				validated[key] = val;
+			}
+			roleMapping = JSON.stringify(validated);
 		}
+
+		validProviders.push({
+			id: providerId,
+			name: validatedConfig.name,
+			type: validatedConfig.type,
+			enabled: validatedConfig.enabled ?? true,
+			clientId: validatedConfig.clientId,
+			clientSecretEncrypted,
+			issuerUrl: validatedConfig.issuerUrl || null,
+			authorizationUrl: validatedConfig.authorizationUrl || null,
+			tokenUrl: validatedConfig.tokenUrl || null,
+			userInfoUrl: validatedConfig.userInfoUrl || null,
+			jwksUrl: validatedConfig.jwksUrl || null,
+			autoProvision: validatedConfig.autoProvision ?? true,
+			defaultRole: validatedConfig.defaultRole || 'viewer',
+			roleMapping,
+			roleClaim: validatedConfig.roleClaim || 'groups',
+			usernameClaim: validatedConfig.usernameClaim || 'preferred_username',
+			emailClaim: validatedConfig.emailClaim || 'email',
+			usePkce: validatedConfig.usePkce ?? true,
+			scopes: validatedConfig.scopes || 'openid profile email',
+			createdAt: new Date(),
+			updatedAt: new Date()
+		});
 	}
 
 	if (validProviders.length === 0) {

--- a/src/lib/server/lifecycle/startup.ts
+++ b/src/lib/server/lifecycle/startup.ts
@@ -149,14 +149,12 @@ export async function initializeGyre(): Promise<void> {
 			logger.info(`   ✓ Seeded ${seedResult.created} auth provider(s)`);
 		}
 		if (seedResult.skipped > 0) {
-			logger.info(
-				`   ℹ Skipped ${seedResult.skipped} provider(s) (existing or invalid/missing secrets)`
-			);
+			logger.info(`   ℹ Skipped ${seedResult.skipped} existing provider(s)`);
 		}
 		logger.info('   ✓ Authentication settings ready');
 	} catch (error) {
 		logger.error(error, '   ✗ Failed to seed auth settings');
-		// Don't throw - app can still work without seeded providers
+		throw error;
 	}
 
 	// Schedule reconciliation history cleanup

--- a/src/lib/server/lifecycle/startup.ts
+++ b/src/lib/server/lifecycle/startup.ts
@@ -77,6 +77,7 @@ export async function initializeGyre(): Promise<void> {
 						tokenFile = join(tmpdir(), `gyre-setup-token-${Date.now()}.txt`);
 						try {
 							writeFileSync(tokenFile, token, { mode: 0o600, flag: 'wx' });
+							return tokenFile;
 						} catch (writeErr) {
 							logger.error(writeErr, '   ✗ Failed to write setup token file');
 							throw writeErr;

--- a/src/lib/server/request/initialization.ts
+++ b/src/lib/server/request/initialization.ts
@@ -1,21 +1,39 @@
-import { initializeGyre } from '$lib/server/initialize.js';
 import { logger } from '$lib/server/logger.js';
 
 let initialized = false;
 let initializingPromise: Promise<void> | undefined;
+let initializationState: 'not_started' | 'initializing' | 'ready' | 'failed' = 'not_started';
+let failureMessage: string | undefined;
+
+export function getGyreInitializationStatus(): {
+	state: 'not_started' | 'initializing' | 'ready' | 'failed';
+	message?: string;
+} {
+	return { state: initializationState, message: failureMessage };
+}
 
 export async function ensureGyreInitialized(): Promise<void> {
 	if (initialized) {
 		return;
 	}
 
+	if (initializationState === 'failed') {
+		throw new Error(failureMessage ?? 'Gyre initialization failed');
+	}
+
 	if (!initializingPromise) {
-		initializingPromise = initializeGyre()
+		initializationState = 'initializing';
+		failureMessage = undefined;
+		initializingPromise = import('$lib/server/initialize.js')
+			.then(({ initializeGyre }) => initializeGyre())
 			.then(() => {
 				initialized = true;
+				initializationState = 'ready';
 			})
 			.catch((error) => {
 				logger.error(error, 'Failed to initialize Gyre:');
+				initializationState = 'failed';
+				failureMessage = error instanceof Error ? error.message : 'Gyre initialization failed';
 				throw error;
 			})
 			.finally(() => {

--- a/src/lib/server/settings.ts
+++ b/src/lib/server/settings.ts
@@ -3,7 +3,7 @@
  * Manages key-value application settings with environment variable overrides.
  */
 
-import { getDb } from './db';
+import { getDb, getDbSync } from './db';
 import { appSettings } from './db/schema';
 import { eq } from 'drizzle-orm';
 
@@ -91,7 +91,7 @@ export async function setSetting(key: string, value: string): Promise<void> {
 export async function setSettings(values: Array<{ key: string; value: string }>): Promise<void> {
 	if (values.length === 0) return;
 
-	const db = await getDb();
+	const db = getDbSync();
 	const updatedAt = new Date();
 
 	db.transaction((tx) => {

--- a/src/lib/server/settings.ts
+++ b/src/lib/server/settings.ts
@@ -42,6 +42,8 @@ const ENV_OVERRIDES: Record<string, string> = {
 	[SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS]: 'GYRE_AUDIT_LOG_RETENTION_DAYS'
 };
 
+export const SETTING_ENV_OVERRIDES = ENV_OVERRIDES;
+
 /**
  * Get a setting value with env var override.
  * @param key - Setting key
@@ -84,6 +86,29 @@ export async function setSetting(key: string, value: string): Promise<void> {
 			target: appSettings.key,
 			set: { value, updatedAt: new Date() }
 		});
+}
+
+export async function setSettings(values: Array<{ key: string; value: string }>): Promise<void> {
+	if (values.length === 0) return;
+
+	const db = await getDb();
+	const updatedAt = new Date();
+
+	db.transaction((tx) => {
+		for (const { key, value } of values) {
+			tx.insert(appSettings)
+				.values({
+					key,
+					value,
+					updatedAt
+				})
+				.onConflictDoUpdate({
+					target: appSettings.key,
+					set: { value, updatedAt }
+				})
+				.run();
+		}
+	});
 }
 
 /**

--- a/src/routes/api/ready/+server.ts
+++ b/src/routes/api/ready/+server.ts
@@ -1,0 +1,1 @@
+export { GET, _metadata } from '../v1/ready/+server.js';

--- a/src/routes/api/v1/admin/settings/+server.ts
+++ b/src/routes/api/v1/admin/settings/+server.ts
@@ -231,14 +231,35 @@ export const PATCH: RequestHandler = async ({ locals, request, setHeaders }) => 
 		}
 
 		const { requestedKeys, updates } = normalizeSettingsPayload(body);
+		if (updates.length === 0) {
+			const [authSettings, auditRetentionDays] = await Promise.all([
+				getAuthSettings(),
+				getAuditLogRetentionDays()
+			]);
+			return json({
+				settings: {
+					localLoginEnabled: {
+						value: authSettings.localLoginEnabled,
+						overriddenByEnv: isSettingOverriddenByEnv(SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED)
+					},
+					allowSignup: {
+						value: authSettings.allowSignup,
+						overriddenByEnv: isSettingOverriddenByEnv(SETTINGS_KEYS.AUTH_ALLOW_SIGNUP)
+					},
+					domainAllowlist: {
+						value: authSettings.domainAllowlist,
+						overriddenByEnv: isSettingOverriddenByEnv(SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST)
+					},
+					auditRetentionDays: {
+						value: auditRetentionDays,
+						overriddenByEnv: isSettingOverriddenByEnv(SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS)
+					}
+				}
+			});
+		}
+
 		await setSettings(updates);
 		const changedKeys = updates.map((update) => update.key);
-
-		// Return updated settings
-		const [authSettings, auditRetentionDays] = await Promise.all([
-			getAuthSettings(),
-			getAuditLogRetentionDays()
-		]);
 		await logPrivilegedMutationSuccess({
 			action: 'settings:update',
 			user,
@@ -248,6 +269,12 @@ export const PATCH: RequestHandler = async ({ locals, request, setHeaders }) => 
 				changedKeys
 			}
 		});
+
+		// Return updated settings
+		const [authSettings, auditRetentionDays] = await Promise.all([
+			getAuthSettings(),
+			getAuditLogRetentionDays()
+		]);
 		return json({
 			settings: {
 				localLoginEnabled: {

--- a/src/routes/api/v1/admin/settings/+server.ts
+++ b/src/routes/api/v1/admin/settings/+server.ts
@@ -10,9 +10,10 @@ import type { RequestHandler } from './$types';
 import {
 	getAuthSettings,
 	getAuditLogRetentionDays,
-	setSetting,
+	setSettings,
 	SETTINGS_KEYS,
-	isSettingOverriddenByEnv
+	isSettingOverriddenByEnv,
+	SETTING_ENV_OVERRIDES
 } from '$lib/server/settings';
 import {
 	enforceUserRateLimitPreset,
@@ -77,10 +78,101 @@ export const _metadata = {
 			},
 			400: { description: 'Invalid request body' },
 			401: { description: 'Unauthorized' },
+			409: { description: 'Setting is locked by environment variable' },
 			403: { description: 'Admin access required' }
 		}
 	}
 };
+
+const PUBLIC_SETTING_MAP = {
+	localLoginEnabled: SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED,
+	allowSignup: SETTINGS_KEYS.AUTH_ALLOW_SIGNUP,
+	domainAllowlist: SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST,
+	auditRetentionDays: SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS
+} as const;
+
+type PublicSettingKey = keyof typeof PUBLIC_SETTING_MAP;
+
+function normalizeSettingsPayload(body: unknown): {
+	requestedKeys: string[];
+	updates: Array<{ key: string; value: string }>;
+} {
+	if (!body || typeof body !== 'object' || Array.isArray(body)) {
+		throw error(400, { message: 'Invalid request body' });
+	}
+
+	const requestedKeys = Object.keys(body);
+	const unknownKeys = requestedKeys.filter((key) => !(key in PUBLIC_SETTING_MAP));
+	if (unknownKeys.length > 0) {
+		throw error(400, { message: `Unknown setting field(s): ${unknownKeys.join(', ')}` });
+	}
+
+	const payload = body as Record<string, unknown>;
+	const updates: Array<{ key: string; value: string }> = [];
+
+	if ('localLoginEnabled' in payload) {
+		if (typeof payload.localLoginEnabled !== 'boolean') {
+			throw error(400, { message: 'localLoginEnabled must be a boolean' });
+		}
+		updates.push({
+			key: SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED,
+			value: String(payload.localLoginEnabled)
+		});
+	}
+
+	if ('allowSignup' in payload) {
+		if (typeof payload.allowSignup !== 'boolean') {
+			throw error(400, { message: 'allowSignup must be a boolean' });
+		}
+		updates.push({ key: SETTINGS_KEYS.AUTH_ALLOW_SIGNUP, value: String(payload.allowSignup) });
+	}
+
+	if ('domainAllowlist' in payload) {
+		if (!Array.isArray(payload.domainAllowlist)) {
+			throw error(400, { message: 'domainAllowlist must be an array of strings' });
+		}
+		if (!payload.domainAllowlist.every((domain) => typeof domain === 'string')) {
+			throw error(400, { message: 'domainAllowlist entries must be strings' });
+		}
+		const domains = payload.domainAllowlist
+			.map((domain) => domain.trim().toLowerCase())
+			.filter((domain) => domain.length > 0);
+		const uniqueDomains = [...new Set(domains)];
+		updates.push({
+			key: SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST,
+			value: JSON.stringify(uniqueDomains)
+		});
+	}
+
+	if ('auditRetentionDays' in payload) {
+		if (
+			typeof payload.auditRetentionDays !== 'number' ||
+			!Number.isFinite(payload.auditRetentionDays)
+		) {
+			throw error(400, { message: 'auditRetentionDays must be a finite number' });
+		}
+		const retention = Math.floor(payload.auditRetentionDays);
+		if (retention < 1 || retention > 3650) {
+			throw error(400, { message: 'auditRetentionDays must be between 1 and 3650' });
+		}
+		updates.push({ key: SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS, value: String(retention) });
+	}
+
+	const lockedFields = requestedKeys.filter((key) =>
+		isSettingOverriddenByEnv(PUBLIC_SETTING_MAP[key as PublicSettingKey])
+	);
+	if (lockedFields.length > 0) {
+		const details = lockedFields.map((key) => {
+			const settingKey = PUBLIC_SETTING_MAP[key as PublicSettingKey];
+			return `${key} (${SETTING_ENV_OVERRIDES[settingKey]})`;
+		});
+		throw error(409, {
+			message: `Setting field(s) are locked by environment variable: ${details.join(', ')}`
+		});
+	}
+
+	return { requestedKeys, updates };
+}
 
 /**
  * GET /api/admin/settings
@@ -138,58 +230,9 @@ export const PATCH: RequestHandler = async ({ locals, request, setHeaders }) => 
 			throw error(400, { message: 'Invalid JSON body' });
 		}
 
-		// Validate input
-		if (!body || typeof body !== 'object') {
-			throw error(400, { message: 'Invalid request body' });
-		}
-		const changedKeys: string[] = [];
-		const requestedKeys = Object.keys(body);
-
-		// Update settings
-		if (typeof body.localLoginEnabled === 'boolean') {
-			if (!isSettingOverriddenByEnv(SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED)) {
-				await setSetting(SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED, String(body.localLoginEnabled));
-				changedKeys.push(SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED);
-			}
-		}
-
-		if (typeof body.allowSignup === 'boolean') {
-			if (!isSettingOverriddenByEnv(SETTINGS_KEYS.AUTH_ALLOW_SIGNUP)) {
-				await setSetting(SETTINGS_KEYS.AUTH_ALLOW_SIGNUP, String(body.allowSignup));
-				changedKeys.push(SETTINGS_KEYS.AUTH_ALLOW_SIGNUP);
-			}
-		}
-
-		if (Array.isArray(body.domainAllowlist)) {
-			if (!isSettingOverriddenByEnv(SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST)) {
-				// Validate domains
-				const domains = body.domainAllowlist
-					.filter((d: unknown) => typeof d === 'string')
-					.map((d: string) => d.trim().toLowerCase())
-					.filter((d: string) => d.length > 0);
-
-				const uniqueDomains = [...new Set(domains)];
-				await setSetting(SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST, JSON.stringify(uniqueDomains));
-				changedKeys.push(SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST);
-			}
-		}
-
-		if (typeof body.auditRetentionDays === 'number') {
-			if (!isSettingOverriddenByEnv(SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS)) {
-				if (!Number.isFinite(body.auditRetentionDays)) {
-					throw error(400, { message: 'Audit retention days must be a finite number' });
-				}
-
-				const retention = Math.floor(body.auditRetentionDays);
-				// Validate range (1-3650 days)
-				if (retention < 1 || retention > 3650) {
-					throw error(400, { message: 'Audit retention days must be between 1 and 3650' });
-				}
-
-				await setSetting(SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS, String(retention));
-				changedKeys.push(SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS);
-			}
-		}
+		const { requestedKeys, updates } = normalizeSettingsPayload(body);
+		await setSettings(updates);
+		const changedKeys = updates.map((update) => update.key);
 
 		// Return updated settings
 		const [authSettings, auditRetentionDays] = await Promise.all([

--- a/src/routes/api/v1/ready/+server.ts
+++ b/src/routes/api/v1/ready/+server.ts
@@ -1,0 +1,42 @@
+import { json } from '@sveltejs/kit';
+import { z } from '$lib/server/openapi';
+import { getGyreInitializationStatus } from '$lib/server/request/initialization.js';
+import type { RequestHandler } from './$types';
+
+export const _metadata = {
+	GET: {
+		summary: 'Application readiness check',
+		description: 'Reports whether Gyre initialization has completed successfully.',
+		tags: ['System'],
+		responses: {
+			200: {
+				description: 'Application is ready',
+				content: {
+					'application/json': {
+						schema: z.object({
+							status: z.literal('ready')
+						})
+					}
+				}
+			},
+			503: { description: 'Application initialization is incomplete or failed' }
+		}
+	}
+};
+
+export const GET: RequestHandler = async () => {
+	const status = getGyreInitializationStatus();
+
+	if (status.state === 'ready') {
+		return json({ status: 'ready' });
+	}
+
+	if (status.state === 'failed') {
+		return json({ status: 'failed', message: 'Gyre initialization failed' }, { status: 503 });
+	}
+
+	return json(
+		{ status: 'initializing', message: 'Gyre initialization has not completed' },
+		{ status: 503 }
+	);
+};

--- a/src/routes/api/v1/ready/+server.ts
+++ b/src/routes/api/v1/ready/+server.ts
@@ -19,7 +19,17 @@ export const _metadata = {
 					}
 				}
 			},
-			503: { description: 'Application initialization is incomplete or failed' }
+			503: {
+				description: 'Application initialization is incomplete or failed',
+				content: {
+					'application/json': {
+						schema: z.object({
+							status: z.enum(['initializing', 'failed']),
+							message: z.string()
+						})
+					}
+				}
+			}
 		}
 	}
 };

--- a/src/tests/admin-security-audit-events.test.ts
+++ b/src/tests/admin-security-audit-events.test.ts
@@ -18,6 +18,7 @@ type ClearClientPoolRouteModule =
 
 const auditCalls: Array<[User | null, string, Record<string, unknown> | undefined]> = [];
 const settingWrites: Array<[string, string]> = [];
+const lockedSettingKeys = new Set<string>();
 
 let permissionAllowed = true;
 let clearPoolCalls = 0;
@@ -62,6 +63,7 @@ function createUser(role: User['role'] = 'admin'): User {
 beforeEach(async () => {
 	auditCalls.length = 0;
 	settingWrites.length = 0;
+	lockedSettingKeys.clear();
 	permissionAllowed = true;
 	clearPoolCalls = 0;
 	dbState.insertedProviders.length = 0;
@@ -175,12 +177,16 @@ beforeEach(async () => {
 			setSetting: async (key: string, value: string) => {
 				settingWrites.push([key, value]);
 			},
+			setSettings: async (values: Array<{ key: string; value: string }>) => {
+				settingWrites.push(...values.map(({ key, value }) => [key, value] as [string, string]));
+			},
 			getAuthSettings: async () => ({
 				localLoginEnabled: true,
 				allowSignup: false,
 				domainAllowlist: ['example.com']
 			}),
-			getAuditLogRetentionDays: async () => 90
+			getAuditLogRetentionDays: async () => 90,
+			isSettingOverriddenByEnv: (key: string) => lockedSettingKeys.has(key)
 		})
 	);
 
@@ -343,6 +349,42 @@ describe('admin mutation audit events', () => {
 			requestedKeys: ['allowSignup', 'domainAllowlist'],
 			changedKeys: ['auth.allowSignup', 'auth.domainAllowlist']
 		});
+	});
+
+	test('rejects invalid settings patch without writing or auditing', async () => {
+		await expect(
+			patchSettings({
+				locals: { user: createUser(), cluster: 'cluster-a' },
+				setHeaders: () => {},
+				request: new Request('http://localhost/api/v1/admin/settings', {
+					method: 'PATCH',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ allowSignup: 'false' })
+				})
+			} as Parameters<SettingsRouteModule['PATCH']>[0])
+		).rejects.toMatchObject({ status: 400 });
+
+		expect(settingWrites).toEqual([]);
+		expect(auditCalls).toEqual([]);
+	});
+
+	test('rejects env-locked settings patch without writing or auditing', async () => {
+		lockedSettingKeys.add('auth.allowSignup');
+
+		await expect(
+			patchSettings({
+				locals: { user: createUser(), cluster: 'cluster-a' },
+				setHeaders: () => {},
+				request: new Request('http://localhost/api/v1/admin/settings', {
+					method: 'PATCH',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ allowSignup: false })
+				})
+			} as Parameters<SettingsRouteModule['PATCH']>[0])
+		).rejects.toMatchObject({ status: 409 });
+
+		expect(settingWrites).toEqual([]);
+		expect(auditCalls).toEqual([]);
 	});
 
 	test('logs k8s-client-pool:clear on pool clear mutation', async () => {

--- a/src/tests/admin-security-audit-events.test.ts
+++ b/src/tests/admin-security-audit-events.test.ts
@@ -387,6 +387,22 @@ describe('admin mutation audit events', () => {
 		expect(auditCalls).toEqual([]);
 	});
 
+	test('does not write or audit when settings patch has no changes', async () => {
+		const response = await patchSettings({
+			locals: { user: createUser(), cluster: 'cluster-a' },
+			setHeaders: () => {},
+			request: new Request('http://localhost/api/v1/admin/settings', {
+				method: 'PATCH',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({})
+			})
+		} as Parameters<SettingsRouteModule['PATCH']>[0]);
+
+		expect(response.status).toBe(200);
+		expect(settingWrites).toEqual([]);
+		expect(auditCalls).toEqual([]);
+	});
+
 	test('logs k8s-client-pool:clear on pool clear mutation', async () => {
 		const response = await clearClientPool({
 			locals: { user: createUser(), cluster: 'cluster-a' }

--- a/src/tests/auth-seed-providers.test.ts
+++ b/src/tests/auth-seed-providers.test.ts
@@ -120,7 +120,7 @@ describe('seedAuthProviders', () => {
 		expect(state.inserted[0].clientSecretEncrypted).not.toBe('super-secret');
 	});
 
-	test('rejects providers that include forbidden clientSecret in JSON payload', async () => {
+	test('throws when providers include forbidden clientSecret in JSON payload', async () => {
 		process.env.GYRE_AUTH_PROVIDERS = JSON.stringify([
 			{
 				name: 'GitHub',
@@ -131,17 +131,11 @@ describe('seedAuthProviders', () => {
 		]);
 		process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET = 'super-secret';
 
-		const result = await seedAuthProviders();
-
-		expect(result).toEqual({ created: 0, skipped: 1 });
+		await expect(seedAuthProviders()).rejects.toThrow('forbidden inline clientSecret');
 		expect(state.inserted.length).toBe(0);
-		expect(state.warnLogs.length).toBeGreaterThan(0);
-		expect(JSON.stringify(state.warnLogs)).toContain(
-			'clientSecret: inline clientSecret is not allowed'
-		);
 	});
 
-	test('skips provider with clear error when provider secret env var is missing', async () => {
+	test('throws when provider secret env var is missing', async () => {
 		process.env.GYRE_AUTH_PROVIDERS = JSON.stringify([
 			{
 				name: 'GitHub',
@@ -151,13 +145,16 @@ describe('seedAuthProviders', () => {
 		]);
 		delete process.env.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET;
 
-		const result = await seedAuthProviders();
-
-		expect(result).toEqual({ created: 0, skipped: 1 });
-		expect(state.inserted.length).toBe(0);
-		expect(state.errorLogs.length).toBeGreaterThan(0);
-		expect(JSON.stringify(state.errorLogs)).toContain(
+		await expect(seedAuthProviders()).rejects.toThrow(
 			'missing required env var GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET'
 		);
+		expect(state.inserted.length).toBe(0);
+	});
+
+	test('throws on malformed providers JSON', async () => {
+		process.env.GYRE_AUTH_PROVIDERS = '{';
+
+		await expect(seedAuthProviders()).rejects.toThrow();
+		expect(state.inserted.length).toBe(0);
 	});
 });

--- a/src/tests/health-routes.test.ts
+++ b/src/tests/health-routes.test.ts
@@ -15,4 +15,25 @@ describe('health routes', () => {
 		expect(await legacyResponse.json()).toEqual({ status: 'ok' });
 		expect(await versionedResponse.json()).toEqual({ status: 'ok' });
 	});
+
+	test('api/ready and api/v1/ready report initializing before startup completes', async () => {
+		const legacyRoute = await import('../routes/api/ready/+server.js');
+		const versionedRoute = await import('../routes/api/v1/ready/+server.js');
+
+		const [legacyResponse, versionedResponse] = await Promise.all([
+			legacyRoute.GET({} as Parameters<typeof legacyRoute.GET>[0]),
+			versionedRoute.GET({} as Parameters<typeof versionedRoute.GET>[0])
+		]);
+
+		expect(legacyResponse.status).toBe(503);
+		expect(versionedResponse.status).toBe(503);
+		expect(await legacyResponse.json()).toEqual({
+			status: 'initializing',
+			message: 'Gyre initialization has not completed'
+		});
+		expect(await versionedResponse.json()).toEqual({
+			status: 'initializing',
+			message: 'Gyre initialization has not completed'
+		});
+	});
 });

--- a/src/tests/helm-chart-regressions.test.ts
+++ b/src/tests/helm-chart-regressions.test.ts
@@ -70,7 +70,9 @@ describe('helm chart regressions', () => {
 		expect(configMap).toContain('BODY_SIZE_LIMIT: {{ .Values.config.bodySizeLimit | quote }}');
 		expect(deployment).toContain('- name: BODY_SIZE_LIMIT');
 		expect(deployment).toContain('key: BODY_SIZE_LIMIT');
-		expect(deployment).toContain('config.additionalConfig.BODY_SIZE_LIMIT is reserved');
+		expect(deployment).toContain('$reservedAdditionalConfig');
+		expect(deployment).toContain('config.additionalConfig.%s is reserved');
+		expect(deployment).toContain('^GYRE_AUTH_PROVIDER_.*_CLIENT_SECRET$');
 	});
 
 	test('values schema includes origin, gatewayApi.tls, and networkPolicy.egress.apiServer', () => {

--- a/src/tests/helpers/module-stubs.ts
+++ b/src/tests/helpers/module-stubs.ts
@@ -170,6 +170,7 @@ export function createSettingsModuleStub(
 		};
 		getSetting: (key: string) => string | Promise<string>;
 		setSetting: (key: string, value: string) => void | Promise<void>;
+		setSettings: (values: Array<{ key: string; value: string }>) => void | Promise<void>;
 		getAuthSettings: () =>
 			| {
 					localLoginEnabled: boolean;
@@ -183,6 +184,7 @@ export function createSettingsModuleStub(
 			  }>;
 		getAuditLogRetentionDays: () => number | Promise<number>;
 		isSettingOverriddenByEnv: (key: string) => boolean;
+		SETTING_ENV_OVERRIDES: Record<string, string>;
 		seedAuthSettings: () => void | Promise<void>;
 		isLocalLoginEnabled: () => boolean | Promise<boolean>;
 		isSignupAllowed: () => boolean | Promise<boolean>;
@@ -206,6 +208,7 @@ export function createSettingsModuleStub(
 			return '';
 		},
 		setSetting: async () => {},
+		setSettings: async () => {},
 		getAuthSettings: async () => ({
 			localLoginEnabled: true,
 			allowSignup: true,
@@ -213,6 +216,12 @@ export function createSettingsModuleStub(
 		}),
 		getAuditLogRetentionDays: async () => 90,
 		isSettingOverriddenByEnv: () => false,
+		SETTING_ENV_OVERRIDES: {
+			[SETTINGS_KEYS.AUTH_LOCAL_LOGIN_ENABLED]: 'GYRE_AUTH_LOCAL_LOGIN_ENABLED',
+			[SETTINGS_KEYS.AUTH_ALLOW_SIGNUP]: 'GYRE_AUTH_ALLOW_SIGNUP',
+			[SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST]: 'GYRE_AUTH_DOMAIN_ALLOWLIST',
+			[SETTINGS_KEYS.AUDIT_LOG_RETENTION_DAYS]: 'GYRE_AUDIT_LOG_RETENTION_DAYS'
+		},
 		seedAuthSettings: async () => {},
 		isLocalLoginEnabled: async () => true,
 		isSignupAllowed: async () => true,

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -13,6 +13,7 @@ const state: { db: ReturnType<typeof drizzle<typeof schema>> | null } = { db: nu
 type SettingsModule = typeof import('../lib/server/settings.js');
 let getSetting: SettingsModule['getSetting'];
 let setSetting: SettingsModule['setSetting'];
+let setSettings: SettingsModule['setSettings'];
 let getAuthSettings: SettingsModule['getAuthSettings'];
 let getAuditLogRetentionDays: SettingsModule['getAuditLogRetentionDays'];
 let isSettingOverriddenByEnv: SettingsModule['isSettingOverriddenByEnv'];
@@ -61,6 +62,7 @@ beforeEach(async () => {
 	const settingsModule = await importFresh<SettingsModule>('../lib/server/settings.js?sut');
 	getSetting = settingsModule.getSetting;
 	setSetting = settingsModule.setSetting;
+	setSettings = settingsModule.setSettings;
 	getAuthSettings = settingsModule.getAuthSettings;
 	getAuditLogRetentionDays = settingsModule.getAuditLogRetentionDays;
 	isSettingOverriddenByEnv = settingsModule.isSettingOverriddenByEnv;
@@ -160,6 +162,18 @@ describe('setSetting', () => {
 
 		const val2 = await getSetting(key);
 		expect(val2).toBe('false');
+	});
+});
+
+describe('setSettings', () => {
+	test('upserts multiple settings in one transaction', async () => {
+		await setSettings([
+			{ key: SETTINGS_KEYS.AUTH_ALLOW_SIGNUP, value: 'false' },
+			{ key: SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST, value: '["example.com"]' }
+		]);
+
+		expect(await getSetting(SETTINGS_KEYS.AUTH_ALLOW_SIGNUP)).toBe('false');
+		expect(await getSetting(SETTINGS_KEYS.AUTH_DOMAIN_ALLOWLIST)).toBe('["example.com"]');
 	});
 });
 


### PR DESCRIPTION
## Summary
- Make startup initialization fail closed: auth provider seeding now throws on malformed or incomplete config instead of silently skipping entries, and startup now propagates fatal seeding failures.
- Add explicit readiness endpoints at `/api/v1/ready` and legacy `/api/ready`, with initialization-aware `503` responses until startup completes or after fatal failure.
- Tighten admin settings PATCH handling to validate the full payload, reject unknown fields, return `409` for env-locked settings, and apply accepted updates atomically.
- Harden Helm chart rendering by reserving chart-owned env vars, blocking provider secret collisions, and switching the default readiness probe to `/api/v1/ready`.
- Update docs and tests to cover readiness semantics, settings validation, startup failure behavior, and chart regression checks.

## Testing
- `Not run` in this environment.
- Added/updated tests for readiness routes, admin settings validation, auth provider seeding failures, and Helm chart regressions.
- Concrete checks covered by the test changes: invalid settings payloads return `400`, env-locked settings return `409`, readiness returns `503` before initialization completes, and malformed auth provider config now throws instead of being skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added readiness endpoint reporting ready/initializing/failed states.

* **Bug Fixes**
  * Improved initialization flow with clearer 503 responses for non-ready requests.
  * Stricter validation that rejects reserved/forbidden additional-config keys and invalid auth-provider configs.
  * Settings PATCH now returns 409 for fields locked by environment variables and applies bulk updates atomically.

* **Documentation**
  * Updated API and Helm docs for probe behavior and reserved-config guidance.

* **Tests**
  * Added/adjusted tests for readiness, seeding, settings, and Helm chart validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->