### PR TITLE
Resolve ambiguous duplicate exports reported by Fallow

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -16,7 +16,7 @@
 	"ignoreExports": [
 		{
 			"file": "src/lib/components/ui/**/index.ts",
-			"exports": ["*"]
+			"exports": ["Root"]
 		},
 		{
 			"file": "src/lib/server/db/index.ts",
@@ -37,14 +37,6 @@
 		{
 			"file": "src/routes/**/+server.ts",
 			"exports": ["_metadata"]
-		},
-		{
-			"file": "src/lib/server/auth/crypto.ts",
-			"exports": ["*"]
-		},
-		{
-			"file": "src/lib/server/clusters/encryption.ts",
-			"exports": ["*"]
 		},
 		{
 			"file": "src/lib/templates/index.ts",

--- a/src/lib/server/auth/crypto.ts
+++ b/src/lib/server/auth/crypto.ts
@@ -115,7 +115,7 @@ export function decryptSecret(ciphertext: string): string {
  * Check if the encryption key is the insecure development default.
  * Use this to warn users in production environments.
  */
-export function isUsingDevelopmentKey(): boolean {
+export function isUsingDevelopmentAuthKey(): boolean {
 	return !process.env.AUTH_ENCRYPTION_KEY;
 }
 
@@ -123,7 +123,7 @@ export function isUsingDevelopmentKey(): boolean {
  * Validate that encryption/decryption works correctly.
  * Useful for startup checks.
  */
-export function testEncryption(): boolean {
+export function testAuthEncryption(): boolean {
 	try {
 		const testSecret = 'test-secret-' + crypto.randomBytes(8).toString('hex');
 		const encrypted = encryptSecret(testSecret);

--- a/src/lib/server/clusters/encryption.ts
+++ b/src/lib/server/clusters/encryption.ts
@@ -46,14 +46,14 @@ function getEncryptionKeyLazy(): string {
 /**
  * Check if the encryption key is the insecure development default.
  */
-export function isUsingDevelopmentKey(): boolean {
+export function isUsingDevelopmentClusterKey(): boolean {
 	return !process.env.GYRE_ENCRYPTION_KEY;
 }
 
 /**
  * Validate that encryption/decryption works correctly.
  */
-export function testEncryption(): boolean {
+export function testClusterEncryption(): boolean {
 	try {
 		const testSecret = 'test-kubeconfig-' + crypto.randomUUID();
 		const encrypted = encryptKubeconfig(testSecret);

--- a/src/lib/server/clusters/repository.ts
+++ b/src/lib/server/clusters/repository.ts
@@ -201,5 +201,3 @@ export async function getClusterKubeconfig(id: string): Promise<string | null> {
 
 	return decryptKubeconfig(cluster.kubeconfigEncrypted);
 }
-
-export type { NewCluster, NewClusterContext };

--- a/src/lib/server/lifecycle/security-validation.ts
+++ b/src/lib/server/lifecycle/security-validation.ts
@@ -1,12 +1,6 @@
 import { logger } from '../logger.js';
-import {
-	testEncryption as testAuthEncryption,
-	isUsingDevelopmentKey as isUsingDevAuthKey
-} from '../auth/crypto.js';
-import {
-	testEncryption as testClusterEncryption,
-	isUsingDevelopmentKey as isUsingDevClusterKey
-} from '../clusters/encryption.js';
+import { testAuthEncryption, isUsingDevelopmentAuthKey } from '../auth/crypto.js';
+import { testClusterEncryption, isUsingDevelopmentClusterKey } from '../clusters/encryption.js';
 import { validateProductionSecurityConfig } from '../security-config.js';
 
 export function validateStartupSecurity(isProd: boolean): void {
@@ -17,7 +11,7 @@ export function validateStartupSecurity(isProd: boolean): void {
 		if (!testAuthEncryption()) {
 			throw new Error('AUTH encryption check failed');
 		}
-		if (isUsingDevAuthKey()) {
+		if (isUsingDevelopmentAuthKey()) {
 			if (isProd) {
 				throw new Error('AUTH_ENCRYPTION_KEY must be set in production');
 			}
@@ -28,7 +22,7 @@ export function validateStartupSecurity(isProd: boolean): void {
 		if (!testClusterEncryption()) {
 			throw new Error('Cluster kubeconfig encryption check failed');
 		}
-		if (isUsingDevClusterKey()) {
+		if (isUsingDevelopmentClusterKey()) {
 			if (isProd) {
 				throw new Error('GYRE_ENCRYPTION_KEY must be set in production');
 			}

--- a/src/tests/clusters-encryption.test.ts
+++ b/src/tests/clusters-encryption.test.ts
@@ -76,21 +76,21 @@ afterEach(() => {
 });
 
 describe('Cluster Kubeconfig Encryption', () => {
-	describe('testEncryption()', () => {
+	describe('testClusterEncryption()', () => {
 		test('returns true when encryption subsystem is working', () => {
-			expect(clustersModule.testEncryption()).toBe(true);
+			expect(clustersModule.testClusterEncryption()).toBe(true);
 		});
 	});
 
-	describe('isUsingDevelopmentKey()', () => {
+	describe('isUsingDevelopmentClusterKey()', () => {
 		test('returns true when GYRE_ENCRYPTION_KEY is not set', () => {
 			delete process.env.GYRE_ENCRYPTION_KEY;
-			expect(clustersModule.isUsingDevelopmentKey()).toBe(true);
+			expect(clustersModule.isUsingDevelopmentClusterKey()).toBe(true);
 		});
 
 		test('returns false when GYRE_ENCRYPTION_KEY is set', () => {
 			process.env.GYRE_ENCRYPTION_KEY = 'a'.repeat(64);
-			expect(clustersModule.isUsingDevelopmentKey()).toBe(false);
+			expect(clustersModule.isUsingDevelopmentClusterKey()).toBe(false);
 		});
 	});
 

--- a/src/tests/crypto.test.ts
+++ b/src/tests/crypto.test.ts
@@ -125,21 +125,21 @@ describe('Encryption Module', () => {
 		});
 	});
 
-	describe('isUsingDevelopmentKey', () => {
+	describe('isUsingDevelopmentAuthKey', () => {
 		test('returns true when AUTH_ENCRYPTION_KEY is not set', () => {
 			delete process.env.AUTH_ENCRYPTION_KEY;
-			expect(cryptoModule.isUsingDevelopmentKey()).toBe(true);
+			expect(cryptoModule.isUsingDevelopmentAuthKey()).toBe(true);
 		});
 
 		test('returns false when AUTH_ENCRYPTION_KEY is set', () => {
 			process.env.AUTH_ENCRYPTION_KEY = 'a'.repeat(64);
-			expect(cryptoModule.isUsingDevelopmentKey()).toBe(false);
+			expect(cryptoModule.isUsingDevelopmentAuthKey()).toBe(false);
 		});
 	});
 
-	describe('testEncryption', () => {
+	describe('testAuthEncryption', () => {
 		test('returns true when encryption subsystem is working', () => {
-			expect(cryptoModule.testEncryption()).toBe(true);
+			expect(cryptoModule.testAuthEncryption()).toBe(true);
 		});
 	});
 });

--- a/src/tests/helpers/module-stubs.ts
+++ b/src/tests/helpers/module-stubs.ts
@@ -29,8 +29,8 @@ export function createAuthCryptoModuleStub(
 		decryptSecret: (value: string) => string;
 		encryptSecret: (value: string) => string;
 		generateEncryptionKey: () => string;
-		isUsingDevelopmentKey: () => boolean;
-		testEncryption: () => boolean;
+		isUsingDevelopmentAuthKey: () => boolean;
+		testAuthEncryption: () => boolean;
 		_resetKeyCache: () => void;
 	}> = {}
 ) {
@@ -67,8 +67,8 @@ export function createAuthCryptoModuleStub(
 			return `${ivHex}:${ciphertext}:${authTag}`;
 		},
 		generateEncryptionKey: () => randomBytes(32).toString('hex'),
-		isUsingDevelopmentKey: () => !process.env.AUTH_ENCRYPTION_KEY,
-		testEncryption: () => {
+		isUsingDevelopmentAuthKey: () => !process.env.AUTH_ENCRYPTION_KEY,
+		testAuthEncryption: () => {
 			const encrypted = stub.encryptSecret('test-value');
 			return stub.decryptSecret(encrypted) === 'test-value';
 		},


### PR DESCRIPTION
Closes #525

## Summary
- Removed accidental cluster repository type re-exports.
- Renamed auth and cluster encryption helper exports to domain-specific names.
- Narrowed Fallow UI barrel suppression to the intentional Root export convention.

## Verification
- npx fallow dead-code --duplicate-exports
- npx fallow dead-code --unused-types --file src/lib/server/clusters/repository.ts
- pnpm exec vitest run src/tests/crypto.test.ts src/tests/clusters-encryption.test.ts
- pnpm verify:repo:ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal encryption function names across authentication and cluster modules for consistency.
  * Removed unused type re-exports.
  * Updated corresponding test files and test utilities to reflect API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EnTRoPY0120/gyre/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->