### PR TITLE
refactor(server): split event poller hotspot

### DIFF
--- a/src/lib/server/events/poller.ts
+++ b/src/lib/server/events/poller.ts
@@ -27,213 +27,8 @@ export async function poll(context: ClusterContext) {
 
 	try {
 		for (const resourceType of WATCH_RESOURCES) {
-			try {
-				// Pass clusterId to listFluxResources to get resources from the correct cluster
-				const resourceList = await listFluxResources(
-					resourceType,
-					context.clusterId === IN_CLUSTER_ID ? undefined : context.clusterId
-				);
-
-				if (!context.isActive) return;
-
-				resourcePollsTotal.labels(context.clusterId, resourceType, 'success').inc();
-
-				if (resourceList && resourceList.items) {
-					const currentMessageKeys = new Set<string>();
-
-					for (const resource of resourceList.items) {
-						const key = `${resourceType}/${resource.metadata.namespace}/${resource.metadata.name}`;
-						currentMessageKeys.add(key);
-
-						const conditions = resource.status?.conditions?.map((c: K8sCondition) => ({
-							type: c.type,
-							status: c.status,
-							reason: c.reason,
-							message: c.message
-						}));
-
-						const currentState = JSON.stringify({
-							resourceVersion: resource.metadata?.resourceVersion,
-							generation: resource.metadata?.generation,
-							observedGeneration: resource.status?.observedGeneration
-						});
-
-						const readyCondition = conditions?.find((c: { type: string }) => c.type === 'Ready');
-
-						// Update resource status gauge
-						fluxResourceStatusGauge
-							.labels(
-								context.clusterId,
-								resourceType,
-								resource.metadata.namespace || 'unknown',
-								resource.metadata.name || 'unknown',
-								'Ready'
-							)
-							.set(readyCondition?.status === 'True' ? 1 : 0);
-
-						const revision = getResourceRevision(resource);
-
-						const notificationState = JSON.stringify({
-							revision: revision,
-							readyStatus: readyCondition?.status,
-							readyReason: readyCondition?.reason,
-							messagePreview: readyCondition?.message?.substring(0, 100) || ''
-						});
-
-						const previousState = context.lastStates.get(key);
-
-						const now = Date.now();
-						// Only record firstSeen for resources not yet in lastStates.
-						// Resources in lastStates but missing from resourceFirstSeen had their
-						// entry pruned after settling — treat them as already settled.
-						if (!context.resourceFirstSeen.has(key) && !context.lastStates.has(key)) {
-							context.resourceFirstSeen.set(key, now);
-						}
-						const isSettled = context.resourceFirstSeen.has(key)
-							? now - context.resourceFirstSeen.get(key)! > SETTLING_PERIOD_MS
-							: true; // no firstSeen entry + exists in lastStates = already settled
-
-						if (!previousState) {
-							if (isSettled) {
-								resourceUpdatesTotal.labels(context.clusterId, resourceType, 'added').inc();
-
-								// Capture initial reconciliation history
-								try {
-									await captureReconciliation({
-										resourceType,
-										namespace: resource.metadata.namespace || '',
-										name: resource.metadata.name || '',
-										clusterId: context.clusterId,
-										resource,
-										triggerType: 'automatic'
-									});
-								} catch (err) {
-									logger.error(
-										{
-											err: normalizeError(err),
-											resourceType,
-											resourceName: resource.metadata.name,
-											namespace: resource.metadata.namespace
-										},
-										'[EventBus] Failed to capture reconciliation history'
-									);
-									// Don't fail event broadcast if history capture fails
-								}
-
-								if (!context.isActive) return;
-
-								broadcast(context, {
-									type: 'ADDED',
-									clusterId: context.clusterId,
-									resourceType,
-									resource: {
-										metadata: {
-											name: resource.metadata.name,
-											namespace: resource.metadata.namespace,
-											uid: resource.metadata.uid || 'unknown'
-										},
-										status: resource.status
-									},
-									timestamp: new Date().toISOString()
-								});
-
-								context.lastStates.set(key, currentState);
-								context.lastNotificationStates.set(key, notificationState);
-								context.resourceFirstSeen.delete(key);
-							}
-						} else if (previousState && previousState !== currentState) {
-							const previousNotificationState = context.lastNotificationStates.get(key);
-
-							if (!previousNotificationState || previousNotificationState !== notificationState) {
-								const prevState = previousNotificationState
-									? JSON.parse(previousNotificationState)
-									: {};
-								const currState = JSON.parse(notificationState);
-
-								const revisionChanged = prevState.revision !== currState.revision;
-								const becameFailed = currState.readyStatus === 'False';
-								const becameHealthy =
-									prevState.readyStatus === 'False' && currState.readyStatus === 'True';
-								const isTransientState =
-									!currState.readyStatus || currState.readyStatus === 'Unknown';
-
-								const shouldNotify = revisionChanged || becameFailed || becameHealthy;
-
-								if (shouldNotify && !isTransientState) {
-									resourceUpdatesTotal.labels(context.clusterId, resourceType, 'modified').inc();
-
-									// Capture reconciliation history
-									try {
-										await captureReconciliation({
-											resourceType,
-											namespace: resource.metadata.namespace || '',
-											name: resource.metadata.name || '',
-											clusterId: context.clusterId,
-											resource,
-											triggerType: 'automatic'
-										});
-									} catch (err) {
-										logger.error(
-											{
-												err: normalizeError(err),
-												resourceType,
-												resourceName: resource.metadata.name,
-												namespace: resource.metadata.namespace
-											},
-											'[EventBus] Failed to capture reconciliation history'
-										);
-										// Don't fail event broadcast if history capture fails
-									}
-
-									if (!context.isActive) return;
-
-									broadcast(context, {
-										type: 'MODIFIED',
-										clusterId: context.clusterId,
-										resourceType,
-										resource: {
-											metadata: {
-												name: resource.metadata.name,
-												namespace: resource.metadata.namespace,
-												uid: resource.metadata.uid || 'unknown'
-											},
-											status: resource.status
-										},
-										timestamp: new Date().toISOString()
-									});
-								}
-								if (!isTransientState) {
-									context.lastNotificationStates.set(key, notificationState);
-								}
-							}
-
-							context.lastStates.set(key, currentState);
-						}
-					}
-
-					for (const key of Array.from(context.lastStates.keys())) {
-						if (key.startsWith(`${resourceType}/`) && !currentMessageKeys.has(key)) {
-							broadcastDeletedResource(context, key);
-						}
-					}
-
-					for (const key of Array.from(context.resourceFirstSeen.keys())) {
-						if (
-							key.startsWith(`${resourceType}/`) &&
-							!currentMessageKeys.has(key) &&
-							!context.lastStates.has(key)
-						) {
-							broadcastDeletedResource(context, key);
-						}
-					}
-				}
-			} catch (err) {
-				resourcePollsTotal.labels(context.clusterId, resourceType, 'error').inc();
-				logger.error(
-					{ clusterId: context.clusterId, resourceType, err: normalizeError(err) },
-					'[EventBus] Error polling resource type'
-				);
-			}
+			const shouldContinue = await pollResourceType(context, resourceType);
+			if (!shouldContinue) return;
 		}
 	} catch (err) {
 		logger.error(
@@ -248,6 +43,300 @@ export async function poll(context: ClusterContext) {
 	if (context.isActive) {
 		context.pollTimeout = setTimeout(() => poll(context), POLL_INTERVAL_MS);
 	}
+}
+
+async function pollResourceType(
+	context: ClusterContext,
+	resourceType: FluxResourceType
+): Promise<boolean> {
+	try {
+		// Pass clusterId to listFluxResources to get resources from the correct cluster
+		const resourceList = await listFluxResources(
+			resourceType,
+			context.clusterId === IN_CLUSTER_ID ? undefined : context.clusterId
+		);
+
+		if (!context.isActive) return false;
+
+		resourcePollsTotal.labels(context.clusterId, resourceType, 'success').inc();
+
+		if (resourceList && resourceList.items) {
+			return processResourceItems(context, resourceType, resourceList.items);
+		}
+	} catch (err) {
+		resourcePollsTotal.labels(context.clusterId, resourceType, 'error').inc();
+		logger.error(
+			{ clusterId: context.clusterId, resourceType, err: normalizeError(err) },
+			'[EventBus] Error polling resource type'
+		);
+	}
+
+	return true;
+}
+
+async function processResourceItems(
+	context: ClusterContext,
+	resourceType: FluxResourceType,
+	items: FluxResource[]
+): Promise<boolean> {
+	const currentKeys = new Set<string>();
+
+	for (const resource of items) {
+		const shouldContinue = await processResource(context, resourceType, resource, currentKeys);
+		if (!shouldContinue) return false;
+	}
+
+	pruneMissingResources(context, resourceType, currentKeys);
+	return true;
+}
+
+async function processResource(
+	context: ClusterContext,
+	resourceType: FluxResourceType,
+	resource: FluxResource,
+	currentKeys: Set<string>
+): Promise<boolean> {
+	const key = buildResourceKey(resourceType, resource);
+	currentKeys.add(key);
+
+	const readyCondition = getReadyCondition(resource);
+
+	fluxResourceStatusGauge
+		.labels(
+			context.clusterId,
+			resourceType,
+			resource.metadata.namespace || 'unknown',
+			resource.metadata.name || 'unknown',
+			'Ready'
+		)
+		.set(readyCondition?.status === 'True' ? 1 : 0);
+
+	const currentState = buildResourceState(resource);
+	const notificationState = buildNotificationState(resource);
+	const previousState = context.lastStates.get(key);
+	const now = Date.now();
+
+	if (!context.resourceFirstSeen.has(key) && !context.lastStates.has(key)) {
+		context.resourceFirstSeen.set(key, now);
+	}
+
+	if (!previousState) {
+		if (!isResourceSettled(context, key, now)) return true;
+
+		return handleAddedResource(context, {
+			resourceType,
+			resource,
+			key,
+			currentState,
+			notificationState
+		});
+	}
+
+	if (previousState !== currentState) {
+		const shouldContinue = await handleModifiedResource(context, {
+			resourceType,
+			resource,
+			key,
+			currentState,
+			notificationState
+		});
+		if (!shouldContinue) return false;
+	}
+
+	return true;
+}
+
+interface ResourceChangeDetails {
+	resourceType: FluxResourceType;
+	resource: FluxResource;
+	key: string;
+	currentState: string;
+	notificationState: string;
+}
+
+async function handleAddedResource(
+	context: ClusterContext,
+	details: ResourceChangeDetails
+): Promise<boolean> {
+	const { resourceType, resource, key, currentState, notificationState } = details;
+
+	resourceUpdatesTotal.labels(context.clusterId, resourceType, 'added').inc();
+	await captureReconciliationSafely(context, resourceType, resource);
+
+	if (!context.isActive) return false;
+
+	broadcastResourceChange(context, 'ADDED', resourceType, resource);
+	context.lastStates.set(key, currentState);
+	context.lastNotificationStates.set(key, notificationState);
+	context.resourceFirstSeen.delete(key);
+
+	return true;
+}
+
+async function handleModifiedResource(
+	context: ClusterContext,
+	details: ResourceChangeDetails
+): Promise<boolean> {
+	const { resourceType, resource, key, currentState, notificationState } = details;
+	const previousNotificationState = context.lastNotificationStates.get(key);
+
+	if (!previousNotificationState || previousNotificationState !== notificationState) {
+		const { shouldNotify, isTransientState } = shouldNotifyModified(
+			previousNotificationState,
+			notificationState
+		);
+
+		if (shouldNotify && !isTransientState) {
+			resourceUpdatesTotal.labels(context.clusterId, resourceType, 'modified').inc();
+			await captureReconciliationSafely(context, resourceType, resource);
+
+			if (!context.isActive) return false;
+
+			broadcastResourceChange(context, 'MODIFIED', resourceType, resource);
+		}
+
+		if (!isTransientState) {
+			context.lastNotificationStates.set(key, notificationState);
+		}
+	}
+
+	context.lastStates.set(key, currentState);
+	return true;
+}
+
+function pruneMissingResources(
+	context: ClusterContext,
+	resourceType: FluxResourceType,
+	currentKeys: Set<string>
+): void {
+	for (const key of Array.from(context.lastStates.keys())) {
+		if (key.startsWith(`${resourceType}/`) && !currentKeys.has(key)) {
+			broadcastDeletedResource(context, key);
+		}
+	}
+
+	for (const key of Array.from(context.resourceFirstSeen.keys())) {
+		if (
+			key.startsWith(`${resourceType}/`) &&
+			!currentKeys.has(key) &&
+			!context.lastStates.has(key)
+		) {
+			broadcastDeletedResource(context, key);
+		}
+	}
+}
+
+async function captureReconciliationSafely(
+	context: ClusterContext,
+	resourceType: FluxResourceType,
+	resource: FluxResource
+): Promise<void> {
+	try {
+		await captureReconciliation({
+			resourceType,
+			namespace: resource.metadata.namespace || '',
+			name: resource.metadata.name || '',
+			clusterId: context.clusterId,
+			resource,
+			triggerType: 'automatic'
+		});
+	} catch (err) {
+		logger.error(
+			{
+				err: normalizeError(err),
+				resourceType,
+				resourceName: resource.metadata.name,
+				namespace: resource.metadata.namespace
+			},
+			'[EventBus] Failed to capture reconciliation history'
+		);
+		// Don't fail event broadcast if history capture fails
+	}
+}
+
+function broadcastResourceChange(
+	context: ClusterContext,
+	type: 'ADDED' | 'MODIFIED',
+	resourceType: FluxResourceType,
+	resource: FluxResource
+): void {
+	broadcast(context, {
+		type,
+		clusterId: context.clusterId,
+		resourceType,
+		resource: {
+			metadata: {
+				name: resource.metadata.name,
+				namespace: resource.metadata.namespace,
+				uid: resource.metadata.uid || 'unknown'
+			},
+			status: resource.status
+		},
+		timestamp: new Date().toISOString()
+	});
+}
+
+function buildResourceKey(resourceType: FluxResourceType, resource: FluxResource): string {
+	return `${resourceType}/${resource.metadata.namespace}/${resource.metadata.name}`;
+}
+
+function buildResourceState(resource: FluxResource): string {
+	return JSON.stringify({
+		resourceVersion: resource.metadata?.resourceVersion,
+		generation: resource.metadata?.generation,
+		observedGeneration: resource.status?.observedGeneration
+	});
+}
+
+function buildNotificationState(resource: FluxResource): string {
+	const readyCondition = getReadyCondition(resource);
+
+	return JSON.stringify({
+		revision: getResourceRevision(resource),
+		readyStatus: readyCondition?.status,
+		readyReason: readyCondition?.reason,
+		messagePreview: readyCondition?.message?.substring(0, 100) || ''
+	});
+}
+
+function getReadyCondition(
+	resource: FluxResource
+): Pick<K8sCondition, 'type' | 'status' | 'reason' | 'message'> | undefined {
+	const readyCondition = resource.status?.conditions?.find(
+		(condition) => condition.type === 'Ready'
+	);
+	if (!readyCondition) return undefined;
+
+	return {
+		type: readyCondition.type,
+		status: readyCondition.status,
+		reason: readyCondition.reason,
+		message: readyCondition.message
+	};
+}
+
+function isResourceSettled(context: ClusterContext, key: string, now: number): boolean {
+	return context.resourceFirstSeen.has(key)
+		? now - context.resourceFirstSeen.get(key)! > SETTLING_PERIOD_MS
+		: true;
+}
+
+function shouldNotifyModified(
+	previousNotificationState: string | undefined,
+	notificationState: string
+): { shouldNotify: boolean; isTransientState: boolean } {
+	const prevState = previousNotificationState ? JSON.parse(previousNotificationState) : {};
+	const currState = JSON.parse(notificationState);
+
+	const revisionChanged = prevState.revision !== currState.revision;
+	const becameFailed = currState.readyStatus === 'False';
+	const becameHealthy = prevState.readyStatus === 'False' && currState.readyStatus === 'True';
+	const isTransientState = !currState.readyStatus || currState.readyStatus === 'Unknown';
+
+	return {
+		shouldNotify: revisionChanged || becameFailed || becameHealthy,
+		isTransientState
+	};
 }
 
 function broadcastDeletedResource(context: ClusterContext, key: string) {

--- a/src/lib/server/events/poller.ts
+++ b/src/lib/server/events/poller.ts
@@ -61,7 +61,7 @@ async function pollResourceType(
 		resourcePollsTotal.labels(context.clusterId, resourceType, 'success').inc();
 
 		if (resourceList && resourceList.items) {
-			return processResourceItems(context, resourceType, resourceList.items);
+			return await processResourceItems(context, resourceType, resourceList.items);
 		}
 	} catch (err) {
 		resourcePollsTotal.labels(context.clusterId, resourceType, 'error').inc();
@@ -216,12 +216,12 @@ function pruneMissingResources(
 	}
 
 	for (const key of Array.from(context.resourceFirstSeen.keys())) {
-		if (
-			key.startsWith(`${resourceType}/`) &&
-			!currentKeys.has(key) &&
-			!context.lastStates.has(key)
-		) {
-			broadcastDeletedResource(context, key);
+		if (key.startsWith(`${resourceType}/`) && !currentKeys.has(key)) {
+			if (context.lastStates.has(key)) {
+				broadcastDeletedResource(context, key);
+			} else {
+				cleanupResourceState(context, key);
+			}
 		}
 	}
 }
@@ -342,9 +342,6 @@ function shouldNotifyModified(
 function broadcastDeletedResource(context: ClusterContext, key: string) {
 	const [type, namespace, name] = key.split('/');
 
-	// Clear status gauge
-	fluxResourceStatusGauge.remove(context.clusterId, type, namespace, name, 'Ready');
-
 	resourceUpdatesTotal.labels(context.clusterId, type, 'deleted').inc();
 	broadcast(context, {
 		type: 'DELETED',
@@ -360,6 +357,13 @@ function broadcastDeletedResource(context: ClusterContext, key: string) {
 		timestamp: new Date().toISOString()
 	});
 
+	cleanupResourceState(context, key);
+}
+
+function cleanupResourceState(context: ClusterContext, key: string) {
+	const [type, namespace, name] = key.split('/');
+
+	fluxResourceStatusGauge.remove(context.clusterId, type, namespace, name, 'Ready');
 	context.lastStates.delete(key);
 	context.lastNotificationStates.delete(key);
 	context.resourceFirstSeen.delete(key);

--- a/src/lib/server/events/poller.ts
+++ b/src/lib/server/events/poller.ts
@@ -58,11 +58,13 @@ async function pollResourceType(
 
 		if (!context.isActive) return false;
 
-		resourcePollsTotal.labels(context.clusterId, resourceType, 'success').inc();
-
 		if (resourceList && resourceList.items) {
-			return await processResourceItems(context, resourceType, resourceList.items);
+			const shouldContinue = await processResourceItems(context, resourceType, resourceList.items);
+			resourcePollsTotal.labels(context.clusterId, resourceType, 'success').inc();
+			return shouldContinue;
 		}
+
+		resourcePollsTotal.labels(context.clusterId, resourceType, 'success').inc();
 	} catch (err) {
 		resourcePollsTotal.labels(context.clusterId, resourceType, 'error').inc();
 		logger.error(

--- a/src/tests/events.test.ts
+++ b/src/tests/events.test.ts
@@ -20,11 +20,8 @@ let mockCaptureReconciliation: ReturnType<typeof vi.fn>;
 let pollMetricIncrements: Array<{ clusterId: string; resourceType: string; status: string }>;
 let throwOnStatusGaugeSet = false;
 
-beforeEach(async () => {
-	mockResources = [];
-	mockCaptureReconciliation = vi.fn(async () => {});
-	pollMetricIncrements = [];
-	throwOnStatusGaugeSet = false;
+function applyEventMocks(opts: { settlingPeriodMs: number; gaugeThrows?: boolean }) {
+	throwOnStatusGaugeSet = opts.gaugeThrows ?? false;
 	vi.doMock('../lib/server/kubernetes/client.js', () => ({
 		...actualClient,
 		listFluxResources: async () => ({ items: mockResources })
@@ -53,13 +50,20 @@ beforeEach(async () => {
 	}));
 	vi.doMock('../lib/server/config/constants.js', () => ({
 		...actualConstants,
-		SETTLING_PERIOD_MS: -1,
+		SETTLING_PERIOD_MS: opts.settlingPeriodMs,
 		POLL_INTERVAL_MS: 50,
 		HEARTBEAT_INTERVAL_MS: 10000
 	}));
 	vi.doMock('../lib/server/logger.js', () => ({
 		logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
 	}));
+}
+
+beforeEach(async () => {
+	mockResources = [];
+	mockCaptureReconciliation = vi.fn(async () => {});
+	pollMetricIncrements = [];
+	applyEventMocks({ settlingPeriodMs: -1 });
 	const eventsModule = await importFresh<EventsModule>('../lib/server/events.js');
 	subscribe = eventsModule.subscribe;
 	closeAllEventStreams = eventsModule.closeAllEventStreams;
@@ -236,6 +240,14 @@ describe('Poll change detection', () => {
 						metric.status === 'error'
 				)
 			).toBe(true);
+			expect(
+				pollMetricIncrements.some(
+					(metric) =>
+						metric.clusterId === clusterId &&
+						metric.resourceType === 'GitRepository' &&
+						metric.status === 'success'
+				)
+			).toBe(false);
 		} finally {
 			unsub();
 		}
@@ -312,30 +324,7 @@ describe('Poll change detection', () => {
 
 	test('resource removed before settling is cleaned up without DELETED broadcast', async () => {
 		vi.resetModules();
-		vi.doMock('../lib/server/kubernetes/client.js', () => ({
-			...actualClient,
-			listFluxResources: async () => ({ items: mockResources })
-		}));
-		vi.doMock('../lib/server/metrics.js', () => ({
-			...actualMetrics,
-			resourcePollsTotal: { labels: () => ({ inc: () => {} }) },
-			resourceUpdatesTotal: { labels: () => ({ inc: () => {} }) },
-			sseSubscribersGauge: { labels: () => ({ set: () => {} }), reset: () => {} },
-			activeWorkersGauge: { set: () => {} },
-			fluxResourceStatusGauge: { labels: () => ({ set: () => {} }), remove: () => {} }
-		}));
-		vi.doMock('../lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
-			captureReconciliation: mockCaptureReconciliation
-		}));
-		vi.doMock('../lib/server/config/constants.js', () => ({
-			...actualConstants,
-			SETTLING_PERIOD_MS: 60_000,
-			POLL_INTERVAL_MS: 50,
-			HEARTBEAT_INTERVAL_MS: 10000
-		}));
-		vi.doMock('../lib/server/logger.js', () => ({
-			logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
-		}));
+		applyEventMocks({ settlingPeriodMs: 60_000 });
 		const eventsModule = await importFresh<EventsModule>('../lib/server/events.js');
 		const subscribeWithSettling = eventsModule.subscribe;
 

--- a/src/tests/events.test.ts
+++ b/src/tests/events.test.ts
@@ -17,21 +17,36 @@ let subscribe: EventsModule['subscribe'];
 let closeAllEventStreams: EventsModule['closeAllEventStreams'];
 let setEventBusShuttingDown: EventsModule['setEventBusShuttingDown'];
 let mockCaptureReconciliation: ReturnType<typeof vi.fn>;
+let pollMetricIncrements: Array<{ clusterId: string; resourceType: string; status: string }>;
+let throwOnStatusGaugeSet = false;
 
 beforeEach(async () => {
 	mockResources = [];
 	mockCaptureReconciliation = vi.fn(async () => {});
+	pollMetricIncrements = [];
+	throwOnStatusGaugeSet = false;
 	vi.doMock('../lib/server/kubernetes/client.js', () => ({
 		...actualClient,
 		listFluxResources: async () => ({ items: mockResources })
 	}));
 	vi.doMock('../lib/server/metrics.js', () => ({
 		...actualMetrics,
-		resourcePollsTotal: { labels: () => ({ inc: () => {} }) },
+		resourcePollsTotal: {
+			labels: (clusterId: string, resourceType: string, status: string) => ({
+				inc: () => pollMetricIncrements.push({ clusterId, resourceType, status })
+			})
+		},
 		resourceUpdatesTotal: { labels: () => ({ inc: () => {} }) },
 		sseSubscribersGauge: { labels: () => ({ set: () => {} }), reset: () => {} },
 		activeWorkersGauge: { set: () => {} },
-		fluxResourceStatusGauge: { labels: () => ({ set: () => {} }), remove: () => {} }
+		fluxResourceStatusGauge: {
+			labels: () => ({
+				set: () => {
+					if (throwOnStatusGaugeSet) throw new Error('status gauge unavailable');
+				}
+			}),
+			remove: () => {}
+		}
 	}));
 	vi.doMock('../lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
 		captureReconciliation: mockCaptureReconciliation
@@ -203,6 +218,29 @@ describe('subscribe()', () => {
 // ---------------------------------------------------------------------------
 
 describe('Poll change detection', () => {
+	test('resource processing rejection increments poll error metric', async () => {
+		const events: SSEEvent[] = [];
+		const clusterId = uniqueClusterId('processing-error');
+		throwOnStatusGaugeSet = true;
+		mockResources = [makeResource('my-app', 'flux-system', 'v1')];
+
+		const unsub = subscribe((e) => events.push(e), clusterId);
+		await wait(150);
+
+		try {
+			expect(
+				pollMetricIncrements.some(
+					(metric) =>
+						metric.clusterId === clusterId &&
+						metric.resourceType === 'GitRepository' &&
+						metric.status === 'error'
+				)
+			).toBe(true);
+		} finally {
+			unsub();
+		}
+	});
+
 	test('resource with changed resourceVersion broadcasts MODIFIED event', async () => {
 		const events: SSEEvent[] = [];
 		const clusterId = uniqueClusterId('modified');
@@ -267,6 +305,52 @@ describe('Poll change detection', () => {
 		try {
 			const added = events.filter((e) => e.type === 'ADDED');
 			expect(added.length).toBeGreaterThan(0);
+		} finally {
+			unsub();
+		}
+	});
+
+	test('resource removed before settling is cleaned up without DELETED broadcast', async () => {
+		vi.resetModules();
+		vi.doMock('../lib/server/kubernetes/client.js', () => ({
+			...actualClient,
+			listFluxResources: async () => ({ items: mockResources })
+		}));
+		vi.doMock('../lib/server/metrics.js', () => ({
+			...actualMetrics,
+			resourcePollsTotal: { labels: () => ({ inc: () => {} }) },
+			resourceUpdatesTotal: { labels: () => ({ inc: () => {} }) },
+			sseSubscribersGauge: { labels: () => ({ set: () => {} }), reset: () => {} },
+			activeWorkersGauge: { set: () => {} },
+			fluxResourceStatusGauge: { labels: () => ({ set: () => {} }), remove: () => {} }
+		}));
+		vi.doMock('../lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
+			captureReconciliation: mockCaptureReconciliation
+		}));
+		vi.doMock('../lib/server/config/constants.js', () => ({
+			...actualConstants,
+			SETTLING_PERIOD_MS: 60_000,
+			POLL_INTERVAL_MS: 50,
+			HEARTBEAT_INTERVAL_MS: 10000
+		}));
+		vi.doMock('../lib/server/logger.js', () => ({
+			logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+		}));
+		const eventsModule = await importFresh<EventsModule>('../lib/server/events.js');
+		const subscribeWithSettling = eventsModule.subscribe;
+
+		const events: SSEEvent[] = [];
+		const clusterId = uniqueClusterId('removed-before-settle');
+		mockResources = [makeResource('new-app', 'flux-system', 'v1')];
+		const unsub = subscribeWithSettling((e) => events.push(e), clusterId);
+		await wait(150);
+
+		mockResources = [];
+		await wait(150);
+
+		try {
+			expect(events.some((e) => e.type === 'ADDED')).toBe(false);
+			expect(events.some((e) => e.type === 'DELETED')).toBe(false);
 		} finally {
 			unsub();
 		}

--- a/src/tests/events.test.ts
+++ b/src/tests/events.test.ts
@@ -16,9 +16,11 @@ import type { SSEEvent } from '../lib/server/events.js';
 let subscribe: EventsModule['subscribe'];
 let closeAllEventStreams: EventsModule['closeAllEventStreams'];
 let setEventBusShuttingDown: EventsModule['setEventBusShuttingDown'];
+let mockCaptureReconciliation: ReturnType<typeof vi.fn>;
 
 beforeEach(async () => {
 	mockResources = [];
+	mockCaptureReconciliation = vi.fn(async () => {});
 	vi.doMock('../lib/server/kubernetes/client.js', () => ({
 		...actualClient,
 		listFluxResources: async () => ({ items: mockResources })
@@ -32,7 +34,7 @@ beforeEach(async () => {
 		fluxResourceStatusGauge: { labels: () => ({ set: () => {} }), remove: () => {} }
 	}));
 	vi.doMock('../lib/server/kubernetes/flux/reconciliation-tracker.js', () => ({
-		captureReconciliation: async () => {}
+		captureReconciliation: mockCaptureReconciliation
 	}));
 	vi.doMock('../lib/server/config/constants.js', () => ({
 		...actualConstants,
@@ -270,6 +272,24 @@ describe('Poll change detection', () => {
 		}
 	});
 
+	test('captureReconciliation failure does not block ADDED event broadcast', async () => {
+		const events: SSEEvent[] = [];
+		const clusterId = uniqueClusterId('reconciliation-failure');
+		mockCaptureReconciliation.mockRejectedValueOnce(new Error('history unavailable'));
+
+		mockResources = [makeResource('new-app', 'flux-system', 'v1')];
+		const unsub = subscribe((e) => events.push(e), clusterId);
+
+		await wait(150);
+
+		try {
+			expect(mockCaptureReconciliation).toHaveBeenCalled();
+			expect(events.some((e) => e.type === 'ADDED')).toBe(true);
+		} finally {
+			unsub();
+		}
+	});
+
 	test('transient Unknown ready status does not trigger notification', async () => {
 		const events: SSEEvent[] = [];
 		const clusterId = uniqueClusterId('unknown-transient');
@@ -290,6 +310,37 @@ describe('Poll change detection', () => {
 			// Unknown status with unchanged revision should NOT trigger a MODIFIED notification
 			const modifiedAfter = events.slice(eventsAfterFirstPoll).filter((e) => e.type === 'MODIFIED');
 			expect(modifiedAfter.length).toBe(0);
+		} finally {
+			unsub();
+		}
+	});
+
+	test('transient Unknown ready status with changed revision waits for stable notification', async () => {
+		const events: SSEEvent[] = [];
+		const clusterId = uniqueClusterId('unknown-revision-transient');
+
+		mockResources = [makeResource('my-app', 'flux-system', 'v1', 'True', 'rev-1')];
+		const unsub = subscribe((e) => events.push(e), clusterId);
+
+		await wait(150);
+		const eventsAfterFirstPoll = events.length;
+
+		mockResources = [makeResource('my-app', 'flux-system', 'v2', 'Unknown', 'rev-2')];
+		await wait(150);
+
+		const modifiedWhileUnknown = events
+			.slice(eventsAfterFirstPoll)
+			.filter((e) => e.type === 'MODIFIED' && e.resourceType === 'GitRepository');
+
+		mockResources = [makeResource('my-app', 'flux-system', 'v3', 'True', 'rev-2')];
+		await wait(150);
+
+		try {
+			const stableModified = events
+				.slice(eventsAfterFirstPoll)
+				.filter((e) => e.type === 'MODIFIED' && e.resourceType === 'GitRepository');
+			expect(modifiedWhileUnknown).toHaveLength(0);
+			expect(stableModified).toHaveLength(1);
 		} finally {
 			unsub();
 		}


### PR DESCRIPTION
Closes #524 for the event poller hotspot slice.

## Summary
- split the event poller into smaller behavior-preserving helpers
- added focused event-bus coverage around reconciliation failures and transient Ready states
- preserved polling metrics, reconciliation capture, SSE broadcasts, and deletion cleanup behavior

## Verification
- pnpm exec vitest run src/tests/events.test.ts
- pnpm verify:repo:ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event broadcasting reliability when reconciliation errors occur.
  * Suppressed transient readiness noise so users no longer see spurious/duplicate notifications; only stable ADDED/MODIFIED/DELETED events are emitted.
  * Ensured removed resources are consistently pruned and broadcast as deleted.

* **Tests**
  * Added coverage for reconciliation failure handling, settling/gating behavior, and transient readiness scenarios.

* **Refactor**
  * Reorganized polling and event flow into smaller components for maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EnTRoPY0120/gyre/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->