### PR TITLE
refactor: consolidate duplicate cluster input export

### DIFF
--- a/src/routes/admin/clusters/+page.server.ts
+++ b/src/routes/admin/clusters/+page.server.ts
@@ -4,8 +4,8 @@ import { fail } from '@sveltejs/kit';
 import { getAllClustersPaginated, testClusterConnection } from '$lib/server/clusters';
 import { logClusterChange } from '$lib/server/audit';
 import { parseAdminPagination } from '../pagination';
-import { validateClusterCreateInput } from './create-validation';
-import { createClusterAndLog, type ClusterCreateInput } from './create-cluster';
+import { validateClusterCreateInput, type ClusterCreateInput } from './create-validation';
+import { createClusterAndLog } from './create-cluster';
 import { deleteClusterAndLog, toggleClusterAndLog } from './cluster-actions';
 import {
 	getRequiredFormString,

--- a/src/routes/admin/clusters/create-cluster.ts
+++ b/src/routes/admin/clusters/create-cluster.ts
@@ -3,12 +3,7 @@ import { logger } from '$lib/server/logger.js';
 import { createCluster } from '$lib/server/clusters';
 import { logClusterChange } from '$lib/server/audit';
 import type { User } from '$lib/server/db/schema';
-
-export interface ClusterCreateInput {
-	name: string;
-	description: string;
-	kubeconfig: string;
-}
+import type { ClusterCreateInput } from './create-validation';
 
 type CreateClusterDependencies = {
 	createCluster: typeof createCluster;

--- a/src/tests/create-cluster.test.ts
+++ b/src/tests/create-cluster.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
-import {
-	createClusterAndLog,
-	type ClusterCreateInput
-} from '../routes/admin/clusters/create-cluster.js';
+import { createClusterAndLog } from '../routes/admin/clusters/create-cluster.js';
+import type { ClusterCreateInput } from '../routes/admin/clusters/create-validation.js';
 import type { User } from '../lib/server/db/schema.js';
 
 const actor = { id: 'admin-1' } as User;


### PR DESCRIPTION
## Summary
- keep `ClusterCreateInput` defined and exported only by the validation module
- update the cluster action, page server, and type-only test import to use the single definition
- preserve runtime behavior without adding tests for a type-only change

Closes #642

## Validation
- `pnpm format`
- `pnpm format:check`
- `pnpm lint`
- `pnpm check`
- `pnpm test:coverage`
- `pnpm build`
- `pnpm exec fallow dead-code --duplicate-exports --format json --quiet`
- `pnpm exec fallow audit --base origin/main --format json --quiet`
- Fallow complexity audit: zero findings
- `git diff --check`
