### PR TITLE
build: migrate Docker images from Alpine to Debian slim

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,7 @@
 # Trivy Vulnerability Ignores
 # This file lists CVEs that are intentionally ignored with justification
+
+# Debian marks this zlib issue as will_not_fix. It affects optional minizip APIs;
+# the Node runtime does not dynamically link libz, and zlib1g is essential to
+# the Debian package manager so removing it would leave the base image broken.
+CVE-2023-45853

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@
 # =============================================================================
 # Stage 0: Build Kustomize from source to ensure latest Go stdlib (fixes CVEs)
 # =============================================================================
-FROM golang:1.26-bookworm AS kustomize-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS kustomize-builder
+ARG TARGETOS
+ARG TARGETARCH
 ARG KUSTOMIZE_VERSION=v5.8.1
-RUN go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION}
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION}
 
 # =============================================================================
 # Stage 1: Builder - Build the SvelteKit application

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,14 @@ FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS kustomize-builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG KUSTOMIZE_VERSION=v5.8.1
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION}
+RUN mkdir -p /out && \
+  GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+  go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION} && \
+  if [ -x "/go/bin/${TARGETOS}_${TARGETARCH}/kustomize" ]; then \
+    cp "/go/bin/${TARGETOS}_${TARGETARCH}/kustomize" /out/kustomize; \
+  else \
+    cp /go/bin/kustomize /out/kustomize; \
+  fi
 
 # =============================================================================
 # Stage 1: Builder - Build the SvelteKit application
@@ -63,7 +70,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 # Copy Kustomize binary from kustomize-builder
-COPY --from=kustomize-builder /go/bin/kustomize /usr/local/bin/kustomize
+COPY --from=kustomize-builder /out/kustomize /usr/local/bin/kustomize
 
 # Create non-root user for security
 RUN groupadd --gid 1001 gyre && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION}
 # =============================================================================
 # Use Node.js as the builder base so better-sqlite3 compiles against the same
 # Node.js ABI that the runtime uses (avoids ERR_DLOPEN_FAILED at startup).
-FROM node:26-slim AS builder
+FROM node:26-bookworm-slim AS builder
 
 WORKDIR /build
 
@@ -44,7 +44,7 @@ RUN CI=true pnpm prune --prod
 # =============================================================================
 # Stage 2: Runtime - Production image with security hardening
 # =============================================================================
-FROM node:26-slim AS runtime
+FROM node:26-bookworm-slim AS runtime
 
 # Add metadata labels
 LABEL org.opencontainers.image.title="Gyre" \
@@ -57,6 +57,7 @@ LABEL org.opencontainers.image.title="Gyre" \
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y --no-install-recommends ca-certificates && \
+  DEBIAN_FRONTEND=noninteractive apt-get purge -y --allow-remove-essential perl-base && \
   rm -rf /var/lib/apt/lists/*
 
 # Copy Kustomize binary from kustomize-builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # =============================================================================
 # Stage 0: Build Kustomize from source to ensure latest Go stdlib (fixes CVEs)
 # =============================================================================
-FROM golang:1.26-alpine AS kustomize-builder
+FROM golang:1.26-bookworm AS kustomize-builder
 ARG KUSTOMIZE_VERSION=v5.8.1
 RUN go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION}
 
@@ -11,12 +11,15 @@ RUN go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION}
 # =============================================================================
 # Use Node.js as the builder base so better-sqlite3 compiles against the same
 # Node.js ABI that the runtime uses (avoids ERR_DLOPEN_FAILED at startup).
-FROM node:26-alpine3.23 AS builder
+FROM node:26-slim AS builder
 
 WORKDIR /build
 
-# Install native module build tools (better-sqlite3 has no prebuilt musl binaries)
-RUN apk add --no-cache python3 make g++
+# Install native module build tools (better-sqlite3 needs to compile against the
+# same Node.js ABI that the runtime uses).
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends python3 make g++ && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g pnpm@11.1.0
 
@@ -41,7 +44,7 @@ RUN CI=true pnpm prune --prod
 # =============================================================================
 # Stage 2: Runtime - Production image with security hardening
 # =============================================================================
-FROM node:26-alpine3.23 AS runtime
+FROM node:26-slim AS runtime
 
 # Add metadata labels
 LABEL org.opencontainers.image.title="Gyre" \
@@ -49,18 +52,19 @@ LABEL org.opencontainers.image.title="Gyre" \
   org.opencontainers.image.vendor="Gyre Project" \
   org.opencontainers.image.source="https://github.com/EnTRoPY0120/gyre"
 
-# Upgrade OS packages to pull in security patches (e.g. zlib CVE-2026-22184)
-RUN apk upgrade --no-cache
-
-# Install CA certificates
-RUN apk add --no-cache ca-certificates
+# Upgrade OS packages and install CA certificates to pull in security patches
+# (e.g. zlib CVE-2026-22184).
+RUN apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y --no-install-recommends ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
 
 # Copy Kustomize binary from kustomize-builder
 COPY --from=kustomize-builder /go/bin/kustomize /usr/local/bin/kustomize
 
 # Create non-root user for security
-RUN addgroup -g 1001 -S gyre && \
-  adduser -S -D -H -u 1001 -h /app -s /sbin/nologin -G gyre -g gyre gyre
+RUN groupadd --gid 1001 gyre && \
+  useradd --uid 1001 --gid gyre --home-dir /app --shell /usr/sbin/nologin --no-create-home gyre
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Replace Alpine-based Node builder and runtime images with `node:26-slim`.
- Replace the Alpine Kustomize builder with `golang:1.26-bookworm`.
- Translate package installation and non-root user creation to Debian tools.
- Keep native `better-sqlite3` compilation and runtime ABI aligned on glibc.

## Validation

- `docker build --check .`
- `docker build --platform linux/amd64 -t gyre:node-slim .`
- Runtime smoke test as UID/GID 1001, including `better-sqlite3` load.
- `/api/v1/health` returned HTTP 200 inside the container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved container compatibility across different hardware platforms.
  - Updated the application runtime environment for greater stability and predictable deployments.
  - Enhanced certificate and package handling to support reliable secure connections.
  - Continued running the application as a non-root user to strengthen container security.
  - Documented an accepted base-image security finding that does not affect the application’s runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->