### PR TITLE
ci: skip emulated arm64 image builds on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,7 @@ jobs:
       # buildkit runs the arm64 build entirely inside the emulated environment and
       # exports a single-platform image the local daemon can load.
       - name: Build image for scan (arm64)
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -131,6 +132,7 @@ jobs:
           cache-to: type=gha,scope=arm64,mode=min
 
       - name: Run Trivy scan arm64 (blocking)
+        if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           image-ref: gyre:scan-arm64


### PR DESCRIPTION
Pull requests now run the blocking amd64 image build and scan only. ARM64 build and scan remain enforced for pushes and tags before publishing, avoiding stale emulated jobs on PR commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated arm64 security scanning and build checks to run only outside pull request workflows.
  * Pull request validation is now streamlined by skipping these nonessential arm64 steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->