### PR TITLE
fix: break event poller import cycle

### DIFF
--- a/src/lib/server/events.ts
+++ b/src/lib/server/events.ts
@@ -1,5 +1,6 @@
 export * from './events/types.js';
 export * from './events/state.js';
+export * from './events/dispatcher.js';
 export * from './events/bus.js';
 export * from './events/poller.js';
 export * from './events/shutdown.js';

--- a/src/lib/server/events/bus.ts
+++ b/src/lib/server/events/bus.ts
@@ -4,7 +4,8 @@ import { HEARTBEAT_INTERVAL_MS } from '../config/constants.js';
 import { activeWorkers, isEventBusShuttingDown, SERVER_SESSION_ID } from './state.js';
 import { activeWorkersGauge, fluxResourceStatusGauge, sseSubscribersGauge } from '../metrics.js';
 import { poll } from './poller.js';
-import { normalizeError, type ClusterContext, type SSEEvent, type Subscriber } from './types.js';
+import { broadcast } from './dispatcher.js';
+import { normalizeError, type ClusterContext, type Subscriber } from './types.js';
 
 /**
  * Subscribe to events for a specific cluster
@@ -123,26 +124,4 @@ export function stopWorker(context: ClusterContext, reason: string = 'no active 
 		{ clusterId: context.clusterId, reason },
 		'[EventBus] Stopping consolidated polling worker'
 	);
-}
-
-export function broadcast(context: ClusterContext, event: SSEEvent) {
-	// The loop is fault-tolerant: if a subscriber callback throws (e.g. during SHUTDOWN due to a closed stream),
-	// it is caught and logged, ensuring remaining subscribers still receive the event.
-	for (const subscriber of context.subscribers) {
-		try {
-			subscriber(event);
-		} catch (err) {
-			if (event.type === 'SHUTDOWN') {
-				logger.debug(
-					{ clusterId: context.clusterId, err: normalizeError(err) },
-					'[EventBus] Error broadcasting SHUTDOWN to subscriber'
-				);
-			} else {
-				logger.error(
-					{ clusterId: context.clusterId, err: normalizeError(err) },
-					'[EventBus] Error broadcasting to subscriber'
-				);
-			}
-		}
-	}
 }

--- a/src/lib/server/events/dispatcher.ts
+++ b/src/lib/server/events/dispatcher.ts
@@ -1,0 +1,24 @@
+import { logger } from '../logger.js';
+import { normalizeError, type ClusterContext, type SSEEvent } from './types.js';
+
+export function broadcast(context: ClusterContext, event: SSEEvent) {
+	// The loop is fault-tolerant: if a subscriber callback throws (e.g. during SHUTDOWN due to a closed stream),
+	// it is caught and logged, ensuring remaining subscribers still receive the event.
+	for (const subscriber of context.subscribers) {
+		try {
+			subscriber(event);
+		} catch (err) {
+			if (event.type === 'SHUTDOWN') {
+				logger.debug(
+					{ clusterId: context.clusterId, err: normalizeError(err) },
+					'[EventBus] Error broadcasting SHUTDOWN to subscriber'
+				);
+			} else {
+				logger.error(
+					{ clusterId: context.clusterId, err: normalizeError(err) },
+					'[EventBus] Error broadcasting to subscriber'
+				);
+			}
+		}
+	}
+}

--- a/src/lib/server/events/poller.ts
+++ b/src/lib/server/events/poller.ts
@@ -6,7 +6,7 @@ import type { FluxResource, K8sCondition } from '../kubernetes/flux/types.js';
 import { resourcePollsTotal, resourceUpdatesTotal, fluxResourceStatusGauge } from '../metrics.js';
 import { captureReconciliation } from '../kubernetes/flux/reconciliation-tracker.js';
 import { POLL_INTERVAL_MS, SETTLING_PERIOD_MS } from '../config/constants.js';
-import { broadcast } from './bus.js';
+import { broadcast } from './dispatcher.js';
 import { normalizeError, type ClusterContext } from './types.js';
 
 const WATCH_RESOURCES: FluxResourceType[] = [

--- a/src/lib/server/events/shutdown.ts
+++ b/src/lib/server/events/shutdown.ts
@@ -1,7 +1,8 @@
 import { logger } from '../logger.js';
 import { activeWorkers, setEventBusShuttingDown } from './state.js';
 import { activeWorkersGauge, sseSubscribersGauge } from '../metrics.js';
-import { broadcast, stopWorker } from './bus.js';
+import { stopWorker } from './bus.js';
+import { broadcast } from './dispatcher.js';
 import { normalizeError } from './types.js';
 
 export { setEventBusShuttingDown } from './state.js';


### PR DESCRIPTION
Closes #521

## Summary
- move event broadcasting into a dispatcher module
- remove the bus.ts <-> poller.ts circular import
- preserve existing event polling and publishing behavior

## Verification
- pnpm format:check
- pnpm lint
- pnpm check
- pnpm test
- pnpm build
- pnpm verify:repo:ci
- npx fallow dead-code confirms circular_dependencies is 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal event handling architecture to improve code modularity and maintainability. No changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EnTRoPY0120/gyre/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->