### PR TITLE
feat(devcontainer): add contributor development container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
 
 ARG TARGETARCH
+ENV KIND_VERSION=v0.30.0
+ENV FLUX_VERSION=2.8.8
 
 USER root
 
@@ -25,14 +27,30 @@ RUN set -eux; \
 RUN set -eux; \
 	kind_arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
 	case "${kind_arch}" in \
-		amd64|arm64) ;; \
-		*) echo "Unsupported kind architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+		amd64) expected_kind_sha256="517ab7fc89ddeed5fa65abf71530d90648d9638ef0c4cde22c2c11f8097b8889" ;; \
+		arm64) expected_kind_sha256="7ea2de9d2d190022ed4a8a4e3ac0636c8a455e460b9a13ccf19f15d07f4f00eb" ;; \
+		*) echo "Unsupported kind architecture: ${kind_arch}" >&2; exit 1 ;; \
 	esac; \
-	curl -fsSL "https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-${kind_arch}" -o /usr/local/bin/kind; \
-	chmod 0755 /usr/local/bin/kind
+	kind_tmp="$(mktemp)"; \
+	curl -fsSL "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${kind_arch}" -o "${kind_tmp}"; \
+	echo "${expected_kind_sha256}  ${kind_tmp}" | sha256sum -c -; \
+	install -m 0755 "${kind_tmp}" /usr/local/bin/kind; \
+	rm -f "${kind_tmp}"
 
 RUN set -eux; \
-	curl -fsSL https://fluxcd.io/install.sh | bash
+	flux_arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+	case "${flux_arch}" in \
+		amd64) expected_flux_sha256="3791d8fbb73b967ada021186f7b46686a2b180ce206d3c279c3f2ad183877a7f" ;; \
+		arm64) expected_flux_sha256="738604ab040055ace69777988a24def98ada1aff14ae4726e733089dc8cc5e12" ;; \
+		*) echo "Unsupported flux architecture: ${flux_arch}" >&2; exit 1 ;; \
+	esac; \
+	flux_archive="flux_${FLUX_VERSION}_linux_${flux_arch}.tar.gz"; \
+	flux_tmp_dir="$(mktemp -d)"; \
+	curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/${flux_archive}" -o "${flux_tmp_dir}/${flux_archive}"; \
+	echo "${expected_flux_sha256}  ${flux_tmp_dir}/${flux_archive}" | sha256sum -c -; \
+	tar -xzf "${flux_tmp_dir}/${flux_archive}" -C "${flux_tmp_dir}" flux; \
+	install -m 0755 "${flux_tmp_dir}/flux" /usr/local/bin/flux; \
+	rm -rf "${flux_tmp_dir}"
 
 RUN npm install --global pnpm@11.1.0
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
+
+ARG TARGETARCH
+
+USER root
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		apt-transport-https \
+		ca-certificates \
+		curl \
+		gnupg; \
+	mkdir -p /etc/apt/keyrings; \
+	curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg; \
+	echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /" > /etc/apt/sources.list.d/kubernetes.list; \
+	curl -fsSL https://baltocdn.com/helm/signing.asc | gpg --dearmor -o /etc/apt/keyrings/helm.gpg; \
+	echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" > /etc/apt/sources.list.d/helm-stable-debian.list; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		helm \
+		kubectl; \
+	rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+	kind_arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+	case "${kind_arch}" in \
+		amd64|arm64) ;; \
+		*) echo "Unsupported kind architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+	esac; \
+	curl -fsSL "https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-${kind_arch}" -o /usr/local/bin/kind; \
+	chmod 0755 /usr/local/bin/kind
+
+RUN set -eux; \
+	curl -fsSL https://fluxcd.io/install.sh | bash
+
+RUN npm install --global pnpm@11.1.0
+
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,17 @@
 {
 	"name": "Gyre Dev",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"remoteUser": "node",
+	"forwardPorts": [3000],
+	"portsAttributes": {
+		"3000": {
+			"label": "Gyre dev server"
+		}
+	},
 	"mounts": ["source=${localEnv:HOME}/.kube,target=/home/node/.kube,type=bind,readonly"],
-	"postCreateCommand": "bash -lc 'set -euo pipefail; corepack enable; corepack prepare pnpm@11.1.0 --activate; pnpm install'",
+	"postCreateCommand": "bash .devcontainer/post-create.sh",
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -16,7 +24,11 @@
 				"editor.formatOnSave": true,
 				"files.associations": {
 					"*.yaml": "yaml",
-					"*.yml": "yaml"
+					"*.yml": "yaml",
+					"*.gotmpl": "yaml"
+				},
+				"yaml.schemas": {
+					"https://json.schemastore.org/github-workflow.json": ".github/workflows/*.{yml,yaml}"
 				}
 			}
 		}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Node: $(node --version)"
+echo "pnpm: $(pnpm --version)"
+
+node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 13)) { throw new Error('Node.js >=22.13 is required'); }"
+test "$(pnpm --version)" = "11.1.0"
+
+if command -v kubectl >/dev/null 2>&1; then
+	kubectl version --client=true
+else
+	echo "kubectl: not installed"
+fi
+
+if command -v helm >/dev/null 2>&1; then
+	helm version --short
+else
+	echo "helm: not installed"
+fi
+
+if command -v kind >/dev/null 2>&1; then
+	kind version
+else
+	echo "kind: not installed"
+fi
+
+if command -v flux >/dev/null 2>&1; then
+	flux --version
+else
+	echo "flux: not installed"
+fi
+
+pnpm install --frozen-lockfile
+
+# Optional local cluster setup, run manually only when needed:
+# kind create cluster --name gyre
+# flux install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,15 +8,17 @@ Comprehensive contributing guidelines, including development setup, code standar
 
 ## Quick Start (DevContainer)
 
-If using a local devcontainer setup, ensure it installs Node.js and pnpm 11.1.0.
+The repository includes a devcontainer that installs Node.js 22.13+, `pnpm@11.1.0`, and Kubernetes tooling.
 
 1. Open the repository in VS Code with the **Dev Containers** extension.
 2. Press `F1` → **"Dev Containers: Reopen in Container"**.
-3. Inside the container, run:
+3. Wait for `.devcontainer/post-create.sh` to install dependencies.
+4. Inside the container, run:
    ```bash
-   pnpm install
    pnpm dev
    ```
+
+The host kubeconfig is mounted read-only from `~/.kube`; use an existing cluster or create one manually with `kind` and `flux` when needed.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ From a local checkout, run:
 ./scripts/demo.sh
 ```
 
+### Development Container
+
+For a standardized contributor environment, open the repository in VS Code with the Dev Containers extension and run **Dev Containers: Reopen in Container** from the command palette.
+
+The container uses Node.js 22.13+, installs `pnpm@11.1.0`, includes Kubernetes tooling (`kubectl`, `helm`, `kind`, and `flux`), and runs `pnpm install --frozen-lockfile` from `.devcontainer/post-create.sh`.
+
+Start the app inside the container with:
+
+```bash
+pnpm dev
+```
+
+Port `3000` is forwarded automatically. Your host kubeconfig is mounted read-only from `~/.kube` to `/home/node/.kube`, so you can use an existing cluster or manually create one with `kind` and install Flux when needed.
+
 ### Get Admin Credentials (for in-cluster installs)
 
 ```bash

--- a/documentation/docs/contributing.md
+++ b/documentation/docs/contributing.md
@@ -17,18 +17,20 @@ Thank you for your interest in contributing to Gyre! This document outlines the 
 
 ### Quick Start (DevContainer - Recommended)
 
-If using a local devcontainer setup, ensure it installs Node.js and pnpm 11.1.0.
+The repository includes a devcontainer that installs Node.js 22.13+, `pnpm@11.1.0`, and Kubernetes tooling.
 
 1. Open the repository in VS Code with the Dev Containers extension
 2. Press `F1` → "Dev Containers: Reopen in Container"
-3. Optional: Create a local kind cluster with FluxCD for testing
+3. Wait for `.devcontainer/post-create.sh` to install dependencies
 
 ```bash
 # Inside devcontainer, start development server
-pnpm install
 pnpm dev
+```
 
-# Optional: Create test cluster
+The host kubeconfig is mounted read-only from `~/.kube`. Use an existing cluster or create a local kind cluster with FluxCD manually when needed:
+
+```bash
 kind create cluster
 flux install
 ```

--- a/documentation/docs/development.md
+++ b/documentation/docs/development.md
@@ -20,18 +20,20 @@ Gyre is a modern, full-featured WebUI for FluxCD built with SvelteKit. It provid
 
 **DevContainer (Recommended):**
 
-If using a local devcontainer setup, ensure it installs Node.js and pnpm 11.1.0.
+The repository includes a devcontainer that installs Node.js 22.13+, `pnpm@11.1.0`, and Kubernetes tooling.
 
 1. Open repository in VS Code with Dev Containers extension
 2. Press `F1` → "Dev Containers: Reopen in Container"
-3. Optional: Create local kind cluster with FluxCD for testing
+3. Wait for `.devcontainer/post-create.sh` to install dependencies
 
 ```sh
 # Inside devcontainer, start development server
-pnpm install
 pnpm dev
+```
 
-# Optional: Create test cluster
+The host kubeconfig is mounted read-only from `~/.kube`. Use an existing cluster or create a local kind cluster with FluxCD manually when needed:
+
+```sh
 kind create cluster
 flux install
 ```


### PR DESCRIPTION
## Summary

- Add a current-repo devcontainer for Node.js 22.13+ and pnpm 11.1.0
- Install Kubernetes tooling: kubectl, helm, kind, and flux
- Move the root devcontainer config into .devcontainer/ and document usage

Closes #7

## Verification

- bash -n .devcontainer/post-create.sh
- node -e "JSON.parse(require('fs').readFileSync('.devcontainer/devcontainer.json', 'utf8')); console.log('devcontainer json ok')"
- npx --yes pnpm@11.1.0 verify:repo:ci

## Note

- docker build -f .devcontainer/Dockerfile .devcontainer could not be completed locally because this session did not have permission to access /var/run/docker.sock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated getting-started and development docs plus README with standardized Dev Container setup, tooling versions, and read-only host kubeconfig guidance.

* **Chores**
  * Added a containerized development environment with Node.js 22.13+, pnpm 11.1.0, and Kubernetes tooling; container runs dependency install via a post-create step and forwards port 3000.

* **New Features**
  * VS Code settings extended (YAML schemas and *.gotmpl file association) and a post-create script validates tooling versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EnTRoPY0120/gyre/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->