### PR TITLE
refactor: split auth table migration stages

### DIFF
--- a/src/lib/server/db/migrations/auth-tables.ts
+++ b/src/lib/server/db/migrations/auth-tables.ts
@@ -13,9 +13,20 @@ export interface MigrationFlags {
  * app_settings is created first because other migrations use it as a flag store.
  */
 export function initAuthTables(db: Db, flags: MigrationFlags): void {
-	const { hasLegacyPasswordHashColumn, hasNullableSessionToken } = flags;
+	createAppSettingsTable(db);
+	createUsersTable(db);
+	normalizeUsernames(db);
+	ensureUserColumns(db);
+	createSessionsTable(db);
+	if (flags.hasNullableSessionToken) enforceSessionTokenNotNull(db);
+	createAccountsTable(db, flags.hasLegacyPasswordHashColumn);
+	createVerificationsTable(db);
+	if (flags.hasLegacyPasswordHashColumn) migrateLegacyUsers(db);
+	createAuthIndexes(db);
+}
 
-	// App Settings table (must be initialized first to store migration flags)
+function createAppSettingsTable(db: Db): void {
+	// App settings is initialized first because other migrations use it as a flag store.
 	db.run(sql`
 		CREATE TABLE IF NOT EXISTS app_settings (
 			key TEXT PRIMARY KEY,
@@ -23,8 +34,9 @@ export function initAuthTables(db: Db, flags: MigrationFlags): void {
 			updated_at INTEGER NOT NULL DEFAULT (unixepoch())
 		)
 	`);
+}
 
-	// Users table
+function createUsersTable(db: Db): void {
 	db.run(sql`
 		CREATE TABLE IF NOT EXISTS users (
 			id TEXT PRIMARY KEY,
@@ -41,8 +53,9 @@ export function initAuthTables(db: Db, flags: MigrationFlags): void {
 			preferences TEXT
 		)
 	`);
+}
 
-	// Migration: ensure existing usernames are lowercased (run once)
+function normalizeUsernames(db: Db): void {
 	runFlaggedMigration({
 		db,
 		key: 'migrations.users_lowercased',
@@ -57,19 +70,17 @@ export function initAuthTables(db: Db, flags: MigrationFlags): void {
 			const groups = new Map<string, { id: string; username: string }[]>();
 			for (const user of allUsers) {
 				const normalized = user.username.toLowerCase().trim();
-				if (!groups.has(normalized)) {
-					groups.set(normalized, []);
-				}
+				if (!groups.has(normalized)) groups.set(normalized, []);
 				groups.get(normalized)!.push(user);
 			}
 
-			// Pass 1: Set all users to unique temp names to avoid cross-update conflicts
+			// Pass 1: Set all users to unique temp names to avoid cross-update conflicts.
 			for (const user of allUsers) {
 				const tempName = `__tmp__${user.id}`;
 				tx.run(sql`UPDATE users SET username = ${tempName} WHERE id = ${user.id}`);
 			}
 
-			// Pass 2: Assign final names, tracking globally taken names to prevent collisions
+			// Pass 2: Assign final names, tracking globally taken names to prevent collisions.
 			const taken = new Set<string>();
 			for (const [normalized, group] of groups) {
 				group.sort((a, b) => a.id.localeCompare(b.id));
@@ -79,16 +90,16 @@ export function initAuthTables(db: Db, flags: MigrationFlags): void {
 				let counter = 1;
 				for (let i = 0; i < group.length; i++) {
 					let candidate = i === 0 ? normalized : `${normalized}_${i}`;
-					while (taken.has(candidate)) {
-						candidate = `${normalized}_${counter++}`;
-					}
+					while (taken.has(candidate)) candidate = `${normalized}_${counter++}`;
 					taken.add(candidate);
 					tx.run(sql`UPDATE users SET username = ${candidate} WHERE id = ${group[i].id}`);
 				}
 			}
 		}
 	});
+}
 
+function ensureUserColumns(db: Db): void {
 	addColumnsIgnoringDuplicates(
 		db,
 		[
@@ -102,8 +113,9 @@ export function initAuthTables(db: Db, flags: MigrationFlags): void {
 	);
 
 	db.run(sql`UPDATE users SET name = username WHERE name = '' OR name IS NULL`);
+}
 
-	// Sessions table
+function createSessionsTable(db: Db): void {
 	db.run(sql`
 		CREATE TABLE IF NOT EXISTS sessions (
 			id TEXT PRIMARY KEY,
@@ -129,41 +141,42 @@ export function initAuthTables(db: Db, flags: MigrationFlags): void {
 
 	db.run(sql`UPDATE sessions SET token = id WHERE token IS NULL OR token = ''`);
 	db.run(sql`UPDATE sessions SET updated_at = created_at WHERE updated_at IS NULL`);
+}
 
-	if (hasNullableSessionToken) {
-		db.run(sql`PRAGMA foreign_keys = OFF`);
-		try {
-			db.transaction((tx) => {
-				tx.run(sql`
-					CREATE TABLE sessions_next (
-						id TEXT PRIMARY KEY,
-						user_id TEXT NOT NULL,
-						token TEXT NOT NULL UNIQUE,
-						expires_at INTEGER NOT NULL,
-						ip_address TEXT,
-						user_agent TEXT,
-						created_at INTEGER NOT NULL DEFAULT (unixepoch()),
-						updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
-						FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-					)
-				`);
-				tx.run(sql`
-					INSERT INTO sessions_next (id, user_id, token, expires_at, ip_address, user_agent, created_at, updated_at)
-					SELECT id, user_id, token, expires_at, ip_address, user_agent, created_at, updated_at
-					FROM sessions
-				`);
-				tx.run(sql`DROP TABLE sessions`);
-				tx.run(sql`ALTER TABLE sessions_next RENAME TO sessions`);
-			});
-		} catch (err) {
-			logger.error(err, '[DB] Failed to enforce NOT NULL on sessions.token:');
-			throw err;
-		} finally {
-			db.run(sql`PRAGMA foreign_keys = ON`);
-		}
+function enforceSessionTokenNotNull(db: Db): void {
+	db.run(sql`PRAGMA foreign_keys = OFF`);
+	try {
+		db.transaction((tx) => {
+			tx.run(sql`
+				CREATE TABLE sessions_next (
+					id TEXT PRIMARY KEY,
+					user_id TEXT NOT NULL,
+					token TEXT NOT NULL UNIQUE,
+					expires_at INTEGER NOT NULL,
+					ip_address TEXT,
+					user_agent TEXT,
+					created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+					updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+					FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+				)
+			`);
+			tx.run(sql`
+				INSERT INTO sessions_next (id, user_id, token, expires_at, ip_address, user_agent, created_at, updated_at)
+				SELECT id, user_id, token, expires_at, ip_address, user_agent, created_at, updated_at
+				FROM sessions
+			`);
+			tx.run(sql`DROP TABLE sessions`);
+			tx.run(sql`ALTER TABLE sessions_next RENAME TO sessions`);
+		});
+	} catch (err) {
+		logger.error(err, '[DB] Failed to enforce NOT NULL on sessions.token:');
+		throw err;
+	} finally {
+		db.run(sql`PRAGMA foreign_keys = ON`);
 	}
+}
 
-	// Accounts table
+function createAccountsTable(db: Db, hasLegacyPasswordHashColumn: boolean): void {
 	db.run(sql`
 		CREATE TABLE IF NOT EXISTS accounts (
 			id TEXT PRIMARY KEY,
@@ -209,8 +222,9 @@ export function initAuthTables(db: Db, flags: MigrationFlags): void {
 			WHERE is_local = 1 AND password_hash IS NOT NULL AND password_hash != ''
 		`);
 	}
+}
 
-	// Verifications table
+function createVerificationsTable(db: Db): void {
 	db.run(sql`
 		CREATE TABLE IF NOT EXISTS verifications (
 			id TEXT PRIMARY KEY,
@@ -221,51 +235,52 @@ export function initAuthTables(db: Db, flags: MigrationFlags): void {
 			identifier TEXT NOT NULL
 		)
 	`);
+}
 
-	if (hasLegacyPasswordHashColumn) {
-		db.run(sql`PRAGMA foreign_keys = OFF`);
-		try {
-			db.transaction((tx) => {
-				tx.run(sql`
-					CREATE TABLE users_next (
-						id TEXT PRIMARY KEY,
-						username TEXT NOT NULL UNIQUE COLLATE NOCASE,
-						email TEXT,
-						name TEXT NOT NULL DEFAULT '',
-						email_verified INTEGER NOT NULL DEFAULT 0,
-						image TEXT,
-						role TEXT NOT NULL DEFAULT 'viewer',
-						active INTEGER NOT NULL DEFAULT 1,
-						is_local INTEGER NOT NULL DEFAULT 1,
-						created_at INTEGER NOT NULL DEFAULT (unixepoch()),
-						updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
-						preferences TEXT,
-						requires_password_change INTEGER NOT NULL DEFAULT 0
-					)
-				`);
-				tx.run(sql`
-					INSERT INTO users_next (
-						id, username, email, name, email_verified, image,
-						role, active, is_local, created_at, updated_at, preferences,
-						requires_password_change
-					)
-					SELECT
-						id, username, email,
-						COALESCE(name, username, ''),
-						COALESCE(email_verified, 0),
-						image, role, active, is_local, created_at, updated_at, preferences,
-						COALESCE(requires_password_change, 0)
-					FROM users
-				`);
-				tx.run(sql`DROP TABLE users`);
-				tx.run(sql`ALTER TABLE users_next RENAME TO users`);
-			});
-		} finally {
-			db.run(sql`PRAGMA foreign_keys = ON`);
-		}
+function migrateLegacyUsers(db: Db): void {
+	db.run(sql`PRAGMA foreign_keys = OFF`);
+	try {
+		db.transaction((tx) => {
+			tx.run(sql`
+				CREATE TABLE users_next (
+					id TEXT PRIMARY KEY,
+					username TEXT NOT NULL UNIQUE COLLATE NOCASE,
+					email TEXT,
+					name TEXT NOT NULL DEFAULT '',
+					email_verified INTEGER NOT NULL DEFAULT 0,
+					image TEXT,
+					role TEXT NOT NULL DEFAULT 'viewer',
+					active INTEGER NOT NULL DEFAULT 1,
+					is_local INTEGER NOT NULL DEFAULT 1,
+					created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+					updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+					preferences TEXT,
+					requires_password_change INTEGER NOT NULL DEFAULT 0
+				)
+			`);
+			tx.run(sql`
+				INSERT INTO users_next (
+					id, username, email, name, email_verified, image,
+					role, active, is_local, created_at, updated_at, preferences,
+					requires_password_change
+				)
+				SELECT
+					id, username, email,
+					COALESCE(name, username, ''),
+					COALESCE(email_verified, 0),
+					image, role, active, is_local, created_at, updated_at, preferences,
+					COALESCE(requires_password_change, 0)
+				FROM users
+			`);
+			tx.run(sql`DROP TABLE users`);
+			tx.run(sql`ALTER TABLE users_next RENAME TO users`);
+		});
+	} finally {
+		db.run(sql`PRAGMA foreign_keys = ON`);
 	}
+}
 
-	// Indexes
+function createAuthIndexes(db: Db): void {
 	db.run(sql`CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions (expires_at)`);
 	db.run(sql`CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions (user_id)`);
 	db.run(sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_token ON sessions (token)`);


### PR DESCRIPTION
## Summary
- split the 266-line `initAuthTables` migration into focused private stages
- preserve the existing table creation order, migration flags, transactions, SQL, and error handling
- leave the remaining large UI templates for separate, behavior-focused follow-up rather than mechanical file splitting

Closes #643

## Fallow scope
- `initAuthTables` is no longer reported as an oversized production unit
- changed-scope complexity findings: 0
- changed-scope duplication clone groups: 0
- changed-scope unused exports: 0
- the audit's one dependency finding is pre-existing and marked `introduced: false`

## Validation
- `pnpm format`
- `pnpm format:check`
- `pnpm lint`
- `pnpm check`
- `pnpm test:coverage`
- `pnpm build`
- `pnpm exec fallow health --complexity --production --format json --quiet`
- `pnpm exec fallow audit --base origin/main --format json --quiet`
- `git diff --check`
