### PR TITLE
refactor: remove unused exports

### DIFF
--- a/src/lib/server/audit.ts
+++ b/src/lib/server/audit.ts
@@ -201,6 +201,7 @@ export async function getAuditLogsPaginated(
 /**
  * Clean up old audit logs based on retention policy
  */
+// fallow-ignore-next-line unused-export -- dynamically imported by audit cleanup tests
 export async function cleanupOldAuditLogs(): Promise<number> {
 	try {
 		const db = getDbSync();

--- a/src/lib/server/flux/use-cases/resource-diff-helpers.ts
+++ b/src/lib/server/flux/use-cases/resource-diff-helpers.ts
@@ -9,7 +9,7 @@ export type DesiredResourceComparison = {
 	plural: string;
 };
 
-export function pluralForKind(kind: string): string {
+function pluralForKind(kind: string): string {
 	const fluxDefs = Object.values(FLUX_RESOURCES) as Array<{ kind: string; plural: string }>;
 	const fluxDef = fluxDefs.find((resource) => resource.kind === kind);
 	if (fluxDef) return fluxDef.plural;

--- a/src/lib/server/flux/use-cases/resource-diff.ts
+++ b/src/lib/server/flux/use-cases/resource-diff.ts
@@ -200,7 +200,7 @@ export function cleanDiffObject(obj: unknown): unknown {
 	return cleaned;
 }
 
-export async function downloadArtifact(url: string, timeoutMs = 15000): Promise<Buffer> {
+async function downloadArtifact(url: string, timeoutMs = 15000): Promise<Buffer> {
 	return new Promise((resolve, reject) => {
 		const parsedUrl = new URL(url);
 		const client = parsedUrl.protocol === 'https:' ? https : http;

--- a/src/lib/stores/events/helpers.ts
+++ b/src/lib/stores/events/helpers.ts
@@ -125,7 +125,7 @@ export function getNotificationMessage(event: ResourceEvent): string {
 		: `${name} in ${namespace}`;
 }
 
-export function getRevisionFromResource(resource: ResourceEvent['resource']): string | undefined {
+function getRevisionFromResource(resource: ResourceEvent['resource']): string | undefined {
 	if (!resource?.status) return undefined;
 	const status = resource.status as Record<string, unknown>;
 	return (


### PR DESCRIPTION
## Summary
- remove export modifiers from three helpers with no external consumers
- retain the audit cleanup export because audit cleanup tests dynamically import it
- document the intentional Fallow suppression for that dynamic module contract

Closes #641

## Validation
- `pnpm format`
- `pnpm format:check`
- `pnpm lint`
- `pnpm check`
- `pnpm test:coverage`
- `pnpm exec fallow audit --base origin/main --format json --quiet`
- Fallow complexity audit: zero findings
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal helper functions are now kept private where they are not part of the public interface.
  * No user-visible behavior or functionality has changed.

* **Chores**
  * Added a linting exception for a function used through dynamic test imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->