### PR TITLE
chore: migrate tests from Bun to Vitest

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,11 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
 	"remoteUser": "node",
 	"mounts": ["source=${localEnv:HOME}/.kube,target=/home/node/.kube,type=bind,readonly"],
-	"remoteEnv": {
-		"BUN_INSTALL": "/home/node/.bun",
-		"PATH": "/home/node/.bun/bin:${containerEnv:PATH}"
-	},
-	"postCreateCommand": "bash -lc 'set -euo pipefail; if ! command -v bun >/dev/null 2>&1; then export BUN_VERSION=1.3.10; curl -fsSL https://bun.sh/install | bash; fi; export BUN_INSTALL=/home/node/.bun; export PATH=$BUN_INSTALL/bin:$PATH; bun install'",
+	"postCreateCommand": "bash -lc 'set -euo pipefail; corepack enable; corepack prepare pnpm@11.1.0 --activate; pnpm install'",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,11 +30,6 @@ jobs:
         with:
           version: 11.1.0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.3.11
-
       - name: Setup Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,17 +18,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+        with:
+          version: 11.1.0
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: pnpm-lock.yaml
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-        with:
-          version: 11.1.0
 
       - name: Setup Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Comprehensive contributing guidelines, including development setup, code standar
 
 ## Quick Start (DevContainer)
 
-If using a local devcontainer setup, ensure it installs pnpm 11.1.0 and Bun 1.3.11 for tests.
+If using a local devcontainer setup, ensure it installs Node.js and pnpm 11.1.0.
 
 1. Open the repository in VS Code with the **Dev Containers** extension.
 2. Press `F1` → **"Dev Containers: Reopen in Container"**.
@@ -29,9 +29,9 @@ If using a local devcontainer setup, ensure it installs pnpm 11.1.0 and Bun 1.3.
 - `pnpm scripts:check` - Shell script syntax check (`bash -n`)
 - `pnpm verify:repo` - Repo gate for app + Helm + shell scripts
 - `pnpm verify:repo:ci` - Full CI repo gate for app + docs + Helm + shell scripts
-- `pnpm test` - Full Bun test suite (requires Helm on PATH for chart render regression tests)
+- `pnpm test` - Full Vitest test suite (requires Helm on PATH for chart render regression tests)
 
-Tests still use Bun for now (`pnpm test` runs `bun test`) until the follow-up runtime/test migration is completed.
+Tests run through Vitest on Node.js.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ pnpm verify:repo:ci
 ```
 
 `verify` and `verify:ci` are app-only gates. `verify:repo` and `verify:repo:ci` are repo-wide gates.
-Tests still use Bun for now (`pnpm test` runs `bun test`) until the follow-up runtime/test migration is completed.
+Tests run through Vitest on Node.js with `pnpm test`.
 
 ---
 

--- a/documentation/docs/contributing.md
+++ b/documentation/docs/contributing.md
@@ -12,13 +12,12 @@ Thank you for your interest in contributing to Gyre! This document outlines the 
 
 - [Node.js](https://nodejs.org/) 22.13+
 - [pnpm](https://pnpm.io/) 11.1.0
-- [Bun](https://bun.sh/) 1.3.11 (for tests)
 - A Kubernetes cluster with FluxCD installed (for testing)
 - Git
 
 ### Quick Start (DevContainer - Recommended)
 
-If using a local devcontainer setup, ensure it installs pnpm 11.1.0 and Bun 1.3.11 for tests.
+If using a local devcontainer setup, ensure it installs Node.js and pnpm 11.1.0.
 
 1. Open the repository in VS Code with the Dev Containers extension
 2. Press `F1` → "Dev Containers: Reopen in Container"
@@ -236,7 +235,7 @@ Use the same type prefixes as commit messages:
 
 Automated tests are required and part of normal verification (`pnpm test`, `pnpm verify:ci`, `pnpm verify:repo:ci`).
 
-Tests still use Bun for now (`pnpm test` runs `bun test`) until the follow-up runtime/test migration is completed.
+Tests run through Vitest on Node.js with `pnpm test`.
 
 ### Before Submitting a PR
 

--- a/documentation/docs/development.md
+++ b/documentation/docs/development.md
@@ -20,7 +20,7 @@ Gyre is a modern, full-featured WebUI for FluxCD built with SvelteKit. It provid
 
 **DevContainer (Recommended):**
 
-If using a local devcontainer setup, ensure it installs pnpm 11.1.0 and Bun 1.3.11 for tests.
+If using a local devcontainer setup, ensure it installs Node.js and pnpm 11.1.0.
 
 1. Open repository in VS Code with Dev Containers extension
 2. Press `F1` → "Dev Containers: Reopen in Container"
@@ -193,7 +193,7 @@ Multi-cluster support is implemented via `locals.cluster`.
 
 - **Commits**: Follow [Conventional Commits](https://www.conventionalcommits.org/).
 - **Branches**: Use `type/description` naming (e.g., `feat/add-oidc-support`, `fix/rbac-bypass`).
-- **Tests**: Automated tests are part of the normal verification flow (`pnpm test`, `pnpm verify:ci`, `pnpm verify:repo:ci`). Tests still use Bun for now (`pnpm test` runs `bun test`) until the follow-up runtime/test migration is completed.
+- **Tests**: Automated tests run through Vitest on Node.js and are part of the normal verification flow (`pnpm test`, `pnpm verify:ci`, `pnpm verify:repo:ci`).
 
 ## Important Implementation Notes
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -71,7 +71,7 @@ Then open http://localhost:3000 in your browser.
 ## 🛠️ Tech Stack
 
 - **Package Manager:** [pnpm](https://pnpm.io) 11.1.0
-- **Test Runtime:** [Bun](https://bun.sh) 1.3.11
+- **Test Runner:** [Vitest](https://vitest.dev) on Node.js
 - **Framework:** [Svelte 5](https://svelte.dev) + SvelteKit
 - **Styling:** TailwindCSS v4 + shadcn-svelte
 - **Database:** SQLite with [Drizzle ORM](https://orm.drizzle.team)

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -27,6 +27,8 @@
 		"@docusaurus/module-type-aliases": "3.10.1",
 		"@docusaurus/tsconfig": "3.10.1",
 		"@docusaurus/types": "3.10.1",
+		"@types/react": "^19.2.14",
+		"@types/react-dom": "^19.2.3",
 		"typescript": "~6.0.3"
 	},
 	"browserslist": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 		"scripts:check": "find scripts -type f -name '*.sh' -exec bash -n {} +",
 		"verify:repo": "pnpm verify && pnpm helm:check && pnpm scripts:check",
 		"verify:repo:ci": "pnpm verify:ci && pnpm docs:check && pnpm helm:check && pnpm scripts:check",
-		"test": "bun test",
-		"test:watch": "bun test --watch"
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"@asteasolutions/zod-to-openapi": "^8.4.1",
@@ -54,6 +54,7 @@
 	},
 	"devDependencies": {
 		"@internationalized/date": "^3.10.1",
+		"@opentelemetry/api": "1.9.1",
 		"@sveltejs/adapter-node": "^5.5.4",
 		"@sveltejs/kit": "^2.57.1",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
@@ -61,7 +62,6 @@
 		"@tailwindcss/vite": "^4.1.18",
 		"@types/bcryptjs": "^3.0.0",
 		"@types/better-sqlite3": "^7.6.13",
-		"@types/bun": "^1.3.9",
 		"@types/js-cookie": "^3.0.6",
 		"@types/js-yaml": "^4.0.9",
 		"@types/node": "^25.2.1",
@@ -74,7 +74,8 @@
 		"tailwind-variants": "^3.2.2",
 		"tailwindcss": "^4.1.18",
 		"typescript": "^6.0.2",
-		"vite": "^8.0.8"
+		"vite": "^8.0.8",
+		"vitest": "4.1.6"
 	},
 	"overrides": {
 		"cookie": "0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: ^1.6.5
-        version: 1.6.10(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.13)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.5)(vue@3.5.34(typescript@6.0.3))
+        version: 1.6.10(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.5)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(vue@3.5.34(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.9.0
@@ -37,7 +37,7 @@ importers:
         version: 4.1.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.13)(kysely@0.28.17)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(kysely@0.28.17)
       fuse.js:
         specifier: ^7.1.0
         version: 7.3.0
@@ -90,6 +90,9 @@ importers:
       '@internationalized/date':
         specifier: ^3.10.1
         version: 3.12.1
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
       '@sveltejs/adapter-node':
         specifier: ^5.5.4
         version: 5.5.4(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))
@@ -111,9 +114,6 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
-      '@types/bun':
-        specifier: ^1.3.9
-        version: 1.3.13
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
@@ -153,6 +153,9 @@ importers:
       vite:
         specifier: ^8.0.8
         version: 8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
 
   documentation:
     dependencies:
@@ -187,6 +190,12 @@ importers:
       '@docusaurus/types':
         specifier: 3.10.1
         version: 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -3221,8 +3230,8 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
-  '@types/bun@1.3.13':
-    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
@@ -3235,6 +3244,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -3335,6 +3347,11 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react-router-config@5.0.11':
     resolution: {integrity: sha512-WmSAg7WgqW7m4x8Mt4N6ZyKz0BubSj/2tVUMsAHp+Yd2AMwcSbeFq9WympT19p5heCFmF97R9eD5uUR/t4HEqw==}
 
@@ -3412,6 +3429,35 @@ packages:
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
+
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@vue-macros/common@3.1.2':
     resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
@@ -3713,6 +3759,10 @@ packages:
     resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
     engines: {node: '>=12.0.0'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -3979,9 +4029,6 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bun-types@1.3.13:
-    resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
-
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -4041,6 +4088,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4866,6 +4917,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -5782,6 +5837,7 @@ packages:
 
   lucide-svelte@1.0.1:
     resolution: {integrity: sha512-WvzZgk0pqzgda+AErLvgWxHkfg/+GgUwqKMRHvzt0IqyMdmyEDzDCk3Z+Wo/3y753oIgx8u9Q4eUbWkghFa8Jg==}
+    deprecated: Package deprecated. Please use @lucide/svelte instead.
     peerDependencies:
       svelte: ^3 || ^4 || ^5.0.0-next.42
 
@@ -7347,6 +7403,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -7445,6 +7504,9 @@ packages:
     resolution: {integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==}
     engines: {node: '>=12'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -7455,6 +7517,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-buffers@3.0.3:
     resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
@@ -7723,6 +7788,13 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -7734,6 +7806,10 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -8005,6 +8081,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -8158,6 +8275,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@4.0.1:
@@ -9170,12 +9292,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.13)(kysely@0.28.17))':
+  '@better-auth/drizzle-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(kysely@0.28.17))':
     dependencies:
       '@better-auth/core': 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.13)(kysely@0.28.17)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(kysely@0.28.17)
 
   '@better-auth/kysely-adapter@1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
@@ -12167,9 +12289,10 @@ snapshots:
     dependencies:
       '@types/node': 25.6.2
 
-  '@types/bun@1.3.13':
+  '@types/chai@5.2.3':
     dependencies:
-      bun-types: 1.3.13
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
@@ -12185,6 +12308,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -12287,6 +12412,10 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react-router-config@5.0.11':
     dependencies:
       '@types/history': 4.7.11
@@ -12377,6 +12506,47 @@ snapshots:
       vue: 3.5.34(typescript@6.0.3)
 
   '@vercel/oidc@3.1.0': {}
+
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vue-macros/common@3.1.2(vue@3.5.34(typescript@6.0.3))':
     dependencies:
@@ -12715,6 +12885,8 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.3
@@ -12831,10 +13003,10 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
-  better-auth@1.6.10(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.13)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.5)(vue@3.5.34(typescript@6.0.3)):
+  better-auth@1.6.10(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(kysely@0.28.17))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.5)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.13)(kysely@0.28.17))
+      '@better-auth/drizzle-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(kysely@0.28.17))
       '@better-auth/kysely-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.10(@better-auth/core@1.6.10(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -12854,10 +13026,11 @@ snapshots:
       '@sveltejs/kit': 2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       better-sqlite3: 12.9.0
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.13)(kysely@0.28.17)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(kysely@0.28.17)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       svelte: 5.55.5
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       vue: 3.5.34(typescript@6.0.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -12978,10 +13151,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bun-types@1.3.13:
-    dependencies:
-      '@types/node': 25.6.2
-
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -13042,6 +13211,8 @@ snapshots:
   caniuse-lite@1.0.30001792: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -13550,12 +13721,11 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(bun-types@1.3.13)(kysely@0.28.17):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)(kysely@0.28.17):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.9.0
-      bun-types: 1.3.13
       kysely: 0.28.17
 
   dunder-proto@1.0.1:
@@ -13825,6 +13995,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   express@4.22.1:
     dependencies:
@@ -16907,6 +17079,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-concat@1.0.1: {}
@@ -17018,11 +17192,15 @@ snapshots:
 
   srcset@4.0.0: {}
 
+  stackback@0.0.2: {}
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.1.0: {}
 
   stream-buffers@3.0.3: {}
 
@@ -17318,6 +17496,10 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -17326,6 +17508,8 @@ snapshots:
   tinypool@1.1.1: {}
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -17566,6 +17750,34 @@ snapshots:
     optionalDependencies:
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.6.2
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -17788,6 +18000,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@4.0.1:
     dependencies:

--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -9,43 +9,50 @@ export function withRequestContext<T>(requestId: string, fn: () => T): T {
 
 const level = process.env.LOG_LEVEL ?? (process.env.NODE_ENV === 'production' ? 'info' : 'debug');
 
-const pinoLogger = pino({
-	level,
-	base: undefined, // Removes pid and hostname fields, which are redundant in containerized environments like Kubernetes
-	timestamp: pino.stdTimeFunctions.isoTime,
-	redact: {
-		paths: [
-			'password',
-			'ADMIN_PASSWORD',
-			'token',
-			'secret',
-			'authorization',
-			'cookie',
-			'email',
-			'apiKey',
-			'bearer',
-			'accessToken',
-			'refreshToken',
-			'clientSecret',
-			'credential',
-			'err.config.data',
-			'req.headers.authorization',
-			'*.password',
-			'*.token',
-			'*.secret',
-			'*.apiKey',
-			'*.bearer',
-			'*.accessToken',
-			'*.refreshToken',
-			'*.clientSecret',
-			'*.authorization',
-			'*.cookie',
-			'*.email',
-			'*.credential'
-		],
-		censor: '[REDACTED]'
+const pinoLogger = pino(
+	{
+		level,
+		base: undefined, // Removes pid and hostname fields, which are redundant in containerized environments like Kubernetes
+		timestamp: pino.stdTimeFunctions.isoTime,
+		redact: {
+			paths: [
+				'password',
+				'ADMIN_PASSWORD',
+				'token',
+				'secret',
+				'authorization',
+				'cookie',
+				'email',
+				'apiKey',
+				'bearer',
+				'accessToken',
+				'refreshToken',
+				'clientSecret',
+				'credential',
+				'err.config.data',
+				'req.headers.authorization',
+				'*.password',
+				'*.token',
+				'*.secret',
+				'*.apiKey',
+				'*.bearer',
+				'*.accessToken',
+				'*.refreshToken',
+				'*.clientSecret',
+				'*.authorization',
+				'*.cookie',
+				'*.email',
+				'*.credential'
+			],
+			censor: '[REDACTED]'
+		}
+	},
+	{
+		write: (message) => {
+			process.stdout.write(message);
+		}
 	}
-});
+);
 
 function sanitizeLogMessage(msg: string): string {
 	// eslint-disable-next-line no-control-regex

--- a/src/tests/action-feedback.test.ts
+++ b/src/tests/action-feedback.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { resolveResourceActionFeedback } from '../lib/components/flux/action-feedback.js';
 
 describe('resolveResourceActionFeedback', () => {

--- a/src/tests/admin-auth-providers-guard.test.ts
+++ b/src/tests/admin-auth-providers-guard.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { User } from '../lib/server/db/schema.js';
 import { importFresh } from './helpers/import-fresh';
 import { createRbacModuleStub } from './helpers/module-stubs';
@@ -32,7 +32,7 @@ function createUser(role: User['role'] = 'editor'): User {
 beforeEach(async () => {
 	permissionChecks.length = 0;
 
-	mock.module('$lib/server/rbac.js', () =>
+	vi.doMock('$lib/server/rbac.js', () =>
 		createRbacModuleStub({
 			checkPermission: async (...args: unknown[]) => {
 				permissionChecks.push(args);
@@ -49,7 +49,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('admin auth providers explicit in-handler guard', () => {

--- a/src/tests/admin-navigation.test.ts
+++ b/src/tests/admin-navigation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { ADMIN_HOME_FEATURES, getAdminSidebarLinks } from '../lib/navigation/admin.js';
 
 describe('getAdminSidebarLinks', () => {

--- a/src/tests/admin-password-hardening.test.ts
+++ b/src/tests/admin-password-hardening.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import {
 	generateStrongPassword,
 	validateAdminPasswordStrength

--- a/src/tests/admin-readiness.test.ts
+++ b/src/tests/admin-readiness.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { buildAdminReadinessSummary } from '../lib/server/admin-readiness';
 import type { AdminReadinessState } from '../lib/server/admin-readiness';
 

--- a/src/tests/admin-security-audit-events.test.ts
+++ b/src/tests/admin-security-audit-events.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { User } from '../lib/server/db/schema.js';
 import * as actualKubernetesClient from '../lib/server/kubernetes/client.js';
 import { importFresh } from './helpers/import-fresh';
@@ -79,20 +79,20 @@ beforeEach(async () => {
 		logLogout: async () => {},
 		logResourceWrite: async () => {}
 	};
-	mock.module('$lib/server/audit', () => auditModuleStub);
-	mock.module('$lib/server/audit.js', () => auditModuleStub);
+	vi.doMock('$lib/server/audit', () => auditModuleStub);
+	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
 
 	const rbacModuleStub = createRbacModuleStub({
 		checkPermission: async () => permissionAllowed
 	});
-	mock.module('$lib/server/rbac.js', () => rbacModuleStub);
-	mock.module('$lib/server/rbac', () => rbacModuleStub);
+	vi.doMock('$lib/server/rbac.js', () => rbacModuleStub);
+	vi.doMock('$lib/server/rbac', () => rbacModuleStub);
 
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
 
-	mock.module('$lib/server/db', () => ({
+	vi.doMock('$lib/server/db', () => ({
 		getDb: async () => ({
 			query: {
 				authProviders: {
@@ -144,7 +144,7 @@ beforeEach(async () => {
 		})
 	}));
 
-	mock.module('$lib/auth/role-mapping', () => ({
+	vi.doMock('$lib/auth/role-mapping', () => ({
 		parseRoleMappingInput: (input: unknown) => {
 			if (!input) return null;
 			if (typeof input === 'object') return input;
@@ -152,7 +152,7 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('$lib/server/auth/role-mapping', () => ({
+	vi.doMock('$lib/server/auth/role-mapping', () => ({
 		parseRoleMappingSafe: (value: unknown) => {
 			if (!value) return null;
 			if (typeof value === 'string') {
@@ -166,13 +166,13 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('$lib/server/auth/oauth', () => ({
+	vi.doMock('$lib/server/auth/oauth', () => ({
 		validateProviderConfig: () => ({ valid: true, errors: [] })
 	}));
 
-	mock.module('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
+	vi.doMock('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
 
-	mock.module('$lib/server/settings', () =>
+	vi.doMock('$lib/server/settings', () =>
 		createSettingsModuleStub({
 			setSetting: async (key: string, value: string) => {
 				settingWrites.push([key, value]);
@@ -190,7 +190,7 @@ beforeEach(async () => {
 		})
 	);
 
-	mock.module('$lib/server/kubernetes/client.js', () => ({
+	vi.doMock('$lib/server/kubernetes/client.js', () => ({
 		...actualKubernetesClient,
 		clearClientPool: () => {
 			clearPoolCalls += 1;
@@ -216,7 +216,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('admin mutation audit events', () => {

--- a/src/tests/app-smoke.test.ts
+++ b/src/tests/app-smoke.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { afterAll, beforeAll, expect, test } from 'vitest';
 import {
 	getRuntimeAdminPassword,
 	getRuntimeApp,

--- a/src/tests/audit-cleanup.test.ts
+++ b/src/tests/audit-cleanup.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 
-spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
 
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../lib/server/db/schema.js';
 import { appSettings, auditLogs } from '../lib/server/db/schema.js';
 
@@ -105,7 +105,7 @@ function setRetentionDays(db: TestDb, value: string) {
 }
 
 beforeEach(async () => {
-	mock.module('../lib/server/db/index.js', () => ({
+	vi.doMock('../lib/server/db/index.js', () => ({
 		getDb: async () => state.db,
 		getDbSync: () => state.db,
 		schema
@@ -119,7 +119,8 @@ beforeEach(async () => {
 afterEach(() => {
 	stopAuditLogCleanup();
 	state.db = null;
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 // ---------------------------------------------------------------------------
@@ -215,7 +216,7 @@ describe('Audit Log Scheduler', () => {
 	});
 
 	test('scheduleAuditLogCleanup sets up timeouts', () => {
-		const setTimeoutSpy = spyOn(global, 'setTimeout');
+		const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
 
 		scheduleAuditLogCleanup();
 
@@ -226,8 +227,8 @@ describe('Audit Log Scheduler', () => {
 	});
 
 	test('stopAuditLogCleanup clears timeouts', () => {
-		const clearTimeoutSpy = spyOn(global, 'clearTimeout');
-		const clearIntervalSpy = spyOn(global, 'clearInterval');
+		const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+		const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
 
 		scheduleAuditLogCleanup();
 		stopAuditLogCleanup();

--- a/src/tests/audit-redaction.test.ts
+++ b/src/tests/audit-redaction.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'vitest';
 import { redactSensitiveFields } from '../lib/server/audit.js';
 
 describe('redactSensitiveFields', () => {

--- a/src/tests/auth-seed-providers.test.ts
+++ b/src/tests/auth-seed-providers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 import { createAuthCryptoModuleStub, createLoggerModuleStub } from './helpers/module-stubs';
 
@@ -66,8 +66,8 @@ beforeEach(async () => {
 		state.infoLogs.push(message);
 	};
 
-	mock.module('../lib/server/logger.js', () => loggerModuleStub);
-	mock.module('../lib/server/auth/crypto', () =>
+	vi.doMock('../lib/server/logger.js', () => loggerModuleStub);
+	vi.doMock('../lib/server/auth/crypto', () =>
 		createAuthCryptoModuleStub({
 			encryptSecret: (value: string) => {
 				state.encryptInputs.push(value);
@@ -75,10 +75,10 @@ beforeEach(async () => {
 			}
 		})
 	);
-	mock.module('../lib/server/db', () => ({
+	vi.doMock('../lib/server/db', () => ({
 		getDb: async () => buildDbMock()
 	}));
-	mock.module('../lib/server/db/schema', () => ({
+	vi.doMock('../lib/server/db/schema', () => ({
 		authProviders: {}
 	}));
 
@@ -98,7 +98,8 @@ afterEach(() => {
 			originalEnv.GYRE_AUTH_PROVIDER_GITHUB_CLIENT_SECRET;
 	}
 
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('seedAuthProviders', () => {

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'vitest';
 import {
 	generateStrongPassword,
 	hashPassword,

--- a/src/tests/backup-encryption.test.ts
+++ b/src/tests/backup-encryption.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach, spyOn } from 'bun:test';
+import { afterAll, describe, test, expect, afterEach, vi } from 'vitest';
 import crypto from 'node:crypto';
 import * as nodeFs from 'node:fs';
 import {
@@ -12,14 +12,53 @@ import {
 } from '../lib/server/backup';
 
 const KEY_LENGTH = 32;
+const backupFixtureEnv = vi.hoisted(() => {
+	const root = `${process.env.TMPDIR || '/tmp'}/backup-encryption-${process.pid}-${Date.now()}`;
+	const originalBackupDir = process.env.BACKUP_DIR;
+	const originalRuntimeBackupRoot = process.env.GYRE_RUNTIME_BACKUP_ROOT;
+	const originalRuntimeTestMode = process.env.GYRE_RUNTIME_TEST_MODE;
+	process.env.BACKUP_DIR = root;
+	process.env.GYRE_RUNTIME_BACKUP_ROOT = root;
+	process.env.GYRE_RUNTIME_TEST_MODE = '1';
+
+	return { originalBackupDir, originalRuntimeBackupRoot, originalRuntimeTestMode, root };
+});
+
+let backupFilenameSequence = 0;
 
 function makeKey(): Buffer {
 	return crypto.randomBytes(KEY_LENGTH);
 }
 
+function makeBackupFilename(extension: '.db' | '.db.enc'): string {
+	const timestamp = new Date(Date.now() + backupFilenameSequence++)
+		.toISOString()
+		.replace(/[:.]/g, '-');
+	return `gyre-backup-${timestamp}${extension}`;
+}
+
 describe('Backup Encryption Module', () => {
 	const originalEnv = process.env.BACKUP_ENCRYPTION_KEY;
 	const originalNodeEnv = process.env.NODE_ENV;
+
+	afterAll(() => {
+		if (backupFixtureEnv.originalBackupDir !== undefined) {
+			process.env.BACKUP_DIR = backupFixtureEnv.originalBackupDir;
+		} else {
+			delete process.env.BACKUP_DIR;
+		}
+		if (backupFixtureEnv.originalRuntimeBackupRoot !== undefined) {
+			process.env.GYRE_RUNTIME_BACKUP_ROOT = backupFixtureEnv.originalRuntimeBackupRoot;
+		} else {
+			delete process.env.GYRE_RUNTIME_BACKUP_ROOT;
+		}
+		if (backupFixtureEnv.originalRuntimeTestMode !== undefined) {
+			process.env.GYRE_RUNTIME_TEST_MODE = backupFixtureEnv.originalRuntimeTestMode;
+		} else {
+			delete process.env.GYRE_RUNTIME_TEST_MODE;
+		}
+		nodeFs.rmSync(backupFixtureEnv.root, { force: true, recursive: true });
+	});
 
 	afterEach(() => {
 		if (originalEnv !== undefined) {
@@ -168,45 +207,39 @@ describe('Backup Encryption Module', () => {
 
 	describe('getDecryptedBackupBuffer', () => {
 		const validKeyHex = 'b'.repeat(64);
-		const encFilename = 'gyre-backup-2024-01-01T00-00-00-000Z.db.enc';
 
 		test('decrypts an encrypted .db.enc file and returns the original plaintext', () => {
 			process.env.BACKUP_ENCRYPTION_KEY = validKeyHex;
+			const encFilename = makeBackupFilename('.db.enc');
 
 			const plaintext = Buffer.from('fake SQLite payload for testing');
 			const keyBuf = Buffer.from(validKeyHex, 'hex');
 			const encrypted = _encryptBackup(plaintext, keyBuf);
 
-			// Mock existsSync to say the file exists, and readFileSync to return the encrypted buffer
-			const existsSpy = spyOn(nodeFs, 'existsSync').mockReturnValue(true);
-			const readSpy = spyOn(nodeFs, 'readFileSync').mockImplementation(
-				() => encrypted as unknown as never
-			);
+			nodeFs.mkdirSync(backupFixtureEnv.root, { recursive: true });
+			nodeFs.writeFileSync(`${backupFixtureEnv.root}/${encFilename}`, encrypted);
 
 			try {
 				const result = getDecryptedBackupBuffer(encFilename);
 				expect(result).not.toBeNull();
 				expect(result).toEqual(plaintext);
 			} finally {
-				existsSpy.mockRestore();
-				readSpy.mockRestore();
+				nodeFs.rmSync(`${backupFixtureEnv.root}/${encFilename}`, { force: true });
 				delete process.env.BACKUP_ENCRYPTION_KEY;
 			}
 		});
 
 		test('throws BackupError when BACKUP_ENCRYPTION_KEY is unset for a .db.enc file', () => {
 			delete process.env.BACKUP_ENCRYPTION_KEY;
+			const encFilename = makeBackupFilename('.db.enc');
 
-			const existsSpy = spyOn(nodeFs, 'existsSync').mockReturnValue(true);
-			const readSpy = spyOn(nodeFs, 'readFileSync').mockImplementation(
-				() => Buffer.alloc(64) as unknown as never
-			);
+			nodeFs.mkdirSync(backupFixtureEnv.root, { recursive: true });
+			nodeFs.writeFileSync(`${backupFixtureEnv.root}/${encFilename}`, Buffer.alloc(64));
 
 			try {
 				expect(() => getDecryptedBackupBuffer(encFilename)).toThrow(BackupError);
 			} finally {
-				existsSpy.mockRestore();
-				readSpy.mockRestore();
+				nodeFs.rmSync(`${backupFixtureEnv.root}/${encFilename}`, { force: true });
 			}
 		});
 	});

--- a/src/tests/backup-routes.test.ts
+++ b/src/tests/backup-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as actualFs from 'node:fs';
 import { Readable } from 'node:stream';
 import * as actualRequestLimits from '../lib/server/request-limits.js';
@@ -122,9 +122,9 @@ beforeEach(async () => {
 	restoreCalls.length = 0;
 	auditCalls.length = 0;
 
-	mock.module('$lib/server/logger.js', () => createLoggerModuleStub());
-	mock.module('$lib/server/rbac', () => createRbacModuleStub());
-	mock.module('$lib/server/rate-limiter.js', () => createRateLimiterModuleStub());
+	vi.doMock('$lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('$lib/server/rbac', () => createRbacModuleStub());
+	vi.doMock('$lib/server/rate-limiter.js', () => createRateLimiterModuleStub());
 	const auditModuleStub = {
 		logAudit: async (_user: unknown, action: string, details: { resourceName?: string } = {}) => {
 			if (auditError) {
@@ -135,12 +135,12 @@ beforeEach(async () => {
 		logLogin: async () => {},
 		logLogout: async () => {}
 	};
-	mock.module('$lib/server/audit', () => auditModuleStub);
-	mock.module('$lib/server/audit.js', () => auditModuleStub);
+	vi.doMock('$lib/server/audit', () => auditModuleStub);
+	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
 	const requestLimitsModuleStub = createRequestLimitsModuleStub();
-	mock.module('$lib/server/request-limits', () => requestLimitsModuleStub);
-	mock.module('$lib/server/request-limits.js', () => requestLimitsModuleStub);
-	mock.module('$lib/server/backup', () => ({
+	vi.doMock('$lib/server/request-limits', () => requestLimitsModuleStub);
+	vi.doMock('$lib/server/request-limits.js', () => requestLimitsModuleStub);
+	vi.doMock('$lib/server/backup', () => ({
 		BACKUP_FILENAME_RE,
 		BackupError: StubBackupError,
 		getBackupPath: (filename: string) => {
@@ -172,7 +172,7 @@ beforeEach(async () => {
 			return restoreResult;
 		}
 	}));
-	mock.module('node:fs', () => ({
+	vi.doMock('node:fs', () => ({
 		...actualFs,
 		createReadStream: () => Readable.from([plainDownloadBody]),
 		statSync: () => ({ size: plainDownloadBody.byteLength })
@@ -187,7 +187,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('backup route behavior', () => {

--- a/src/tests/batch-operation.test.ts
+++ b/src/tests/batch-operation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 import { createRateLimiterModuleStub, createRbacModuleStub } from './helpers/module-stubs';
 
@@ -18,10 +18,10 @@ beforeEach(async () => {
 	reconciledNames.length = 0;
 
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rbac', () => createRbacModuleStub());
-	mock.module('$lib/server/rbac.js', () => createRbacModuleStub());
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rbac', () => createRbacModuleStub());
+	vi.doMock('$lib/server/rbac.js', () => createRbacModuleStub());
 	const auditModuleStub = {
 		logAudit: async () => {
 			throw new Error('audit unavailable');
@@ -29,8 +29,8 @@ beforeEach(async () => {
 		logLogin: async () => {},
 		logLogout: async () => {}
 	};
-	mock.module('$lib/server/audit', () => auditModuleStub);
-	mock.module('$lib/server/audit.js', () => auditModuleStub);
+	vi.doMock('$lib/server/audit', () => auditModuleStub);
+	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
 	const kubernetesClientModuleStub = {
 		deleteFluxResourcesBatch: async () => {},
 		getCustomObjectsApi: async () => ({
@@ -44,9 +44,9 @@ beforeEach(async () => {
 		}),
 		handleK8sError: (err: unknown) => err
 	};
-	mock.module('$lib/server/kubernetes/client', () => kubernetesClientModuleStub);
-	mock.module('$lib/server/kubernetes/client.js', () => kubernetesClientModuleStub);
-	mock.module('$lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
+	vi.doMock('$lib/server/kubernetes/client', () => kubernetesClientModuleStub);
+	vi.doMock('$lib/server/kubernetes/client.js', () => kubernetesClientModuleStub);
+	vi.doMock('$lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
 		captureReconciliation: async () => {}
 	}));
 	const resourcesModuleStub = {
@@ -64,8 +64,8 @@ beforeEach(async () => {
 				? 'Kustomization'
 				: undefined
 	};
-	mock.module('$lib/server/kubernetes/flux/resources', () => resourcesModuleStub);
-	mock.module('$lib/server/kubernetes/flux/resources.js', () => resourcesModuleStub);
+	vi.doMock('$lib/server/kubernetes/flux/resources', () => resourcesModuleStub);
+	vi.doMock('$lib/server/kubernetes/flux/resources.js', () => resourcesModuleStub);
 
 	runBatchFluxOperation = (
 		await importFresh<BatchOperationModule>('../lib/server/flux/use-cases/batch-operation.js')
@@ -73,7 +73,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('batch Flux operation auditing', () => {

--- a/src/tests/bulk-actions.test.ts
+++ b/src/tests/bulk-actions.test.ts
@@ -1,9 +1,9 @@
-import { afterAll, describe, expect, mock, test } from 'bun:test';
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import type { FluxResource } from '../lib/types/flux.js';
 import type { BatchOperationResponse } from '../lib/components/flux/bulk-actions.js';
 
-mock.module('$app/environment', () => ({ dev: false }));
-mock.module('$env/dynamic/public', () => ({ env: {} }));
+vi.mock('$app/environment', () => ({ dev: false }));
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
 
 const { buildRetryPayload, partitionBatchOperationResult } =
 	await import('../lib/components/flux/bulk-actions.js');
@@ -178,5 +178,6 @@ describe('partitionBatchOperationResult', () => {
 });
 
 afterAll(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });

--- a/src/tests/change-password-route.test.ts
+++ b/src/tests/change-password-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { INVALID_SPAN_CONTEXT, trace } from '@opentelemetry/api';
 import type { Cookies } from '@sveltejs/kit';
 import type { User } from '../lib/server/db/schema.js';
@@ -91,7 +91,7 @@ function buildEvent(): ChangePasswordEvent {
 beforeEach(async () => {
 	Object.assign(authState, createAuthState());
 
-	mock.module('$lib/server/auth', () => ({
+	vi.doMock('$lib/server/auth', () => ({
 		SESSION_DURATION_DAYS: 30,
 		addPasswordHistory: async () => {},
 		authenticateUser: async () => null,
@@ -132,16 +132,16 @@ beforeEach(async () => {
 		revokeBetterAuthSessionByCookieValue: async () => {}
 	};
 
-	mock.module('$lib/server/auth/better-auth', () => betterAuthModuleStub);
-	mock.module('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
 
-	mock.module('$lib/server/logger.js', () => createLoggerModuleStub());
-	mock.module('$lib/server/audit', () => ({
+	vi.doMock('$lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('$lib/server/audit', () => ({
 		logAudit: async () => {}
 	}));
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
 
 	POST = (
 		await importFresh<ChangePasswordRouteModule>('../routes/api/v1/auth/change-password/+server.js')
@@ -149,7 +149,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('change-password route credential handling', () => {

--- a/src/tests/cluster-selection-route.test.ts
+++ b/src/tests/cluster-selection-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { IN_CLUSTER_ID } from '../lib/clusters/identity.js';
 import { importFresh } from './helpers/import-fresh';
 
@@ -45,7 +45,7 @@ beforeEach(() => {
 	};
 	localContextNames = [];
 	defaultLocalContext = null;
-	mock.module('$lib/server/clusters/repository.js', () => ({
+	vi.doMock('$lib/server/clusters/repository.js', () => ({
 		getClusterById: async () => clusterRecord,
 		getSelectableClusters: async () => [
 			...(localContextNames.length > 0
@@ -81,7 +81,7 @@ beforeEach(() => {
 				: [])
 		]
 	}));
-	mock.module('$lib/server/clusters/local-kubeconfig.js', () => ({
+	vi.doMock('$lib/server/clusters/local-kubeconfig.js', () => ({
 		getDefaultLocalKubeconfigContext: () => defaultLocalContext,
 		hasLocalKubeconfigContext: (contextName: string) => localContextNames.includes(contextName),
 		shouldUseLocalKubeconfigContexts: () => localContextNames.length > 0
@@ -89,7 +89,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('cluster selection route', () => {

--- a/src/tests/clusters-encryption.test.ts
+++ b/src/tests/clusters-encryption.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../lib/server/db/schema.js';
 import { clusters } from '../lib/server/db/schema.js';
 import { importFresh } from './helpers/import-fresh';
@@ -54,7 +54,7 @@ function insertCluster(db: TestDb, id: string, kubeconfigEncrypted: string | nul
 const originalKey = process.env.GYRE_ENCRYPTION_KEY;
 
 beforeEach(async () => {
-	mock.module('../lib/server/db/index.js', () => ({
+	vi.doMock('../lib/server/db/index.js', () => ({
 		getDb: async () => state.db,
 		getDbSync: () => state.db,
 		schema
@@ -71,7 +71,8 @@ afterEach(() => {
 	}
 	clustersModule._resetEncryptionKeyCache();
 	state.db = null;
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('Cluster Kubeconfig Encryption', () => {

--- a/src/tests/command-palette.test.ts
+++ b/src/tests/command-palette.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'vitest';
 import { commandPaletteOpen } from '../lib/stores/commandPalette.js';
 
 // Helper: read current store value synchronously via subscribe

--- a/src/tests/config-constants.test.ts
+++ b/src/tests/config-constants.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterEach } from 'vitest';
 import { parseEnvInt } from '../lib/server/config/constants';
 
 const ENV_VAR = 'GYRE_TEST_PARSE_ENV_INT';

--- a/src/tests/crypto.test.ts
+++ b/src/tests/crypto.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 
 type CryptoModule = typeof import('../lib/server/auth/crypto.ts');

--- a/src/tests/csrf.test.ts
+++ b/src/tests/csrf.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'vitest';
 import { generateCsrfToken, validateCsrfToken } from '../lib/server/csrf';
 
 describe('CSRF Protection', () => {

--- a/src/tests/diff-api-error-handling.test.ts
+++ b/src/tests/diff-api-error-handling.test.ts
@@ -7,7 +7,7 @@
  * is always called with the original error.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import { classifyDiffError } from '../lib/server/kubernetes/flux/diff-errors.js';
 
 // ---------------------------------------------------------------------------

--- a/src/tests/events.test.ts
+++ b/src/tests/events.test.ts
@@ -1,13 +1,13 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as actualClient from '../lib/server/kubernetes/client.js';
 import * as actualConstants from '../lib/server/config/constants.js';
 import * as actualMetrics from '../lib/server/metrics.js';
 import { importFresh } from './helpers/import-fresh';
 
 // Suppress console noise - must be before imports
-spyOn(console, 'log').mockImplementation(() => {});
-spyOn(console, 'warn').mockImplementation(() => {});
-spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'warn').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
 
 // Mock listFluxResources to control what resources are returned
 let mockResources: any[] = [];
@@ -19,11 +19,11 @@ let setEventBusShuttingDown: EventsModule['setEventBusShuttingDown'];
 
 beforeEach(async () => {
 	mockResources = [];
-	mock.module('../lib/server/kubernetes/client.js', () => ({
+	vi.doMock('../lib/server/kubernetes/client.js', () => ({
 		...actualClient,
 		listFluxResources: async () => ({ items: mockResources })
 	}));
-	mock.module('../lib/server/metrics.js', () => ({
+	vi.doMock('../lib/server/metrics.js', () => ({
 		...actualMetrics,
 		resourcePollsTotal: { labels: () => ({ inc: () => {} }) },
 		resourceUpdatesTotal: { labels: () => ({ inc: () => {} }) },
@@ -31,16 +31,16 @@ beforeEach(async () => {
 		activeWorkersGauge: { set: () => {} },
 		fluxResourceStatusGauge: { labels: () => ({ set: () => {} }), remove: () => {} }
 	}));
-	mock.module('../lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
+	vi.doMock('../lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
 		captureReconciliation: async () => {}
 	}));
-	mock.module('../lib/server/config/constants.js', () => ({
+	vi.doMock('../lib/server/config/constants.js', () => ({
 		...actualConstants,
 		SETTLING_PERIOD_MS: -1,
 		POLL_INTERVAL_MS: 50,
 		HEARTBEAT_INTERVAL_MS: 10000
 	}));
-	mock.module('../lib/server/logger.js', () => ({
+	vi.doMock('../lib/server/logger.js', () => ({
 		logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
 	}));
 	const eventsModule = await importFresh<EventsModule>('../lib/server/events.js');
@@ -50,7 +50,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/file-upload-security.test.ts
+++ b/src/tests/file-upload-security.test.ts
@@ -4,7 +4,7 @@
  * Covers sanitizeFilename, isAllowedBackupExtension, and the kubeconfig
  * kind/apiVersion check added in GH #286.
  */
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'vitest';
 import {
 	sanitizeFilename,
 	isAllowedBackupExtension,

--- a/src/tests/filtering.test.ts
+++ b/src/tests/filtering.test.ts
@@ -1,7 +1,7 @@
-import { afterAll, describe, expect, mock, test } from 'bun:test';
+import { afterAll, describe, expect, test, vi } from 'vitest';
 
-mock.module('$app/environment', () => ({ dev: false }));
-mock.module('$env/dynamic/public', () => ({ env: {} }));
+vi.mock('$app/environment', () => ({ dev: false }));
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
 
 const { searchParamsToFilters, filtersToSearchParams, parseLabels, defaultFilterState } =
 	await import('../lib/utils/filtering.js');
@@ -69,7 +69,8 @@ describe('searchParamsToFilters', () => {
 });
 
 afterAll(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/flux-action-routes.test.ts
+++ b/src/tests/flux-action-routes.test.ts
@@ -39,6 +39,47 @@ const getResourceDef = (resourceType: string) =>
 
 const getResourceTypeByPlural = (plural: string) => resolveFluxResourceType(plural);
 
+const actionsMock = {
+	deleteResource: async () => {},
+	reconcileResource: async (...args: unknown[]) => {
+		capturedReconcileCalls.push(args);
+		if (args[2] === 'bad') {
+			throw new Error('reconcile failed');
+		}
+	},
+	toggleSuspendResource: async (...args: unknown[]) => {
+		capturedToggleSuspendCalls.push(args);
+	}
+};
+
+const resourcesMock = {
+	resolveFluxResourceType,
+	getResourceDef,
+	getResourceTypeByPlural,
+	getAllResourcePlurals: () => ['kustomizations', 'gitrepositories', 'helmreleases']
+};
+
+const auditModuleStub = {
+	logResourceWrite: async (...args: unknown[]) => {
+		capturedLogWrites.push(args);
+	},
+	logAudit: async (...args: unknown[]) => {
+		capturedAuditCalls.push(args);
+	},
+	logLogin: async () => {},
+	logLogout: async () => {}
+};
+
+const validationMock = {
+	...actualValidation,
+	validateK8sNamespace: () => {},
+	validateK8sName: () => {}
+};
+
+const reconciliationTrackerMock = {
+	captureReconciliation: async () => {}
+};
+
 function createUser(role: User['role'] = 'editor'): User {
 	const now = new Date();
 	return {
@@ -90,76 +131,25 @@ beforeEach(async () => {
 		})
 	);
 
-	vi.doMock('$lib/server/kubernetes/flux/actions', () => ({
-		deleteResource: async () => {},
-		reconcileResource: async (...args: unknown[]) => {
-			capturedReconcileCalls.push(args);
-			if (args[2] === 'bad') {
-				throw new Error('reconcile failed');
-			}
-		},
-		toggleSuspendResource: async (...args: unknown[]) => {
-			capturedToggleSuspendCalls.push(args);
-		}
-	}));
-	vi.doMock('$lib/server/kubernetes/flux/actions.js', () => ({
-		deleteResource: async () => {},
-		reconcileResource: async (...args: unknown[]) => {
-			capturedReconcileCalls.push(args);
-			if (args[2] === 'bad') {
-				throw new Error('reconcile failed');
-			}
-		},
-		toggleSuspendResource: async (...args: unknown[]) => {
-			capturedToggleSuspendCalls.push(args);
-		}
-	}));
+	vi.doMock('$lib/server/kubernetes/flux/actions', () => actionsMock);
+	vi.doMock('$lib/server/kubernetes/flux/actions.js', () => actionsMock);
 
-	vi.doMock('$lib/server/kubernetes/flux/resources', () => ({
-		resolveFluxResourceType,
-		getResourceDef,
-		getResourceTypeByPlural,
-		getAllResourcePlurals: () => ['kustomizations', 'gitrepositories', 'helmreleases']
-	}));
-	vi.doMock('$lib/server/kubernetes/flux/resources.js', () => ({
-		resolveFluxResourceType,
-		getResourceDef,
-		getResourceTypeByPlural,
-		getAllResourcePlurals: () => ['kustomizations', 'gitrepositories', 'helmreleases']
-	}));
+	vi.doMock('$lib/server/kubernetes/flux/resources', () => resourcesMock);
+	vi.doMock('$lib/server/kubernetes/flux/resources.js', () => resourcesMock);
 
-	const auditModuleStub = {
-		logResourceWrite: async (...args: unknown[]) => {
-			capturedLogWrites.push(args);
-		},
-		logAudit: async (...args: unknown[]) => {
-			capturedAuditCalls.push(args);
-		},
-		logLogin: async () => {},
-		logLogout: async () => {}
-	};
 	vi.doMock('$lib/server/audit', () => auditModuleStub);
 	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
 
 	vi.doMock('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
 
-	vi.doMock('$lib/server/validation', () => ({
-		...actualValidation,
-		validateK8sNamespace: () => {},
-		validateK8sName: () => {}
-	}));
-	vi.doMock('$lib/server/validation.js', () => ({
-		...actualValidation,
-		validateK8sNamespace: () => {},
-		validateK8sName: () => {}
-	}));
+	vi.doMock('$lib/server/validation', () => validationMock);
+	vi.doMock('$lib/server/validation.js', () => validationMock);
 
-	vi.doMock('$lib/server/kubernetes/flux/reconciliation-tracker', () => ({
-		captureReconciliation: async () => {}
-	}));
-	vi.doMock('$lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
-		captureReconciliation: async () => {}
-	}));
+	vi.doMock('$lib/server/kubernetes/flux/reconciliation-tracker', () => reconciliationTrackerMock);
+	vi.doMock(
+		'$lib/server/kubernetes/flux/reconciliation-tracker.js',
+		() => reconciliationTrackerMock
+	);
 
 	reconcilePOST = (
 		await importFresh<ReconcileRouteModule>(

--- a/src/tests/flux-action-routes.test.ts
+++ b/src/tests/flux-action-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { User } from '../lib/server/db/schema.js';
 import * as actualValidation from '../lib/server/validation.js';
 import { importFresh } from './helpers/import-fresh';
@@ -81,7 +81,7 @@ beforeEach(async () => {
 	capturedLogWrites.length = 0;
 	capturedAuditCalls.length = 0;
 
-	mock.module('$lib/server/rbac.js', () =>
+	vi.doMock('$lib/server/rbac.js', () =>
 		createRbacModuleStub({
 			checkPermission: async (...args: unknown[]) => {
 				capturedPermissionChecks.push(args);
@@ -90,7 +90,7 @@ beforeEach(async () => {
 		})
 	);
 
-	mock.module('$lib/server/kubernetes/flux/actions', () => ({
+	vi.doMock('$lib/server/kubernetes/flux/actions', () => ({
 		deleteResource: async () => {},
 		reconcileResource: async (...args: unknown[]) => {
 			capturedReconcileCalls.push(args);
@@ -102,7 +102,7 @@ beforeEach(async () => {
 			capturedToggleSuspendCalls.push(args);
 		}
 	}));
-	mock.module('$lib/server/kubernetes/flux/actions.js', () => ({
+	vi.doMock('$lib/server/kubernetes/flux/actions.js', () => ({
 		deleteResource: async () => {},
 		reconcileResource: async (...args: unknown[]) => {
 			capturedReconcileCalls.push(args);
@@ -115,13 +115,13 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('$lib/server/kubernetes/flux/resources', () => ({
+	vi.doMock('$lib/server/kubernetes/flux/resources', () => ({
 		resolveFluxResourceType,
 		getResourceDef,
 		getResourceTypeByPlural,
 		getAllResourcePlurals: () => ['kustomizations', 'gitrepositories', 'helmreleases']
 	}));
-	mock.module('$lib/server/kubernetes/flux/resources.js', () => ({
+	vi.doMock('$lib/server/kubernetes/flux/resources.js', () => ({
 		resolveFluxResourceType,
 		getResourceDef,
 		getResourceTypeByPlural,
@@ -138,26 +138,26 @@ beforeEach(async () => {
 		logLogin: async () => {},
 		logLogout: async () => {}
 	};
-	mock.module('$lib/server/audit', () => auditModuleStub);
-	mock.module('$lib/server/audit.js', () => auditModuleStub);
+	vi.doMock('$lib/server/audit', () => auditModuleStub);
+	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
 
-	mock.module('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
+	vi.doMock('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
 
-	mock.module('$lib/server/validation', () => ({
+	vi.doMock('$lib/server/validation', () => ({
 		...actualValidation,
 		validateK8sNamespace: () => {},
 		validateK8sName: () => {}
 	}));
-	mock.module('$lib/server/validation.js', () => ({
+	vi.doMock('$lib/server/validation.js', () => ({
 		...actualValidation,
 		validateK8sNamespace: () => {},
 		validateK8sName: () => {}
 	}));
 
-	mock.module('$lib/server/kubernetes/flux/reconciliation-tracker', () => ({
+	vi.doMock('$lib/server/kubernetes/flux/reconciliation-tracker', () => ({
 		captureReconciliation: async () => {}
 	}));
-	mock.module('$lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
+	vi.doMock('$lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
 		captureReconciliation: async () => {}
 	}));
 
@@ -179,7 +179,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('Flux action routes normalize plural resource types', () => {

--- a/src/tests/flux-actions.test.ts
+++ b/src/tests/flux-actions.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 
 type FluxActionsModule = typeof import('../lib/server/kubernetes/flux/actions.ts');
 
-spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
 
 let capturedPatchArgs: unknown[] = [];
 let capturedDeleteArgs: unknown[] = [];
@@ -46,7 +46,7 @@ beforeEach(async () => {
 	capturedDeleteArgs = [];
 	apiShouldThrow = false;
 
-	mock.module('../lib/server/kubernetes/client', () => ({
+	vi.doMock('../lib/server/kubernetes/client', () => ({
 		getCustomObjectsApi: async () => mockApi,
 		handleK8sError: (error: unknown, context: string) => {
 			return new Error(
@@ -55,7 +55,7 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('../lib/server/kubernetes/flux/resources', () => ({
+	vi.doMock('../lib/server/kubernetes/flux/resources', () => ({
 		getResourceDef: (resourceType: keyof typeof fluxResourceDefs) => fluxResourceDefs[resourceType],
 		resolveFluxResourceType: (resourceType: string) => {
 			if (resourceType === 'kustomizations') return 'Kustomization';
@@ -67,7 +67,7 @@ beforeEach(async () => {
 			return undefined;
 		}
 	}));
-	mock.module('../lib/server/kubernetes/flux/resources.js', () => ({
+	vi.doMock('../lib/server/kubernetes/flux/resources.js', () => ({
 		getResourceDef: (resourceType: keyof typeof fluxResourceDefs) => fluxResourceDefs[resourceType],
 		resolveFluxResourceType: (resourceType: string) => {
 			if (resourceType === 'kustomizations') return 'Kustomization';
@@ -84,7 +84,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('toggleSuspendResource', () => {

--- a/src/tests/flux-actions.test.ts
+++ b/src/tests/flux-actions.test.ts
@@ -3,8 +3,6 @@ import { importFresh } from './helpers/import-fresh';
 
 type FluxActionsModule = typeof import('../lib/server/kubernetes/flux/actions.ts');
 
-vi.spyOn(console, 'log').mockImplementation(() => {});
-
 let capturedPatchArgs: unknown[] = [];
 let capturedDeleteArgs: unknown[] = [];
 let apiShouldThrow = false;
@@ -28,6 +26,19 @@ const fluxResourceDefs = {
 	}
 } as const;
 
+const fluxResourcesMock = {
+	getResourceDef: (resourceType: keyof typeof fluxResourceDefs) => fluxResourceDefs[resourceType],
+	resolveFluxResourceType: (resourceType: string) => {
+		if (resourceType === 'kustomizations') return 'Kustomization';
+		if (resourceType === 'gitrepositories') return 'GitRepository';
+		if (resourceType === 'helmreleases') return 'HelmRelease';
+		if (resourceType in fluxResourceDefs) {
+			return resourceType as keyof typeof fluxResourceDefs;
+		}
+		return undefined;
+	}
+};
+
 const mockApi = {
 	patchNamespacedCustomObject: async (...args: unknown[]) => {
 		capturedPatchArgs = args;
@@ -45,6 +56,7 @@ beforeEach(async () => {
 	capturedPatchArgs = [];
 	capturedDeleteArgs = [];
 	apiShouldThrow = false;
+	vi.spyOn(console, 'log').mockImplementation(() => {});
 
 	vi.doMock('../lib/server/kubernetes/client', () => ({
 		getCustomObjectsApi: async () => mockApi,
@@ -55,30 +67,8 @@ beforeEach(async () => {
 		}
 	}));
 
-	vi.doMock('../lib/server/kubernetes/flux/resources', () => ({
-		getResourceDef: (resourceType: keyof typeof fluxResourceDefs) => fluxResourceDefs[resourceType],
-		resolveFluxResourceType: (resourceType: string) => {
-			if (resourceType === 'kustomizations') return 'Kustomization';
-			if (resourceType === 'gitrepositories') return 'GitRepository';
-			if (resourceType === 'helmreleases') return 'HelmRelease';
-			if (resourceType in fluxResourceDefs) {
-				return resourceType as keyof typeof fluxResourceDefs;
-			}
-			return undefined;
-		}
-	}));
-	vi.doMock('../lib/server/kubernetes/flux/resources.js', () => ({
-		getResourceDef: (resourceType: keyof typeof fluxResourceDefs) => fluxResourceDefs[resourceType],
-		resolveFluxResourceType: (resourceType: string) => {
-			if (resourceType === 'kustomizations') return 'Kustomization';
-			if (resourceType === 'gitrepositories') return 'GitRepository';
-			if (resourceType === 'helmreleases') return 'HelmRelease';
-			if (resourceType in fluxResourceDefs) {
-				return resourceType as keyof typeof fluxResourceDefs;
-			}
-			return undefined;
-		}
-	}));
+	vi.doMock('../lib/server/kubernetes/flux/resources', () => fluxResourcesMock);
+	vi.doMock('../lib/server/kubernetes/flux/resources.js', () => fluxResourcesMock);
 
 	fluxActions = await importFresh<FluxActionsModule>('../lib/server/kubernetes/flux/actions.ts');
 });

--- a/src/tests/flux-artifact-url-security.test.ts
+++ b/src/tests/flux-artifact-url-security.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'vitest';
 import { validateFluxArtifactUrl } from '../lib/server/kubernetes/flux/artifact-url-security.js';
 
 afterEach(() => {

--- a/src/tests/flux-list-cluster-wide-rbac.test.ts
+++ b/src/tests/flux-list-cluster-wide-rbac.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { User } from '../lib/server/db/schema.js';
 import * as actualClient from '../lib/server/kubernetes/client.js';
 import * as actualValidation from '../lib/server/validation.js';
@@ -40,7 +40,7 @@ beforeEach(async () => {
 	allowClusterWide = true;
 	allowScoped = true;
 
-	mock.module('$lib/server/http/guards.js', () => ({
+	vi.doMock('$lib/server/http/guards.js', () => ({
 		requireAuthenticatedUser: () => {},
 		requireClusterContext: (locals: App.Locals) => locals.cluster ?? 'cluster-a',
 		requireClusterWideRead: async (locals: App.Locals) => {
@@ -62,15 +62,15 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('$lib/server/kubernetes/client.js', () => ({
+	vi.doMock('$lib/server/kubernetes/client.js', () => ({
 		...actualClient,
 		listFluxResources: async () => ({ items: [], total: 0, hasMore: false, offset: 0, limit: 50 }),
 		createFluxResource: async () => ({ ok: true })
 	}));
 
-	mock.module('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
+	vi.doMock('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
 
-	mock.module('$lib/server/validation', () => ({
+	vi.doMock('$lib/server/validation', () => ({
 		...actualValidation,
 		validateK8sNamespace: () => {},
 		validateFluxResourceSpec: () => null
@@ -84,7 +84,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('flux [resourceType] RBAC boundaries', () => {

--- a/src/tests/flux-resources.test.ts
+++ b/src/tests/flux-resources.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'vitest';
 import {
 	getResourceDef,
 	getResourceTypeByPlural,

--- a/src/tests/flux-route-adapters.test.ts
+++ b/src/tests/flux-route-adapters.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 
 let listServiceResult = {
@@ -22,6 +22,7 @@ let detailServiceResult = {
 const guardCalls: string[] = [];
 const serviceCalls: Array<{ name: string; payload: unknown }> = [];
 beforeEach(() => {
+	vi.resetModules();
 	guardCalls.length = 0;
 	serviceCalls.length = 0;
 	listServiceResult = {
@@ -42,7 +43,7 @@ beforeEach(() => {
 		}
 	};
 
-	mock.module('$lib/server/http/guards.js', () => ({
+	vi.doMock('$lib/server/http/guards.js', () => ({
 		requireAuthenticatedUser: () => {
 			guardCalls.push('requireAuthenticatedUser');
 		},
@@ -53,6 +54,8 @@ beforeEach(() => {
 		requireClusterWideRead: async () => {
 			guardCalls.push('requireClusterWideRead');
 		},
+		resolveFluxRouteResourceType: (resourceType: string) =>
+			resourceType === 'gitrepositories' ? 'GitRepository' : resourceType,
 		requireScopedPermission: async (_locals: App.Locals, action: string) => {
 			guardCalls.push(`requireScopedPermission:${action}`);
 		},
@@ -61,7 +64,7 @@ beforeEach(() => {
 		}
 	}));
 
-	mock.module('$lib/server/flux/services.js', () => ({
+	vi.doMock('$lib/server/flux/services.js', () => ({
 		DEFAULT_FLUX_VERSION: 'v2.x.x',
 		getFluxHealthSummary: async () => ({
 			status: 'healthy',
@@ -81,7 +84,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('flux route adapters', () => {

--- a/src/tests/flux-security.test.ts
+++ b/src/tests/flux-security.test.ts
@@ -5,10 +5,11 @@
  * apiVersion/kind mismatch detection, namespace validation, and YAML schema
  * restrictions — without requiring full SvelteKit route infrastructure.
  */
-import { describe, test, expect, mock } from 'bun:test';
+import { describe, test, expect, vi } from 'vitest';
 import yaml from 'js-yaml';
 
-mock.restore();
+vi.restoreAllMocks();
+vi.resetModules();
 
 import {
 	getResourceDef,

--- a/src/tests/flux-server-loads.test.ts
+++ b/src/tests/flux-server-loads.test.ts
@@ -1,11 +1,5 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { IN_CLUSTER_ID } from '../lib/clusters/identity.js';
-import * as actualAdminReadiness from '../lib/server/admin-readiness.js';
-import * as actualDashboardCache from '../lib/server/dashboard-cache.js';
-import * as actualClusters from '../lib/server/clusters.js';
-import * as actualServices from '../lib/server/flux/services.js';
-import * as actualGuards from '../lib/server/http/guards.js';
-import * as actualMetrics from '../lib/server/metrics.js';
 
 let healthResult: unknown = {
 	status: 'healthy',
@@ -101,6 +95,7 @@ function createUser() {
 }
 
 beforeEach(() => {
+	vi.resetModules();
 	healthResult = {
 		status: 'healthy',
 		kubernetes: {
@@ -165,7 +160,7 @@ beforeEach(() => {
 		}
 	] as const;
 
-	mock.module('$lib/server/flux/services.js', () => ({
+	vi.doMock('$lib/server/flux/services.js', () => ({
 		DEFAULT_FLUX_VERSION: 'v2.x.x',
 		getFluxHealthSummary: async () => {
 			if (healthShouldThrow) {
@@ -191,7 +186,7 @@ beforeEach(() => {
 		listFluxResourcesForType: async () => listResult
 	}));
 
-	mock.module('$lib/server/http/guards.js', () => ({
+	vi.doMock('$lib/server/http/guards.js', () => ({
 		requireClusterContext: (locals: App.Locals) => requireClusterContextMock(locals),
 		requireClusterWideRead: async (locals: App.Locals) => {
 			const clusterId = requireClusterContextMock(locals);
@@ -211,7 +206,7 @@ beforeEach(() => {
 		}
 	}));
 
-	mock.module('$lib/server/clusters.js', () => ({
+	vi.doMock('$lib/server/clusters.js', () => ({
 		getSelectableClusters: async (currentContext?: string | null) => {
 			const expectedContext = getExpectedSelectableClustersContext();
 			if (currentContext !== expectedContext) {
@@ -224,7 +219,7 @@ beforeEach(() => {
 		}
 	}));
 
-	mock.module('$lib/server/dashboard-cache', () => ({
+	vi.doMock('$lib/server/dashboard-cache', () => ({
 		getDashboardCache: (key: string) => {
 			getDashboardCacheCalls.push(key);
 			return dashboardCacheEntries.get(key) ?? null;
@@ -239,13 +234,12 @@ beforeEach(() => {
 		}
 	}));
 
-	mock.module('$lib/server/metrics.js', () => ({
-		...actualMetrics,
+	vi.doMock('$lib/server/metrics.js', () => ({
 		loginAttemptsTotal: { labels: () => ({ inc: () => {} }) },
 		sessionsCleanedUpTotal: { inc: () => {} }
 	}));
 
-	mock.module('$lib/server/admin-readiness.js', () => ({
+	vi.doMock('$lib/server/admin-readiness.js', () => ({
 		getAdminReadinessSummary: async () => {
 			adminReadinessCalls.push(true);
 			return adminReadinessResult;
@@ -254,18 +248,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	mock.restore();
-	mock.module('$lib/server/flux/services.js', () => actualServices);
-	mock.module('$lib/server/clusters.js', () => actualClusters);
-	mock.module('$lib/server/http/guards.js', () => actualGuards);
-	mock.module('$lib/server/dashboard-cache', () => actualDashboardCache);
-	mock.module('$lib/server/metrics.js', () => actualMetrics);
-	mock.module('$lib/server/admin-readiness.js', () => actualAdminReadiness);
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('migrated server loads', () => {
 	async function loadDashboardPage(locals: App.Locals, parentClusterId = 'cluster-b') {
-		const { load } = await import(`../routes/+page.server.js?case=${Date.now()}-${Math.random()}`);
+		const { load } = await import('../routes/+page.server.js');
 
 		return await load({
 			locals,
@@ -282,9 +271,7 @@ describe('migrated server loads', () => {
 	}
 
 	test('layout load uses shared services and preserves health/version fallbacks', async () => {
-		const { load } = await import(
-			`../routes/+layout.server.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { load } = await import('../routes/+layout.server.js');
 
 		const success = await load({
 			depends: () => {},
@@ -523,9 +510,7 @@ describe('migrated server loads', () => {
 	});
 
 	test('resource list load calls the shared service and keeps the UI-facing shape', async () => {
-		const { load } = await import(
-			`../routes/resources/[type]/+page.server.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { load } = await import('../routes/resources/[type]/+page.server.js');
 
 		const result = await load({
 			depends: () => {},
@@ -545,9 +530,7 @@ describe('migrated server loads', () => {
 	});
 
 	test('resource detail load calls the shared service and preserves 404/error semantics', async () => {
-		const { load } = await import(
-			`../routes/resources/[type]/[namespace]/[name]/+page.server.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { load } = await import('../routes/resources/[type]/[namespace]/[name]/+page.server.js');
 
 		const result = await load({
 			depends: () => {},
@@ -563,9 +546,8 @@ describe('migrated server loads', () => {
 		});
 
 		detailServiceError = { status: 404, body: { message: 'upstream missing' } };
-		const { load: load404 } = await import(
-			`../routes/resources/[type]/[namespace]/[name]/+page.server.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { load: load404 } =
+			await import('../routes/resources/[type]/[namespace]/[name]/+page.server.js');
 		await expect(
 			load404({
 				depends: () => {},
@@ -583,9 +565,8 @@ describe('migrated server loads', () => {
 		});
 
 		detailServiceError = { status: 500, body: { message: 'service exploded' } };
-		const { load: load500 } = await import(
-			`../routes/resources/[type]/[namespace]/[name]/+page.server.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { load: load500 } =
+			await import('../routes/resources/[type]/[namespace]/[name]/+page.server.js');
 		await expect(
 			load500({
 				depends: () => {},

--- a/src/tests/flux-services.test.ts
+++ b/src/tests/flux-services.test.ts
@@ -1,9 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import * as actualClient from '../lib/server/kubernetes/client.js';
-import * as actualK8sConfig from '../lib/server/kubernetes/config.js';
-import * as actualK8sErrors from '../lib/server/kubernetes/errors.js';
-import * as actualResources from '../lib/server/kubernetes/flux/resources.js';
-import * as actualLogger from '../lib/server/logger.js';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createKubernetesErrorsModuleStub } from './helpers/module-stubs';
 
 let validateKubeConfigResult = true;
@@ -34,6 +29,7 @@ let getFluxResourceStatusImpl = async () => ({
 });
 
 beforeEach(() => {
+	vi.resetModules();
 	validateKubeConfigResult = true;
 	listDeploymentsImpl = async () => ({
 		items: [
@@ -76,11 +72,11 @@ beforeEach(() => {
 		status: { observedGeneration: 1 }
 	});
 
-	mock.module('$lib/server/kubernetes/config.js', () => ({
+	vi.doMock('$lib/server/kubernetes/config.js', () => ({
 		validateKubeConfig: async () => validateKubeConfigResult
 	}));
 
-	mock.module('$lib/server/kubernetes/client.js', () => ({
+	vi.doMock('$lib/server/kubernetes/client.js', () => ({
 		getFluxResource: (...args: unknown[]) => getFluxResourceImpl(...args),
 		getFluxResourceStatus: (...args: unknown[]) => getFluxResourceStatusImpl(...args),
 		getKubeConfig: async () => ({
@@ -107,9 +103,9 @@ beforeEach(() => {
 		listFluxResources: (...args: unknown[]) => listFluxResourcesImpl(...args)
 	}));
 
-	mock.module('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
+	vi.doMock('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
 
-	mock.module('$lib/server/kubernetes/flux/resources.js', () => ({
+	vi.doMock('$lib/server/kubernetes/flux/resources.js', () => ({
 		getAllResourcePlurals: () => ['gitrepositories'],
 		getAllResourceTypes: () => ['GitRepository', 'Kustomization'],
 		resolveFluxResourceType: (resourceType: string) =>
@@ -118,7 +114,7 @@ beforeEach(() => {
 				: undefined
 	}));
 
-	mock.module('$lib/server/logger.js', () => ({
+	vi.doMock('$lib/server/logger.js', () => ({
 		logger: {
 			error: () => {},
 			warn: () => {}
@@ -127,19 +123,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	mock.restore();
-	mock.module('$lib/server/kubernetes/config.js', () => actualK8sConfig);
-	mock.module('$lib/server/kubernetes/client.js', () => actualClient);
-	mock.module('$lib/server/kubernetes/errors.js', () => actualK8sErrors);
-	mock.module('$lib/server/kubernetes/flux/resources.js', () => actualResources);
-	mock.module('$lib/server/logger.js', () => actualLogger);
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('flux shared services', () => {
 	test('returns basic health for unauthenticated callers when details are not requested', async () => {
-		const { getFluxHealthSummary } = await import(
-			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { getFluxHealthSummary } = await import('$lib/server/flux/services.js');
 
 		await expect(
 			getFluxHealthSummary({
@@ -150,9 +140,7 @@ describe('flux shared services', () => {
 	});
 
 	test('returns detailed health metadata when requested', async () => {
-		const { getFluxHealthSummary } = await import(
-			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { getFluxHealthSummary } = await import('$lib/server/flux/services.js');
 
 		const result = await getFluxHealthSummary({
 			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
@@ -181,9 +169,8 @@ describe('flux shared services', () => {
 		listDeploymentsImpl = async () => {
 			throw Object.assign(new Error('not found'), { code: 404 });
 		};
-		const { getFluxInstalledVersion, DEFAULT_FLUX_VERSION } = await import(
-			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { getFluxInstalledVersion, DEFAULT_FLUX_VERSION } =
+			await import('$lib/server/flux/services.js');
 
 		await expect(
 			getFluxInstalledVersion({
@@ -196,9 +183,7 @@ describe('flux shared services', () => {
 		listDeploymentsImpl = async () => {
 			throw new Error('boom');
 		};
-		const { getFluxInstalledVersion } = await import(
-			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { getFluxInstalledVersion } = await import('$lib/server/flux/services.js');
 
 		await expect(
 			getFluxInstalledVersion({
@@ -208,9 +193,7 @@ describe('flux shared services', () => {
 	});
 
 	test('reports partial overview failures while keeping successful summaries', async () => {
-		const { getFluxOverviewSummary } = await import(
-			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { getFluxOverviewSummary } = await import('$lib/server/flux/services.js');
 
 		const result = await getFluxOverviewSummary({
 			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null }
@@ -237,9 +220,7 @@ describe('flux shared services', () => {
 			offset: 0,
 			total: 1
 		});
-		const { listFluxResourcesForType } = await import(
-			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { listFluxResourcesForType } = await import('$lib/server/flux/services.js');
 
 		const result = await listFluxResourcesForType({
 			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
@@ -261,9 +242,7 @@ describe('flux shared services', () => {
 	});
 
 	test('returns detail data for status-only lookups and preserves resourceVersion', async () => {
-		const { getFluxResourceDetail } = await import(
-			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { getFluxResourceDetail } = await import('$lib/server/flux/services.js');
 
 		const result = await getFluxResourceDetail({
 			locals: { cluster: 'cluster-a', requestId: 'req-1', session: null, user: null },
@@ -289,9 +268,7 @@ describe('flux shared services', () => {
 				body: { message: 'GitRepository not found: flux-system/demo' }
 			};
 		};
-		const { getFluxResourceDetail } = await import(
-			`../lib/server/flux/services.js?case=${Date.now()}-${Math.random()}`
-		);
+		const { getFluxResourceDetail } = await import('$lib/server/flux/services.js');
 
 		await expect(
 			getFluxResourceDetail({

--- a/src/tests/health-routes.test.ts
+++ b/src/tests/health-routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 
 describe('health routes', () => {
 	test('api/health and api/v1/health return the same public status payload', async () => {

--- a/src/tests/helm-chart-regressions.test.ts
+++ b/src/tests/helm-chart-regressions.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const TEST_DIR = import.meta.dir;
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 
 function readRepoFile(relativePath: string): string {
 	return readFileSync(resolve(TEST_DIR, '..', relativePath), 'utf8');

--- a/src/tests/helpers/import-fresh.ts
+++ b/src/tests/helpers/import-fresh.ts
@@ -1,5 +1,4 @@
 export function importFresh<TModule>(path: string): Promise<TModule> {
 	const moduleUrl = new URL(path, new URL('../', import.meta.url));
-	moduleUrl.searchParams.set('case', `${Date.now()}-${Math.random()}`);
 	return import(moduleUrl.href) as Promise<TModule>;
 }

--- a/src/tests/helpers/oauth.ts
+++ b/src/tests/helpers/oauth.ts
@@ -1,4 +1,4 @@
-import { expect } from 'bun:test';
+import { expect } from 'vitest';
 
 export async function expectOAuthErrorCode(promise: Promise<unknown>, code: string) {
 	try {

--- a/src/tests/helpers/runtime-app.ts
+++ b/src/tests/helpers/runtime-app.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
 
 const HEALTH_PATH = '/api/v1/health';
 const ADMIN_PASSWORD = 'RuntimeAdminPassword!1';
@@ -24,6 +25,36 @@ interface RuntimeAppHandle {
 let buildPromise: Promise<void> | null = null;
 let runtimeAppPromise: Promise<RuntimeAppHandle> | null = null;
 
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function captureStream(stream: NodeJS.ReadableStream): Promise<string> {
+	const chunks: Buffer[] = [];
+	stream.on('data', (chunk: Buffer | string) => {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	});
+	return new Promise((resolve, reject) => {
+		stream.once('error', reject);
+		stream.once('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+	});
+}
+
+function requirePipe(stream: NodeJS.ReadableStream | null, name: string): NodeJS.ReadableStream {
+	if (!stream) {
+		throw new Error(`${name} was not configured as a pipe`);
+	}
+
+	return stream;
+}
+
+function waitForExit(process: ChildProcess): Promise<number | null> {
+	return new Promise((resolve, reject) => {
+		process.once('error', reject);
+		process.once('exit', (code) => resolve(code));
+	});
+}
+
 async function runBuildOnce(): Promise<void> {
 	if (!buildPromise) {
 		buildPromise = (async () => {
@@ -31,23 +62,20 @@ async function runBuildOnce(): Promise<void> {
 				...process.env,
 				NODE_ENV: 'production'
 			};
-			const build = Bun.spawn(['bun', 'run', 'build'], {
+			const build = spawn('pnpm', ['build'], {
 				cwd: REPO_ROOT,
 				env: buildEnv,
-				stderr: 'pipe',
-				stdout: 'pipe'
+				stdio: ['ignore', 'pipe', 'pipe']
 			});
-			const stdoutPromise = new Response(build.stdout).text();
-			const stderrPromise = new Response(build.stderr).text();
+			const stdoutPromise = captureStream(requirePipe(build.stdout, 'build stdout'));
+			const stderrPromise = captureStream(requirePipe(build.stderr, 'build stderr'));
 			stdoutPromise.catch(() => {});
 			stderrPromise.catch(() => {});
-			const exitCode = await build.exited;
+			const exitCode = await waitForExit(build);
 
 			if (exitCode !== 0) {
 				const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
-				throw new Error(
-					`bun run build failed with exit code ${exitCode}\n${stdout}${stderr}`.trim()
-				);
+				throw new Error(`pnpm build failed with exit code ${exitCode}\n${stdout}${stderr}`.trim());
 			}
 		})().catch((error) => {
 			buildPromise = null;
@@ -100,7 +128,7 @@ async function waitForServerExit(serverExited: Promise<void>, timeoutMs: number)
 	}
 }
 
-async function terminateServer(server: ReturnType<typeof Bun.spawn>, serverExited: Promise<void>) {
+async function terminateServer(server: ChildProcess, serverExited: Promise<void>) {
 	server.kill('SIGTERM');
 	if (!(await waitForServerExit(serverExited, TERMINATION_GRACE_MS))) {
 		server.kill('SIGKILL');
@@ -110,13 +138,14 @@ async function terminateServer(server: ReturnType<typeof Bun.spawn>, serverExite
 
 async function waitForReadiness(
 	baseUrl: string,
-	server: ReturnType<typeof Bun.spawn>,
+	server: ChildProcess,
 	captureStderr: () => Promise<string>,
 	timeoutMs = 30_000
 ): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
-	const exitedResultPromise = server.exited.then((code) => ({ code, exited: true as const }));
-	const serverExited = server.exited.then(
+	const exitPromise = waitForExit(server);
+	const exitedResultPromise = exitPromise.then((code) => ({ code, exited: true as const }));
+	const serverExited = exitPromise.then(
 		() => undefined,
 		() => undefined
 	);
@@ -124,7 +153,7 @@ async function waitForReadiness(
 	while (Date.now() < deadline) {
 		const exitResult = await Promise.race([
 			exitedResultPromise,
-			Bun.sleep(250).then(() => ({ code: 0, exited: false as const }))
+			sleep(250).then(() => ({ code: 0, exited: false as const }))
 		]);
 
 		if (exitResult.exited) {
@@ -165,7 +194,7 @@ export async function getRuntimeApp(): Promise<RuntimeAppHandle> {
 			const backupDir = mkdtempSync(RUNTIME_TEMP_PREFIX);
 			const databasePath = join(tempDataDir, 'gyre.db');
 
-			const server = Bun.spawn(['node', 'build/index.js'], {
+			const server = spawn('node', ['build/index.js'], {
 				cwd: REPO_ROOT,
 				env: {
 					...process.env,
@@ -183,15 +212,12 @@ export async function getRuntimeApp(): Promise<RuntimeAppHandle> {
 					NODE_ENV: 'production',
 					PORT: String(port)
 				},
-				stderr: 'pipe',
-				stdout: 'ignore'
+				stdio: ['ignore', 'ignore', 'pipe']
 			});
-			const stderrPromise = server.stderr
-				? new Response(server.stderr).text()
-				: Promise.resolve('');
+			const stderrPromise = captureStream(requirePipe(server.stderr, 'server stderr'));
 			const captureStderr = () => stderrPromise;
 			const baseUrl = `http://127.0.0.1:${port}`;
-			const serverExited = server.exited.then(
+			const serverExited = waitForExit(server).then(
 				() => undefined,
 				() => undefined
 			);

--- a/src/tests/hooks-public-routes.test.ts
+++ b/src/tests/hooks-public-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import type { User } from '../lib/server/db/schema.js';
 import { isPublicRoute } from '../lib/isPublicRoute.js';
 import * as actualConfig from '../lib/server/config.js';
@@ -6,7 +6,7 @@ import * as actualConstants from '../lib/server/config/constants.js';
 import * as actualMetrics from '../lib/server/metrics.js';
 import { createRateLimiterModuleStub, createRbacModuleStub } from './helpers/module-stubs';
 
-let checkPermissionSpy: ReturnType<typeof spyOn> | undefined;
+let checkPermissionSpy: ReturnType<typeof vi.spyOn> | undefined;
 
 function createUser(role: User['role'] = 'admin'): User {
 	const now = new Date();
@@ -34,19 +34,19 @@ async function callMetrics(options: {
 	user?: User | null;
 	cluster?: string;
 }): Promise<Response> {
-	mock.module('$lib/server/config', () => ({ ...actualConfig, IS_PROD: options.isProd }));
-	mock.module('$lib/server/config.js', () => ({ ...actualConfig, IS_PROD: options.isProd }));
-	mock.module('$lib/server/config/constants', () => ({
+	vi.doMock('$lib/server/config', () => ({ ...actualConfig, IS_PROD: options.isProd }));
+	vi.doMock('$lib/server/config.js', () => ({ ...actualConfig, IS_PROD: options.isProd }));
+	vi.doMock('$lib/server/config/constants', () => ({
 		...actualConstants,
 		GYRE_METRICS_TOKEN: options.metricsToken ?? ''
 	}));
-	mock.module('$lib/server/config/constants.js', () => ({
+	vi.doMock('$lib/server/config/constants.js', () => ({
 		...actualConstants,
 		GYRE_METRICS_TOKEN: options.metricsToken ?? ''
 	}));
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
 
 	const rbacModule = createRbacModuleStub({
 		checkPermission: async (
@@ -61,21 +61,23 @@ async function callMetrics(options: {
 			return user.role === 'admin';
 		}
 	});
-	checkPermissionSpy = spyOn(rbacModule, 'checkPermission').mockImplementation(
-		async (
-			user: User,
-			permission: string,
-			_resourceType: string | undefined,
-			_namespace: string | undefined,
-			cluster: string | undefined
-		) => {
-			expect(permission).toBe('admin');
-			expect(cluster).toBe(options.cluster);
-			return user.role === 'admin';
-		}
-	);
-	mock.module('$lib/server/rbac.js', () => rbacModule);
-	mock.module('$lib/server/metrics', () => ({
+	checkPermissionSpy = vi
+		.spyOn(rbacModule, 'checkPermission')
+		.mockImplementation(
+			async (
+				user: User,
+				permission: string,
+				_resourceType: string | undefined,
+				_namespace: string | undefined,
+				cluster: string | undefined
+			) => {
+				expect(permission).toBe('admin');
+				expect(cluster).toBe(options.cluster);
+				return user.role === 'admin';
+			}
+		);
+	vi.doMock('$lib/server/rbac.js', () => rbacModule);
+	vi.doMock('$lib/server/metrics', () => ({
 		...actualMetrics,
 		register: {
 			metrics: async () => '# mock metrics\n',
@@ -83,9 +85,7 @@ async function callMetrics(options: {
 		}
 	}));
 
-	const { GET: metricsGET } = await import(
-		`../routes/metrics/+server.js?case=${Date.now()}-${Math.random()}`
-	);
+	const { GET: metricsGET } = await import('../routes/metrics/+server.js');
 
 	const headers = new Headers();
 	if (options.authHeader) {
@@ -104,7 +104,8 @@ async function callMetrics(options: {
 }
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 	checkPermissionSpy = undefined;
 });
 

--- a/src/tests/k8s-client-reliability.test.ts
+++ b/src/tests/k8s-client-reliability.test.ts
@@ -1,9 +1,15 @@
-import { describe, test, expect, spyOn } from 'bun:test';
+import { afterAll, describe, test, expect, vi } from 'vitest';
 
 // Suppress console noise
-spyOn(console, 'log').mockImplementation(() => {});
-spyOn(console, 'warn').mockImplementation(() => {});
-spyOn(console, 'error').mockImplementation(() => {});
+const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+	consoleLogSpy.mockRestore();
+	consoleWarnSpy.mockRestore();
+	consoleErrorSpy.mockRestore();
+});
 
 import {
 	OPERATION_TIMEOUTS,

--- a/src/tests/k8s-timeout.test.ts
+++ b/src/tests/k8s-timeout.test.ts
@@ -1,10 +1,11 @@
-import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
 
-mock.restore();
+vi.restoreAllMocks();
+vi.resetModules();
 
 // Suppress console noise from handleK8sError's server-side logging and DB init.
-spyOn(console, 'log').mockImplementation(() => {});
-spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
 import * as k8s from '@kubernetes/client-node';
 import {
 	DEFAULT_TIMEOUT_MS,

--- a/src/tests/logger.test.ts
+++ b/src/tests/logger.test.ts
@@ -1,11 +1,12 @@
-import { expect, test, describe, mock, spyOn } from 'bun:test';
+import { expect, test, describe, vi } from 'vitest';
 import { logger } from '../lib/server/logger.js?sut';
 
-mock.restore();
+vi.restoreAllMocks();
+vi.resetModules();
 
 describe('Logger Redaction', () => {
 	test('redacts sensitive fields like password', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 
 		logger.info({ password: 'supersecretpassword', other: 'safe' }, 'Test message');
 
@@ -20,7 +21,7 @@ describe('Logger Redaction', () => {
 	});
 
 	test('redacts ADMIN_PASSWORD', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 
 		logger.info({ ADMIN_PASSWORD: 'adminsecret' }, 'Another message');
 
@@ -36,7 +37,7 @@ describe('Logger Redaction', () => {
 
 describe('Logger Security', () => {
 	test('redacts apiKey field', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info({ apiKey: 'ak-secret-123', other: 'safe' }, 'Test message');
 		const output = stdoutSpy.mock.calls[0][0] as string;
 		expect(output).toContain('[REDACTED]');
@@ -45,7 +46,7 @@ describe('Logger Security', () => {
 	});
 
 	test('redacts accessToken field', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info({ accessToken: 'at-secret-456' }, 'Test message');
 		const output = stdoutSpy.mock.calls[0][0] as string;
 		expect(output).toContain('[REDACTED]');
@@ -54,7 +55,7 @@ describe('Logger Security', () => {
 	});
 
 	test('redacts refreshToken field', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info({ refreshToken: 'rt-secret-789' }, 'Test message');
 		const output = stdoutSpy.mock.calls[0][0] as string;
 		expect(output).toContain('[REDACTED]');
@@ -63,7 +64,7 @@ describe('Logger Security', () => {
 	});
 
 	test('redacts clientSecret field', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info({ clientSecret: 'cs-secret-abc' }, 'Test message');
 		const output = stdoutSpy.mock.calls[0][0] as string;
 		expect(output).toContain('[REDACTED]');
@@ -72,7 +73,7 @@ describe('Logger Security', () => {
 	});
 
 	test('redacts bearer field', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info({ bearer: 'bearer-token-xyz' }, 'Test message');
 		const output = stdoutSpy.mock.calls[0][0] as string;
 		expect(output).toContain('[REDACTED]');
@@ -81,7 +82,7 @@ describe('Logger Security', () => {
 	});
 
 	test('sanitizes newlines in log messages (log injection prevention)', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info('Safe message\nINJECTED: fake log entry');
 		const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
 		expect(parsed.msg).not.toContain('\nINJECTED');
@@ -90,7 +91,7 @@ describe('Logger Security', () => {
 	});
 
 	test('sanitizes carriage returns in log messages', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info('Message\r\nwith CRLF injection');
 		const parsed = JSON.parse(stdoutSpy.mock.calls[0][0] as string);
 		expect(parsed.msg).not.toMatch(/\r\n/);
@@ -98,7 +99,7 @@ describe('Logger Security', () => {
 	});
 
 	test('redacts nested sensitive fields via wildcard paths', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info(
 			{ user: { apiKey: 'ak-secret-123', bearer: 'bearer-token-xyz' } },
 			'Nested redaction test'
@@ -113,7 +114,7 @@ describe('Logger Security', () => {
 
 describe('Logger Signatures', () => {
 	test('handles string message only', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info('Just a message');
 
 		expect(stdoutSpy).toHaveBeenCalled();
@@ -124,7 +125,7 @@ describe('Logger Signatures', () => {
 	});
 
 	test('handles object context only', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info({ userId: 123 });
 
 		expect(stdoutSpy).toHaveBeenCalled();
@@ -135,7 +136,7 @@ describe('Logger Signatures', () => {
 	});
 
 	test('handles error object and message', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		const err = new Error('Test error');
 		logger.error(err, 'Failed operation');
 
@@ -149,7 +150,7 @@ describe('Logger Signatures', () => {
 	});
 
 	test('handles object context and message', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info({ userId: 123 }, 'User logged in');
 
 		expect(stdoutSpy).toHaveBeenCalled();
@@ -161,7 +162,7 @@ describe('Logger Signatures', () => {
 	});
 
 	test('handles message and context (reverse order, non-standard but supported by variadic wrapper)', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info('User logged in', { userId: 123 });
 
 		expect(stdoutSpy).toHaveBeenCalled();
@@ -173,7 +174,7 @@ describe('Logger Signatures', () => {
 	});
 
 	test('handles error with message and extra context (3+ args)', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		const err = new Error('Test error');
 		logger.error(err, 'OAuth error from IdP:', { provider: 'github' });
 
@@ -188,7 +189,7 @@ describe('Logger Signatures', () => {
 	});
 
 	test('handles string message with multiple context objects (3+ args)', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		logger.info('User action', { userId: 42 }, { action: 'login' });
 
 		expect(stdoutSpy).toHaveBeenCalled();
@@ -201,7 +202,7 @@ describe('Logger Signatures', () => {
 	});
 
 	test('does nothing when called with no arguments', () => {
-		const stdoutSpy = spyOn(process.stdout, 'write');
+		const stdoutSpy = vi.spyOn(process.stdout, 'write');
 		// @ts-expect-error - testing invalid call
 		logger.info();
 

--- a/src/tests/login-route.test.ts
+++ b/src/tests/login-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { User } from '../lib/server/db/schema.js';
 import { importFresh } from './helpers/import-fresh';
 import { buildLoginEvent, type LoginEvent } from './helpers/login-route-event';
@@ -54,7 +54,7 @@ function buildEvent(): LoginEvent {
 beforeEach(async () => {
 	Object.assign(routeState, createRouteState());
 
-	mock.module('$lib/server/auth', () => ({
+	vi.doMock('$lib/server/auth', () => ({
 		SESSION_DURATION_DAYS: 30,
 		addPasswordHistory: async () => {},
 		authenticateUser: async () => routeState.authenticatedUser,
@@ -75,7 +75,7 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('$lib/server/settings', () => ({
+	vi.doMock('$lib/server/settings', () => ({
 		getAuthSettings: async () => ({
 			localLoginEnabled: routeState.localLoginEnabled,
 			allowSignup: true,
@@ -90,8 +90,8 @@ beforeEach(async () => {
 		},
 		logLogout: async () => {}
 	};
-	mock.module('$lib/server/audit', () => auditModuleStub);
-	mock.module('$lib/server/audit.js', () => auditModuleStub);
+	vi.doMock('$lib/server/audit', () => auditModuleStub);
+	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
 
 	const betterAuthModuleStub = {
 		BETTER_AUTH_SESSION_COOKIE_NAME: 'gyre_session',
@@ -113,19 +113,20 @@ beforeEach(async () => {
 		revokeBetterAuthSessionByCookieValue: async () => {}
 	};
 
-	mock.module('$lib/server/auth/better-auth', () => betterAuthModuleStub);
-	mock.module('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
 
-	mock.module('$lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('$lib/server/logger.js', () => createLoggerModuleStub());
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
 
 	POST = (await importFresh<LoginRouteModule>('../routes/api/v1/auth/login/+server.js')).POST;
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('login route', () => {

--- a/src/tests/oauth-callback-route.test.ts
+++ b/src/tests/oauth-callback-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { INVALID_SPAN_CONTEXT, trace } from '@opentelemetry/api';
 import type { Cookies } from '@sveltejs/kit';
 import type { User } from '../lib/server/db/schema.js';
@@ -107,7 +107,7 @@ function buildEvent(
 beforeEach(async () => {
 	Object.assign(callbackState, createCallbackState());
 
-	mock.module('$lib/server/auth/oauth', () => ({
+	vi.doMock('$lib/server/auth/oauth', () => ({
 		getOAuthProvider: async () => ({
 			config: { id: 'custom-provider' },
 			validateCallback: async () => ({ accessToken: 'access-token', tokenType: 'Bearer' }),
@@ -129,14 +129,14 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('$lib/server/auth/sso', () => ({
+	vi.doMock('$lib/server/auth/sso', () => ({
 		createOrUpdateSSOUser: async () => ({
 			user: createUser(),
 			accountLinked: true
 		})
 	}));
 
-	mock.module('$lib/server/auth', () => ({
+	vi.doMock('$lib/server/auth', () => ({
 		SESSION_DURATION_DAYS: 30,
 		addPasswordHistory: async () => {},
 		authenticateUser: async () => null,
@@ -179,13 +179,13 @@ beforeEach(async () => {
 		revokeBetterAuthSessionByCookieValue: async () => {}
 	};
 
-	mock.module('$lib/server/auth/better-auth', () => betterAuthModuleStub);
-	mock.module('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
 
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
-	mock.module('$lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/logger.js', () => createLoggerModuleStub());
 
 	GET = (
 		await importFresh<CallbackRouteModule>('../routes/api/v1/auth/[providerId]/callback/+server.js')
@@ -193,7 +193,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('oauth callback route', () => {

--- a/src/tests/oauth-github.test.ts
+++ b/src/tests/oauth-github.test.ts
@@ -1,28 +1,18 @@
-import {
-	describe,
-	test,
-	expect,
-	beforeAll,
-	afterAll,
-	beforeEach,
-	afterEach,
-	mock,
-	spyOn
-} from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { expectOAuthErrorCode } from './helpers/oauth.js';
 import { importFresh } from './helpers/import-fresh';
 import { createAuthCryptoModuleStub } from './helpers/module-stubs';
 
 type GitHubProviderModule = typeof import('../lib/server/auth/oauth/providers/github.js');
 
-let consoleLogSpy: ReturnType<typeof spyOn>;
-let consoleErrorSpy: ReturnType<typeof spyOn>;
-let consoleWarnSpy: ReturnType<typeof spyOn>;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
 beforeAll(() => {
-	consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
-	consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
-	consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+	consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+	consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
 afterAll(() => {
@@ -34,13 +24,13 @@ afterAll(() => {
 let GitHubProvider: GitHubProviderModule['GitHubProvider'];
 
 beforeEach(async () => {
-	mock.module('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
+	vi.doMock('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
 
-	mock.module('$lib/server/auth/pkce', () => ({
+	vi.doMock('$lib/server/auth/pkce', () => ({
 		generateCodeChallenge: (v: string) => `challenge_${v}`
 	}));
 
-	mock.module('arctic', () => ({
+	vi.doMock('arctic', () => ({
 		Google: class MockGoogle {
 			createAuthorizationURL(state: string, verifier: string, scopes: string[]) {
 				return new URL(
@@ -98,7 +88,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 const mockConfig = {
@@ -182,15 +173,15 @@ describe('GitHubProvider.getAuthorizationUrl()', () => {
 describe('GitHubProvider.validateCallback() — PKCE path', () => {
 	test('sends code_verifier in request body', async () => {
 		let capturedBody: string | null = null;
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(
-			async (_url: string | URL | Request, init?: RequestInit) => {
+		const spy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (_url: string | URL | Request, init?: RequestInit) => {
 				capturedBody = init?.body?.toString() ?? null;
 				return new Response(
 					JSON.stringify({ access_token: 'pkce-access-token', token_type: 'bearer' }),
 					{ status: 200, headers: { 'Content-Type': 'application/json' } }
 				);
-			}
-		);
+			});
 		try {
 			const provider = makeProvider();
 			await provider.validateCallback('auth-code', 'my-code-verifier');
@@ -202,7 +193,7 @@ describe('GitHubProvider.validateCallback() — PKCE path', () => {
 	});
 
 	test('returns accessToken extracted from token response', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response(
 				JSON.stringify({ access_token: 'pkce-access-token', token_type: 'bearer' }),
 				{ status: 200, headers: { 'Content-Type': 'application/json' } }
@@ -218,7 +209,7 @@ describe('GitHubProvider.validateCallback() — PKCE path', () => {
 	});
 
 	test('throws OAuthError when request times out', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			const err = new DOMException('The operation was aborted', 'AbortError');
 			throw err;
 		});
@@ -251,14 +242,14 @@ describe('GitHubProvider.validateCallback() — non-PKCE path', () => {
 // ---------------------------------------------------------------------------
 
 describe('GitHubProvider.validateCallback() — error handling', () => {
-	let fetchSpy: ReturnType<typeof spyOn>;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
-		fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
-			async (_input: string | URL | Request, _init?: RequestInit) => {
+		fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (_input: string | URL | Request, _init?: RequestInit) => {
 				return new Response('Bad credentials', { status: 401 });
-			}
-		);
+			});
 	});
 
 	afterEach(() => {
@@ -279,11 +270,12 @@ describe('GitHubProvider.validateCallback() — error handling', () => {
 // ---------------------------------------------------------------------------
 
 describe('GitHubProvider.getUserInfo() — email in profile', () => {
-	let fetchSpy: ReturnType<typeof spyOn>;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
-		fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
-			async (input: string | URL | Request) => {
+		fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (input: string | URL | Request) => {
 				const urlStr = input.toString();
 				if (urlStr === 'https://api.github.com/user') {
 					return new Response(
@@ -299,8 +291,7 @@ describe('GitHubProvider.getUserInfo() — email in profile', () => {
 					);
 				}
 				return new Response('not found', { status: 404 });
-			}
-		);
+			});
 	});
 
 	afterEach(() => {
@@ -322,11 +313,12 @@ describe('GitHubProvider.getUserInfo() — email in profile', () => {
 // ---------------------------------------------------------------------------
 
 describe('GitHubProvider.getUserInfo() — no email in profile', () => {
-	let fetchSpy: ReturnType<typeof spyOn>;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
-		fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
-			async (input: string | URL | Request) => {
+		fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (input: string | URL | Request) => {
 				const urlStr = input.toString();
 				if (urlStr === 'https://api.github.com/user') {
 					return new Response(
@@ -351,8 +343,7 @@ describe('GitHubProvider.getUserInfo() — no email in profile', () => {
 					);
 				}
 				return new Response('not found', { status: 404 });
-			}
-		);
+			});
 	});
 
 	afterEach(() => {
@@ -371,11 +362,12 @@ describe('GitHubProvider.getUserInfo() — no email in profile', () => {
 // ---------------------------------------------------------------------------
 
 describe('GitHubProvider.getUserInfo() — fetchGroups with roleMapping', () => {
-	let fetchSpy: ReturnType<typeof spyOn>;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
-		fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
-			async (input: string | URL | Request) => {
+		fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (input: string | URL | Request) => {
 				const urlStr = input.toString();
 				if (urlStr === 'https://api.github.com/user') {
 					return new Response(
@@ -409,8 +401,7 @@ describe('GitHubProvider.getUserInfo() — fetchGroups with roleMapping', () => 
 					);
 				}
 				return new Response('not found', { status: 404 });
-			}
-		);
+			});
 	});
 
 	afterEach(() => {
@@ -437,14 +428,14 @@ describe('GitHubProvider.getUserInfo() — fetchGroups with roleMapping', () => 
 // ---------------------------------------------------------------------------
 
 describe('GitHubProvider.getUserInfo() — API failure', () => {
-	let fetchSpy: ReturnType<typeof spyOn>;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
-		fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
-			async (_input: string | URL | Request) => {
+		fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (_input: string | URL | Request) => {
 				return new Response('Internal Server Error', { status: 500 });
-			}
-		);
+			});
 	});
 
 	afterEach(() => {

--- a/src/tests/oauth-gitlab.test.ts
+++ b/src/tests/oauth-gitlab.test.ts
@@ -1,13 +1,13 @@
-import { afterAll, afterEach, beforeEach, describe, test, expect, mock, spyOn } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, test, expect, vi } from 'vitest';
 import { expectOAuthErrorCode } from './helpers/oauth.js';
 import { importFresh } from './helpers/import-fresh';
 import { createAuthCryptoModuleStub } from './helpers/module-stubs';
 
 type GitLabProviderModule = typeof import('../lib/server/auth/oauth/providers/gitlab.js');
 
-const consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
-const consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
-const consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 afterAll(() => {
 	consoleLogSpy.mockRestore();
@@ -18,13 +18,13 @@ afterAll(() => {
 let GitLabProvider: GitLabProviderModule['GitLabProvider'];
 
 beforeEach(async () => {
-	mock.module('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
+	vi.doMock('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
 
-	mock.module('$lib/server/auth/pkce', () => ({
+	vi.doMock('$lib/server/auth/pkce', () => ({
 		generateCodeChallenge: (v: string) => `challenge_${v}`
 	}));
 
-	mock.module('arctic', () => ({
+	vi.doMock('arctic', () => ({
 		Google: class MockGoogle {
 			createAuthorizationURL(state: string, verifier: string, scopes: string[]) {
 				return new URL(
@@ -76,7 +76,7 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('$lib/server/logger.js', () => ({
+	vi.doMock('$lib/server/logger.js', () => ({
 		logger: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }
 	}));
 
@@ -86,7 +86,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 const mockConfig = {
@@ -127,7 +128,7 @@ interface FetchMockContext {
 
 function createFetchMock(responseFn: (url: string) => Response) {
 	const ctx: FetchMockContext = { url: null, body: null };
-	const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+	const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
 		const urlStr = url.toString();
 		ctx.url = urlStr;
 		ctx.body = init?.body?.toString() ?? null;
@@ -224,14 +225,16 @@ describe('GitLabProvider.validateCallback() — PKCE path', () => {
 	test('POSTs to ${baseURL}/oauth/token with code_verifier in body', async () => {
 		let capturedUrl: string | null = null;
 		let capturedBody: string | null = null;
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url, init?: RequestInit) => {
-			capturedUrl = url.toString();
-			capturedBody = init?.body?.toString() ?? null;
-			return new Response(JSON.stringify({ access_token: 'pkce-token', token_type: 'bearer' }), {
-				status: 200,
-				headers: { 'content-type': 'application/json' }
+		const spy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (url, init?: RequestInit) => {
+				capturedUrl = url.toString();
+				capturedBody = init?.body?.toString() ?? null;
+				return new Response(JSON.stringify({ access_token: 'pkce-token', token_type: 'bearer' }), {
+					status: 200,
+					headers: { 'content-type': 'application/json' }
+				});
 			});
-		});
 		try {
 			const provider = makeProvider();
 			await provider.validateCallback('auth-code', 'my-verifier');
@@ -244,7 +247,7 @@ describe('GitLabProvider.validateCallback() — PKCE path', () => {
 	});
 
 	test('returns accessToken extracted from token response', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response(
 				JSON.stringify({ access_token: 'pkce-access-token', token_type: 'bearer' }),
 				{ status: 200, headers: { 'content-type': 'application/json' } }
@@ -260,7 +263,7 @@ describe('GitLabProvider.validateCallback() — PKCE path', () => {
 	});
 
 	test('throws OAuthError when request times out', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			throw new DOMException('The operation was aborted', 'AbortError');
 		});
 		try {
@@ -293,7 +296,7 @@ describe('GitLabProvider.validateCallback() — non-PKCE path', () => {
 
 describe('GitLabProvider.validateCallback() — error handling', () => {
 	test('throws OAuthError with TOKEN_EXCHANGE_FAILED on non-OK response', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response('Unauthorized', { status: 401 });
 		});
 		try {
@@ -315,13 +318,15 @@ describe('GitLabProvider.validateCallback() — error handling', () => {
 describe('GitLabProvider.refreshAccessToken()', () => {
 	test('POSTs grant_type=refresh_token and refresh_token to token endpoint', async () => {
 		let capturedBody: string | null = null;
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (_url, init?: RequestInit) => {
-			capturedBody = init?.body?.toString() ?? null;
-			return new Response(
-				JSON.stringify({ access_token: 'new-access-token', token_type: 'bearer' }),
-				{ status: 200, headers: { 'content-type': 'application/json' } }
-			);
-		});
+		const spy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (_url, init?: RequestInit) => {
+				capturedBody = init?.body?.toString() ?? null;
+				return new Response(
+					JSON.stringify({ access_token: 'new-access-token', token_type: 'bearer' }),
+					{ status: 200, headers: { 'content-type': 'application/json' } }
+				);
+			});
 		try {
 			const provider = makeProvider();
 			const tokens = await provider.refreshAccessToken!('old-refresh-token');
@@ -334,7 +339,7 @@ describe('GitLabProvider.refreshAccessToken()', () => {
 	});
 
 	test('throws OAuthError with TOKEN_REFRESH_FAILED on non-OK response', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response('Bad Request', { status: 400 });
 		});
 		try {
@@ -352,7 +357,7 @@ describe('GitLabProvider.refreshAccessToken()', () => {
 
 describe('GitLabProvider.getUserInfo()', () => {
 	test('confirmed_at present → emailVerified: true', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response(
 				JSON.stringify({
 					id: 10,
@@ -379,7 +384,7 @@ describe('GitLabProvider.getUserInfo()', () => {
 	});
 
 	test('confirmed_at absent → emailVerified: false', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response(
 				JSON.stringify({
 					id: 20,
@@ -402,7 +407,7 @@ describe('GitLabProvider.getUserInfo()', () => {
 	});
 
 	test('with roleMapping: fetches groups and populates groups with full_path values', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('/api/v4/user')) {
 				return new Response(
@@ -442,7 +447,7 @@ describe('GitLabProvider.getUserInfo()', () => {
 	});
 
 	test('throws OAuthError with USERINFO_FAILED on API failure', async () => {
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response('Internal Server Error', { status: 500 });
 		});
 		try {
@@ -464,7 +469,7 @@ describe('GitLabProvider.getUserInfo()', () => {
 describe('GitLabProvider — fetchGitLabGroups pagination', () => {
 	test('combines groups from all pages when x-next-page header is present', async () => {
 		let callCount = 0;
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('/api/v4/user')) {
 				return new Response(

--- a/src/tests/oauth-google.test.ts
+++ b/src/tests/oauth-google.test.ts
@@ -1,13 +1,13 @@
-import { afterEach, beforeEach, describe, test, expect, mock, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, test, expect, vi } from 'vitest';
 import { expectOAuthErrorCode } from './helpers/oauth.js';
 import { importFresh } from './helpers/import-fresh';
 import { createAuthCryptoModuleStub } from './helpers/module-stubs';
 
 type GoogleProviderModule = typeof import('../lib/server/auth/oauth/providers/google.js');
 
-spyOn(console, 'log').mockImplementation(() => {});
-spyOn(console, 'error').mockImplementation(() => {});
-spyOn(console, 'warn').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 let arcticShouldThrow = false;
 
@@ -31,9 +31,9 @@ beforeEach(async () => {
 		preferred_username: 'user@google.com'
 	};
 
-	mock.module('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
+	vi.doMock('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
 
-	mock.module('arctic', () => ({
+	vi.doMock('arctic', () => ({
 		Google: class MockGoogle {
 			createAuthorizationURL(state: string, verifier: string, scopes: string[]) {
 				return new URL(
@@ -86,7 +86,7 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('jose', () => ({
+	vi.doMock('jose', () => ({
 		createRemoteJWKSet: () => 'mock-jwks',
 		jwtVerify: async () => ({ payload: {}, protectedHeader: {} }),
 		decodeJwt: () => mockJwtClaims
@@ -98,7 +98,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 const mockConfig = {
@@ -271,7 +272,7 @@ describe('GoogleProvider.getUserInfo()', () => {
 	test('throws OAuthError with USERINFO_FAILED when OIDCProvider throws', async () => {
 		const provider = makeProvider();
 		// Without idToken and without discovery mocked, OIDCProvider calls discover() → fetch throws
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			throw new Error('Network error');
 		});
 		try {

--- a/src/tests/oauth-oidc.test.ts
+++ b/src/tests/oauth-oidc.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { expectOAuthErrorCode } from './helpers/oauth.js';
 import { importFresh } from './helpers/import-fresh';
 import { createAuthCryptoModuleStub } from './helpers/module-stubs';
@@ -7,34 +7,35 @@ type OIDCProviderModule = typeof import('../lib/server/auth/oauth/providers/oidc
 type OAuthIndexModule = typeof import('../lib/server/auth/oauth/index.js');
 type OAuthTypesModule = typeof import('../lib/server/auth/oauth/types.js');
 
-let consoleLogSpy: ReturnType<typeof spyOn>;
-let consoleErrorSpy: ReturnType<typeof spyOn>;
-let consoleWarnSpy: ReturnType<typeof spyOn>;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 let OIDCProvider: OIDCProviderModule['OIDCProvider'];
 let validateProviderConfig: OAuthIndexModule['validateProviderConfig'];
 let OAuthError: OAuthTypesModule['OAuthError'];
 
 beforeEach(() => {
-	consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
-	consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
-	consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+	consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+	consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
 afterEach(() => {
 	consoleLogSpy.mockRestore();
 	consoleErrorSpy.mockRestore();
 	consoleWarnSpy.mockRestore();
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 beforeEach(async () => {
-	mock.module('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
+	vi.doMock('$lib/server/auth/crypto', () => createAuthCryptoModuleStub());
 
-	mock.module('$lib/server/auth/pkce', () => ({
+	vi.doMock('$lib/server/auth/pkce', () => ({
 		generateCodeChallenge: (v: string) => `challenge_${v}`
 	}));
 
-	mock.module('arctic', () => ({
+	vi.doMock('arctic', () => ({
 		Google: class MockGoogle {
 			createAuthorizationURL(state: string, verifier: string, scopes: string[]) {
 				return new URL(
@@ -86,7 +87,7 @@ beforeEach(async () => {
 		}
 	}));
 
-	mock.module('jose', () => ({
+	vi.doMock('jose', () => ({
 		createRemoteJWKSet: () => 'mock-jwks',
 		jwtVerify: async () => ({ payload: {}, protectedHeader: {} }),
 		decodeJwt: () => ({
@@ -152,7 +153,7 @@ function makeProvider(configOverrides: Partial<typeof mockConfig> = {}) {
 }
 
 function mockDiscovery(discovery = MOCK_DISCOVERY) {
-	return spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+	return vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 		const urlStr = url.toString();
 		if (urlStr.includes('.well-known/openid-configuration')) {
 			return new Response(JSON.stringify(discovery), { status: 200 });
@@ -222,7 +223,7 @@ describe('OIDCProvider — discover()', () => {
 			userinfo_endpoint: `${uniqueIssuer}/userinfo`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			if (url.toString().includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discovery), { status: 200 });
 			}
@@ -247,7 +248,7 @@ describe('OIDCProvider — discover()', () => {
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
 		let fetchOptions: RequestInit | undefined;
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
 			fetchOptions = init;
 			return new Response(JSON.stringify(discovery), { status: 200 });
 		});
@@ -270,7 +271,7 @@ describe('OIDCProvider — discover()', () => {
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
 		let fetchCount = 0;
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			if (url.toString().includes('.well-known')) fetchCount++;
 			return new Response(JSON.stringify(discovery), { status: 200 });
 		});
@@ -294,7 +295,7 @@ describe('OIDCProvider — discover()', () => {
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
 		let fetchCount = 0;
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			if (url.toString().includes('.well-known')) fetchCount++;
 			return new Response(JSON.stringify(discovery), { status: 200 });
 		});
@@ -321,7 +322,7 @@ describe('OIDCProvider — discover()', () => {
 
 	test('throws OAuthError with DISCOVERY_FAILED when authorization_endpoint is missing', async () => {
 		const provider = makeProvider();
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response(
 				JSON.stringify({
 					issuer: 'https://provider.example.com',
@@ -348,7 +349,7 @@ describe('OIDCProvider — discover()', () => {
 	test('throws OAuthError with DISCOVERY_FAILED when discovery issuer does not match config', async () => {
 		const uniqueIssuer = `https://issuer-mismatch-${Date.now()}.example.com`;
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response(
 				JSON.stringify({
 					...MOCK_DISCOVERY,
@@ -373,7 +374,7 @@ describe('OIDCProvider — discover()', () => {
 	test('throws OAuthError with DISCOVERY_FAILED when discovery exposes an unsafe endpoint host', async () => {
 		const uniqueIssuer = `https://unsafe-endpoint-${Date.now()}.example.com`;
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async () => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
 			return new Response(
 				JSON.stringify({
 					...MOCK_DISCOVERY,
@@ -423,9 +424,9 @@ describe('OIDCProvider.getAuthorizationUrl()', () => {
 			jwks_uri: `${uniqueIssuer}/.well-known/jwks`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(
-			async () => new Response(JSON.stringify(discovery), { status: 200 })
-		);
+		const spy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async () => new Response(JSON.stringify(discovery), { status: 200 }));
 		try {
 			const url = await provider.getAuthorizationUrl('state', 'my-verifier');
 			expect(url.searchParams.get('code_challenge')).toBe('challenge_my-verifier');
@@ -445,9 +446,9 @@ describe('OIDCProvider.getAuthorizationUrl()', () => {
 			jwks_uri: `${uniqueIssuer}/.well-known/jwks`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(
-			async () => new Response(JSON.stringify(discovery), { status: 200 })
-		);
+		const spy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async () => new Response(JSON.stringify(discovery), { status: 200 }));
 		try {
 			const url = await provider.getAuthorizationUrl('my-csrf-state', 'verifier');
 			expect(url.searchParams.get('state')).toBe('my-csrf-state');
@@ -486,7 +487,7 @@ describe('OIDCProvider.validateCallback()', () => {
 			jwks_uri: `${uniqueIssuer}/.well-known/jwks`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discovery), { status: 200 });
@@ -523,7 +524,7 @@ describe('OIDCProvider.validateCallback()', () => {
 			jwks_uri: `${uniqueIssuer}/.well-known/jwks`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discovery), { status: 200 });
@@ -572,7 +573,7 @@ describe('OIDCProvider.getUserInfo()', () => {
 			userinfo_endpoint: `${uniqueIssuer}/userinfo`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discovery), { status: 200 });
@@ -606,7 +607,7 @@ describe('OIDCProvider.getUserInfo()', () => {
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
 		let userinfoOptions: RequestInit | undefined;
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discovery), { status: 200 });
@@ -640,7 +641,7 @@ describe('OIDCProvider.getUserInfo()', () => {
 			// no userinfo_endpoint
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			if (url.toString().includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discoveryNoUserinfo), { status: 200 });
 			}
@@ -698,7 +699,7 @@ describe('OIDCProvider — mapClaimsToUserInfo()', () => {
 			userinfo_endpoint: `${uniqueIssuer}/userinfo`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer, roleClaim: 'groups' });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discovery), { status: 200 });
@@ -779,7 +780,7 @@ describe('OIDCProvider.refreshAccessToken()', () => {
 			jwks_uri: `${uniqueIssuer}/.well-known/jwks`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discovery), { status: 200 });
@@ -810,7 +811,7 @@ describe('OIDCProvider.refreshAccessToken()', () => {
 			jwks_uri: `${uniqueIssuer}/.well-known/jwks`
 		};
 		const provider = makeProvider({ issuerUrl: uniqueIssuer });
-		const spy = spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+		const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
 			const urlStr = url.toString();
 			if (urlStr.includes('.well-known/openid-configuration')) {
 				return new Response(JSON.stringify(discovery), { status: 200 });

--- a/src/tests/oauth-url-security.test.ts
+++ b/src/tests/oauth-url-security.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import {
 	assertSafeOidcDiscoveryDocument,
 	getIssuerUrlValidationError

--- a/src/tests/pagination.test.ts
+++ b/src/tests/pagination.test.ts
@@ -171,8 +171,27 @@ describe('Pagination Logic', () => {
 });
 
 describe('Pagination – empty database', () => {
-	beforeEach(() => {
+	beforeEach(async () => {
 		state.db = setupInMemoryDb();
+		vi.doMock('../lib/server/db/index.js', () => ({
+			getDb: async () => state.db,
+			getDbSync: () => state.db,
+			schema
+		}));
+		vi.doMock('../lib/server/rbac-defaults.js', () => ({
+			bindUserToDefaultPolicies: async () => {},
+			syncUserPolicyBindings: async () => {}
+		}));
+		vi.doMock('bcryptjs', () => ({
+			default: {
+				hash: async () => 'hashed_password',
+				compare: async () => true
+			},
+			hash: async () => 'hashed_password',
+			compare: async () => true
+		}));
+		listUsersPaginated = (await importFresh<AuthModule>('../lib/server/auth.js?sut'))
+			.listUsersPaginated;
 	});
 
 	test('empty database returns total=0 and empty results', async () => {

--- a/src/tests/pagination.test.ts
+++ b/src/tests/pagination.test.ts
@@ -1,9 +1,9 @@
-import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 
-spyOn(console, 'log').mockImplementation(() => {});
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
+vi.spyOn(console, 'log').mockImplementation(() => {});
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../lib/server/db/schema.js';
 
 type AuthModule = typeof import('../lib/server/auth.js');
@@ -70,16 +70,16 @@ describe('Pagination Logic', () => {
 
 	beforeEach(async () => {
 		state.db = setupInMemoryDb();
-		mock.module('../lib/server/db/index.js', () => ({
+		vi.doMock('../lib/server/db/index.js', () => ({
 			getDb: async () => state.db,
 			getDbSync: () => state.db,
 			schema
 		}));
-		mock.module('../lib/server/rbac-defaults.js', () => ({
+		vi.doMock('../lib/server/rbac-defaults.js', () => ({
 			bindUserToDefaultPolicies: async () => {},
 			syncUserPolicyBindings: async () => {}
 		}));
-		mock.module('bcryptjs', () => ({
+		vi.doMock('bcryptjs', () => ({
 			default: {
 				hash: async () => 'hashed_password',
 				compare: async () => true
@@ -114,7 +114,8 @@ describe('Pagination Logic', () => {
 
 	afterEach(() => {
 		state.db = null;
-		mock.restore();
+		vi.restoreAllMocks();
+		vi.resetModules();
 	});
 
 	test('listUsersPaginated returns correct page size', async () => {

--- a/src/tests/path-validation.test.ts
+++ b/src/tests/path-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/src/tests/privileged-route-sentinel.test.ts
+++ b/src/tests/privileged-route-sentinel.test.ts
@@ -1,15 +1,18 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
+import { execFile } from 'node:child_process';
 import { join, relative } from 'node:path';
-import { $ } from 'bun';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
-const repoRoot = join(import.meta.dir, '..', '..');
+const execFileAsync = promisify(execFile);
+const repoRoot = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
 const routeRoot = join(repoRoot, 'src', 'routes');
 const apiRouteRoot = join(routeRoot, 'api', 'v1');
 
 async function routeFilesUnder(path: string): Promise<string[]> {
-	const output = await $`find ${path} -name '+server.ts' -type f`.text();
-	return output
+	const { stdout } = await execFileAsync('find', [path, '-name', '+server.ts', '-type', 'f']);
+	return stdout
 		.split('\n')
 		.map((line) => line.trim())
 		.filter(Boolean)

--- a/src/tests/rate-limiter.test.ts
+++ b/src/tests/rate-limiter.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { eq } from 'drizzle-orm';
 import * as schema from '../lib/server/db/schema.js';
 
@@ -33,14 +33,15 @@ function setupInMemoryDb() {
 	return drizzle(sqlite, { schema });
 }
 
-mock.restore();
-mock.module('../lib/server/db/index.js', () => ({
+vi.restoreAllMocks();
+vi.resetModules();
+vi.mock('../lib/server/db/index.js', () => ({
 	getDbSync: () => state.db,
 	getDb: async () => state.db,
 	schema
 }));
 
-spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
 import { RateLimiter, SSEConnectionLimiter } from '../lib/server/rate-limiter?sut';
 
 afterEach(() => {

--- a/src/tests/rbac.test.ts
+++ b/src/tests/rbac.test.ts
@@ -1,17 +1,18 @@
-import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 
-spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
 
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../lib/server/db/schema.js';
 
 // Mutable reference shared with the mock closure so each test gets a fresh DB
 const state: { db: ReturnType<typeof drizzle<typeof schema>> | null } = { db: null };
 import type { User } from '../lib/server/db/schema.js';
 
-mock.restore();
-mock.module('../lib/server/db/index.js', () => ({
+vi.restoreAllMocks();
+vi.resetModules();
+vi.mock('../lib/server/db/index.js', () => ({
 	getDb: async () => state.db,
 	getDbSync: () => state.db,
 	schema

--- a/src/tests/request-pipeline-runtime.test.ts
+++ b/src/tests/request-pipeline-runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { RequestEvent } from '@sveltejs/kit';
 import { IN_CLUSTER_ID } from '../lib/clusters/identity.js';
 import type { User } from '../lib/server/db/schema.js';
@@ -103,8 +103,8 @@ beforeEach(() => {
 	clusterWideReadAllowed = true;
 	resolvedRoutes.length = 0;
 
-	mock.module('$lib/server/logger.js', () => createLoggerModuleStub());
-	mock.module('$lib/server/metrics.js', () => ({
+	vi.doMock('$lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('$lib/server/metrics.js', () => ({
 		httpRequestDurationMicroseconds: {
 			labels: () => ({
 				observe: () => {}
@@ -113,13 +113,13 @@ beforeEach(() => {
 		loginAttemptsTotal: { labels: () => ({ inc: () => {} }) },
 		sessionsCleanedUpTotal: { inc: () => {} }
 	}));
-	mock.module('$lib/server/initialize.js', () => ({
+	vi.doMock('$lib/server/initialize.js', () => ({
 		initializeGyre: async () => {}
 	}));
 
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
 
 	const betterAuthModuleStub = {
 		BETTER_AUTH_SESSION_COOKIE_NAME: 'gyre_session',
@@ -140,21 +140,21 @@ beforeEach(() => {
 			}
 		})
 	};
-	mock.module('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
-	mock.module('$lib/server/auth/better-auth', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth', () => betterAuthModuleStub);
 
-	mock.module('$lib/server/csrf.js', () => ({
+	vi.doMock('$lib/server/csrf.js', () => ({
 		generateCsrfToken: (sessionId: string) => `csrf:${sessionId}`,
 		validateCsrfToken: (_sessionId: string, token: string) => csrfValid && token.startsWith('csrf:')
 	}));
 
-	mock.module('$lib/server/clusters/repository.js', () => ({
+	vi.doMock('$lib/server/clusters/repository.js', () => ({
 		getClusterById: async () => clusterRecord,
 		getSelectableClusters: async () => []
 	}));
 
-	mock.module('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
-	mock.module('$lib/server/rbac.js', () =>
+	vi.doMock('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
+	vi.doMock('$lib/server/rbac.js', () =>
 		createRbacModuleStub({
 			checkClusterWideReadPermission: async () => clusterWideReadAllowed,
 			checkPermission: async (user, action) => {
@@ -165,7 +165,7 @@ beforeEach(() => {
 			}
 		})
 	);
-	mock.module('$lib/server/flux/services.js', () => ({
+	vi.doMock('$lib/server/flux/services.js', () => ({
 		getFluxInstalledVersion: async () => ({ version: 'v2.3.0' })
 	}));
 	const auditModuleStub = {
@@ -174,15 +174,16 @@ beforeEach(() => {
 		logLogout: async () => {},
 		logResourceWrite: async () => {}
 	};
-	mock.module('$lib/server/audit', () => auditModuleStub);
-	mock.module('$lib/server/audit.js', () => auditModuleStub);
+	vi.doMock('$lib/server/audit', () => auditModuleStub);
+	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
 });
 
 afterEach(async () => {
 	const { _resetGyreInitializationForTests } =
 		await import('../lib/server/request/initialization.js');
 	_resetGyreInitializationForTests();
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('request pipeline runtime coverage', () => {

--- a/src/tests/request-pipeline.test.ts
+++ b/src/tests/request-pipeline.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { IN_CLUSTER_ID } from '../lib/clusters/identity.js';
 import type { User } from '../lib/server/db/schema.js';
 import { importFresh } from './helpers/import-fresh';
@@ -83,9 +83,9 @@ beforeEach(() => {
 	};
 	observeCalls.length = 0;
 
-	mock.module('$lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('$lib/server/logger.js', () => createLoggerModuleStub());
 
-	mock.module('$lib/server/metrics.js', () => ({
+	vi.doMock('$lib/server/metrics.js', () => ({
 		httpRequestDurationMicroseconds: {
 			labels: (...labels: string[]) => ({
 				observe: (value: number) => observeCalls.push({ labels, value })
@@ -95,13 +95,13 @@ beforeEach(() => {
 		sessionsCleanedUpTotal: { inc: () => {} }
 	}));
 
-	mock.module('$lib/server/initialize.js', () => ({
+	vi.doMock('$lib/server/initialize.js', () => ({
 		initializeGyre: async () => {}
 	}));
 
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
 
 	const betterAuthModuleStub = {
 		BETTER_AUTH_SESSION_COOKIE_NAME: 'gyre_session',
@@ -124,28 +124,28 @@ beforeEach(() => {
 		})
 	};
 
-	mock.module('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
-	mock.module('$lib/server/auth/better-auth', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth', () => betterAuthModuleStub);
 
-	mock.module('$lib/server/csrf.js', () => ({
+	vi.doMock('$lib/server/csrf.js', () => ({
 		generateCsrfToken: (sessionId: string) => `csrf:${sessionId}`,
 		validateCsrfToken: () => csrfValid
 	}));
 
-	mock.module('$lib/server/clusters/repository.js', () => ({
+	vi.doMock('$lib/server/clusters/repository.js', () => ({
 		getClusterById: async (id: string) => {
 			getClusterByIdCalls.push(id);
 			return clusterRecord;
 		},
 		getSelectableClusters: async () => []
 	}));
-	mock.module('$lib/server/clusters/local-kubeconfig.js', () => ({
+	vi.doMock('$lib/server/clusters/local-kubeconfig.js', () => ({
 		getDefaultLocalKubeconfigContext: () => null,
 		hasLocalKubeconfigContext: () => false,
 		shouldUseLocalKubeconfigContexts: () => false
 	}));
 
-	mock.module('$lib/server/kubernetes/errors.js', () =>
+	vi.doMock('$lib/server/kubernetes/errors.js', () =>
 		createKubernetesErrorsModuleStub({
 			errorToHttpResponse: () => errorResponse
 		})
@@ -156,7 +156,8 @@ afterEach(async () => {
 	const { _resetGyreInitializationForTests } =
 		await import('../lib/server/request/initialization.js');
 	_resetGyreInitializationForTests();
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('request pipeline', () => {

--- a/src/tests/resource-health.test.ts
+++ b/src/tests/resource-health.test.ts
@@ -1,8 +1,8 @@
-import { afterAll, describe, expect, mock, test } from 'bun:test';
+import { afterAll, describe, expect, test, vi } from 'vitest';
 
 // Mock SvelteKit virtual modules before importing anything that depends on them
-mock.module('$app/environment', () => ({ dev: false }));
-mock.module('$env/dynamic/public', () => ({ env: {} }));
+vi.mock('$app/environment', () => ({ dev: false }));
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
 
 import { getResourceHealth } from '../lib/utils/flux.js';
 import type { K8sCondition } from '../lib/server/kubernetes/flux/types.js';
@@ -123,7 +123,8 @@ describe('getResourceHealth', () => {
 });
 
 afterAll(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/resources-config.test.ts
+++ b/src/tests/resources-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import {
 	getResourceInfoByKind,
 	resolveResourceKind,

--- a/src/tests/role-mapping.test.ts
+++ b/src/tests/role-mapping.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import {
 	DEFAULT_ROLE_MAPPING_TEMPLATE,
 	parseRoleMappingInput,

--- a/src/tests/search.test.ts
+++ b/src/tests/search.test.ts
@@ -1,8 +1,8 @@
-import { afterAll, describe, expect, mock, test } from 'bun:test';
+import { afterAll, describe, expect, test, vi } from 'vitest';
 
 // Mock SvelteKit virtual modules before importing anything that depends on them
-mock.module('$app/environment', () => ({ dev: false }));
-mock.module('$env/dynamic/public', () => ({ env: {} }));
+vi.mock('$app/environment', () => ({ dev: false }));
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
 
 const { advancedSearch, parseQuery } = await import('../lib/utils/search.js');
 
@@ -132,7 +132,8 @@ describe('advancedSearch', () => {
 });
 
 afterAll(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/security-config.test.ts
+++ b/src/tests/security-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { validateProductionSecurityConfig } from '../lib/server/security-config.js';
 
 function validProductionEnv(): Record<string, string | undefined> {

--- a/src/tests/server-load-self-fetch-boundary.test.ts
+++ b/src/tests/server-load-self-fetch-boundary.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 

--- a/src/tests/session-cleanup.test.ts
+++ b/src/tests/session-cleanup.test.ts
@@ -1,9 +1,9 @@
-import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 
-spyOn(console, 'log').mockImplementation(() => {});
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
+vi.spyOn(console, 'log').mockImplementation(() => {});
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../lib/server/db/schema.js';
 import { sessions, users } from '../lib/server/db/schema.js';
 
@@ -88,12 +88,12 @@ function daysFromNow(days: number) {
 
 beforeEach(async () => {
 	state.db = setupInMemoryDb();
-	mock.module('../lib/server/db/index.js', () => ({
+	vi.doMock('../lib/server/db/index.js', () => ({
 		getDb: async () => state.db,
 		getDbSync: () => state.db,
 		schema
 	}));
-	mock.module('bcryptjs', () => ({
+	vi.doMock('bcryptjs', () => ({
 		default: {
 			hash: async () => 'hashed_password',
 			compare: async () => true
@@ -110,7 +110,8 @@ beforeEach(async () => {
 
 afterEach(() => {
 	state.db = null;
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('cleanupExpiredSessions', () => {
@@ -138,7 +139,7 @@ describe('cleanupExpiredSessions', () => {
 		const db = state.db!;
 		const userId = await insertUser(db);
 		const now = new Date();
-		const spy = spyOn(Date, 'now').mockReturnValue(now.getTime());
+		const spy = vi.spyOn(Date, 'now').mockReturnValue(now.getTime());
 
 		try {
 			insertSession(db, userId, now);

--- a/src/tests/session-cookie-roundtrip.test.ts
+++ b/src/tests/session-cookie-roundtrip.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { RequestEvent } from '@sveltejs/kit';
 import type { User } from '../lib/server/db/schema.js';
 import { importFresh } from './helpers/import-fresh';
@@ -71,8 +71,8 @@ beforeEach(() => {
 	sessionLifecycleCalls.length = 0;
 	signOutCalls = 0;
 
-	mock.module('$lib/server/logger.js', () => createLoggerModuleStub());
-	mock.module('$lib/server/metrics.js', () => ({
+	vi.doMock('$lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('$lib/server/metrics.js', () => ({
 		httpRequestDurationMicroseconds: {
 			labels: () => ({
 				observe: () => {}
@@ -81,28 +81,28 @@ beforeEach(() => {
 		loginAttemptsTotal: { labels: () => ({ inc: () => {} }) },
 		sessionsCleanedUpTotal: { inc: () => {} }
 	}));
-	mock.module('$lib/server/request/initialization.js', () => ({
+	vi.doMock('$lib/server/request/initialization.js', () => ({
 		ensureGyreInitialized: async () => {},
 		isGyreInitialized: () => true
 	}));
-	mock.module('$lib/server/request/rate-limit.js', () => ({
+	vi.doMock('$lib/server/request/rate-limit.js', () => ({
 		enforceGlobalRateLimit: () => null
 	}));
-	mock.module('$lib/server/request/request-size.js', () => ({
+	vi.doMock('$lib/server/request/request-size.js', () => ({
 		STATE_CHANGING_METHODS: ['POST', 'PUT', 'DELETE', 'PATCH'],
 		createPayloadTooLargeResponse: () => new Response('payload too large', { status: 413 }),
 		enforceRequestSizeLimits: async () => null,
 		isPayloadTooLargeError: () => false
 	}));
-	mock.module('$lib/server/initialize.js', () => ({
+	vi.doMock('$lib/server/initialize.js', () => ({
 		initializeGyre: async () => {}
 	}));
 
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
 
-	mock.module('$lib/server/settings', () =>
+	vi.doMock('$lib/server/settings', () =>
 		createSettingsModuleStub({
 			getAuthSettings: async () => ({
 				localLoginEnabled: true,
@@ -128,29 +128,29 @@ beforeEach(() => {
 		normalizeUsername: (username: string) => username.trim().toLowerCase(),
 		verifyPassword: async () => true
 	};
-	mock.module('$lib/server/auth', () => authModuleStub);
-	mock.module('$lib/server/auth.js', () => authModuleStub);
+	vi.doMock('$lib/server/auth', () => authModuleStub);
+	vi.doMock('$lib/server/auth.js', () => authModuleStub);
 	const auditModuleStub = {
 		logAudit: async () => {},
 		logLogin: async () => {},
 		logLogout: async () => {}
 	};
-	mock.module('$lib/server/audit', () => auditModuleStub);
-	mock.module('$lib/server/audit.js', () => auditModuleStub);
-	mock.module('$lib/server/rbac.js', () =>
+	vi.doMock('$lib/server/audit', () => auditModuleStub);
+	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
+	vi.doMock('$lib/server/rbac.js', () =>
 		createRbacModuleStub({
 			checkClusterWideReadPermission: async () => true
 		})
 	);
-	mock.module('$lib/server/flux/services.js', () => ({
+	vi.doMock('$lib/server/flux/services.js', () => ({
 		getFluxInstalledVersion: async () => ({ version: 'v2.3.0' })
 	}));
-	mock.module('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
-	mock.module('$lib/server/clusters/repository.js', () => ({
+	vi.doMock('$lib/server/kubernetes/errors.js', () => createKubernetesErrorsModuleStub());
+	vi.doMock('$lib/server/clusters/repository.js', () => ({
 		getClusterById: async () => ({ id: 'cluster-a', isActive: true }),
 		getSelectableClusters: async () => []
 	}));
-	mock.module('$lib/server/csrf.js', () => ({
+	vi.doMock('$lib/server/csrf.js', () => ({
 		generateCsrfToken: (sessionId: string) => `csrf:${sessionId}`,
 		validateCsrfToken: (sessionId: string, token: string) => token === `csrf:${sessionId}`
 	}));
@@ -195,12 +195,13 @@ beforeEach(() => {
 			sessionLifecycleCalls.push(`revoke:${cookieValue}`);
 		}
 	};
-	mock.module('$lib/server/auth/better-auth', () => betterAuthModuleStub);
-	mock.module('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth', () => betterAuthModuleStub);
+	vi.doMock('$lib/server/auth/better-auth.js', () => betterAuthModuleStub);
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('session cookie round trip behavior', () => {

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -1,10 +1,10 @@
-import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 
-spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
 
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from '../lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 
@@ -52,10 +52,11 @@ function unsetEnv(key: string) {
 }
 
 beforeEach(async () => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 	state.db = setupInMemoryDb();
 	savedEnv = {};
-	mock.module('../lib/server/db/index.js', () => ({
+	vi.doMock('../lib/server/db/index.js', () => ({
 		getDb: async () => state.db,
 		getDbSync: () => state.db,
 		schema
@@ -83,7 +84,8 @@ afterEach(() => {
 		else process.env[key] = val;
 	}
 	state.db = null;
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/sso-auto-provision.test.ts
+++ b/src/tests/sso-auto-provision.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { importFresh } from './helpers/import-fresh';
 import { createAuthCryptoModuleStub, createLoggerModuleStub } from './helpers/module-stubs';
 
@@ -83,7 +83,7 @@ function createProviderConfig(emailClaim = 'email') {
 beforeEach(async () => {
 	Object.assign(dbState, createDbState());
 
-	mock.module('$lib/server/db', () => ({
+	vi.doMock('$lib/server/db', () => ({
 		getDb: async () => ({
 			query: {
 				accounts: {
@@ -146,27 +146,28 @@ beforeEach(async () => {
 		})
 	}));
 
-	mock.module('$lib/server/auth', () => ({
+	vi.doMock('$lib/server/auth', () => ({
 		generateUserId: () => 'generated-user-id',
 		normalizeUsername: (username: string) => username.toLowerCase().trim(),
 		updateUser: async () => null,
 		deleteUserSessions: async () => {}
 	}));
 
-	mock.module('../lib/server/rbac-defaults.js', () => ({
+	vi.doMock('../lib/server/rbac-defaults.js', () => ({
 		bindUserToDefaultPolicies: async () => {}
 	}));
 
-	mock.module('../lib/server/auth/crypto.js', () => createAuthCryptoModuleStub());
+	vi.doMock('../lib/server/auth/crypto.js', () => createAuthCryptoModuleStub());
 
-	mock.module('../lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('../lib/server/logger.js', () => createLoggerModuleStub());
 
 	createOrUpdateSSOUser = (await importFresh<SSOModule>('../lib/server/auth/sso.js'))
 		.createOrUpdateSSOUser;
 });
 
 afterEach(() => {
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('SSO auto provisioning', () => {
@@ -292,7 +293,7 @@ describe('SSO auto provisioning', () => {
 				emailVerified: false
 			}
 		});
-		expect(dbState.updatedUserSets.some((values) => values.emailVerified === true)).toBeFalse();
+		expect(dbState.updatedUserSets.some((values) => values.emailVerified === true)).toBe(false);
 	});
 
 	test('canonicalizes configured email claims before validating and saving them', async () => {

--- a/src/tests/tsconfig.json
+++ b/src/tests/tsconfig.json
@@ -1,6 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"types": ["bun-types"]
-	}
+	"extends": "../../tsconfig.json"
 }

--- a/src/tests/user-preferences-route.test.ts
+++ b/src/tests/user-preferences-route.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { Database } from 'bun:sqlite';
-import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { eq } from 'drizzle-orm';
 import type { UserPreferences } from '../lib/types/user.js';
 import * as schema from '../lib/server/db/schema.js';
@@ -90,20 +90,20 @@ beforeEach(async () => {
 		schema
 	};
 
-	mock.module('$lib/server/db', () => dbModuleMock);
-	mock.module('$lib/server/db/index.js', () => dbModuleMock);
+	vi.doMock('$lib/server/db', () => dbModuleMock);
+	vi.doMock('$lib/server/db/index.js', () => dbModuleMock);
 	const rateLimiterModuleStub = createRateLimiterModuleStub();
-	mock.module('$lib/server/rate-limiter', () => rateLimiterModuleStub);
-	mock.module('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter', () => rateLimiterModuleStub);
+	vi.doMock('$lib/server/rate-limiter.js', () => rateLimiterModuleStub);
 	const auditModuleStub = {
 		logAudit: async () => {},
 		logLogin: async () => {},
 		logLogout: async () => {},
 		logResourceWrite: async () => {}
 	};
-	mock.module('$lib/server/audit', () => auditModuleStub);
-	mock.module('$lib/server/audit.js', () => auditModuleStub);
-	mock.module('$lib/server/logger.js', () => createLoggerModuleStub());
+	vi.doMock('$lib/server/audit', () => auditModuleStub);
+	vi.doMock('$lib/server/audit.js', () => auditModuleStub);
+	vi.doMock('$lib/server/logger.js', () => createLoggerModuleStub());
 
 	const inMemory = setupInMemoryDb();
 	state.db = inMemory.db;
@@ -117,7 +117,8 @@ afterEach(() => {
 	state.sqlite?.close();
 	state.sqlite = null;
 	state.db = null;
-	mock.restore();
+	vi.restoreAllMocks();
+	vi.resetModules();
 });
 
 describe('user preferences route', () => {

--- a/src/tests/user-preferences.test.ts
+++ b/src/tests/user-preferences.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { mergeUserPreferences, preferencesSchema } from '../lib/server/user-preferences.js';
 
 describe('preferencesSchema', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	},
-	"exclude": ["src/tests"] // Tests use bun-specific globals; they have their own tsconfig at src/tests/tsconfig.json
+	"exclude": ["src/tests"] // Tests have their own tsconfig at src/tests/tsconfig.json
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig(({ mode }) => {
 
 	return {
 		plugins: [tailwindcss(), sveltekit()],
+		test: {
+			environment: 'node',
+			include: ['src/tests/**/*.test.ts']
+		},
 		server: {
 			fs: {
 				// Allow Vite dev server to serve files from the project root so that


### PR DESCRIPTION
## Summary
- migrate the test stack from Bun runtime APIs to Vitest on Node
- replace Bun SQLite/test/runtime helpers with Node-compatible equivalents
- update CI, devcontainer setup, and docs to use Node + pnpm/Vitest
- address review feedback for Node spawn stdio, console spy cleanup, and unique temp backup fixtures

Closes #486

## Verification
- pnpm exec vitest run src/tests/backup-encryption.test.ts src/tests/k8s-client-reliability.test.ts src/tests/request-pipeline-runtime.test.ts
- pnpm format
- pnpm verify:repo:ci
- rg -n "bun:test|bun:sqlite|Bun\\.|bun test|setup-bun|bun install|bun run|@types/bun|bun-types|drizzle-orm/bun-sqlite" .

Note: the Bun-reference scan only reports transitive optional peer metadata for `bun-types` in `pnpm-lock.yaml`; no active docs/config/tests/source references remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated package manager from Bun to pnpm (Corepack-enabled) and updated CI to use pnpm.
  * Switched test runner from Bun to Vitest running on Node.js; test suites and helpers updated accordingly.
  * Updated project scripts to use Vitest.

* **Documentation**
  * Updated README, CONTRIBUTING, and developer docs to reflect Node.js + pnpm + Vitest workflow.

* **Dependencies**
  * Bumped several dev dependencies and added Vitest.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EnTRoPY0120/gyre/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->