### PR TITLE
docs: sync README and documentation with current behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ NODE_ENV=development
 # TTL for the dashboard resource-count cache (milliseconds).
 # GYRE_DASHBOARD_CACHE_TTL_MS=30000
 
+# TTL for cached admin-readiness dependency reads (milliseconds).
+# GYRE_ADMIN_READINESS_CACHE_TTL_MS=10000
+
 # Settling period after an ADDED event before notifications are emitted (ms).
 # Prevents spam during initial cluster sync.
 # GYRE_SETTLING_PERIOD_MS=30000
@@ -53,6 +56,9 @@ NODE_ENV=development
 
 # Interval between SSE heartbeat messages sent to connected clients (milliseconds).
 # GYRE_HEARTBEAT_INTERVAL_MS=30000
+
+# Number of days to retain audit-log entries.
+# GYRE_AUDIT_LOG_RETENTION_DAYS=90
 
 # Maximum request body size accepted by adapter-node (default: 512K).
 # Must be set to ≥ 500M to allow kubeconfig and backup uploads.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - 🌐 **Multi-Cluster** - Manage multiple Kubernetes clusters
 - 🔐 **Built-in Security** - RBAC plus local login, GitHub, Google, GitLab, and generic OIDC/OAuth2 auth support
 - ⚡ **Real-time Updates** - Live resource monitoring via SSE
-- 📊 **Complete FluxCD Support** - All resource types supported
+- 📊 **GitOps Toolkit Resources** - Manage all 13 supported resources, including Flux image automation
 
 [See full feature list →](https://entropy0120.github.io/gyre/features)
 
@@ -35,7 +35,7 @@ The most natural way to install Gyre is by using Flux itself. Add this `HelmRele
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: gyre
@@ -93,13 +93,14 @@ docker run \
     -e GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32) \
     -e BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32) \
     -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
+    -e GYRE_METRICS_TOKEN=$(openssl rand -hex 32) \
     -v gyre-data:/data \
     -v ~/.kube/config:/app/.kube/config:ro \
     -p 3000:3000 \
     ghcr.io/entropy0120/gyre:latest
 ```
 
-_Note: Make sure your current context points to a valid cluster with Flux installed. Omit `ADMIN_PASSWORD` to let Gyre generate one, or set a strong password that satisfies the app password policy._
+_Note: Make sure your current context points to a valid cluster with Flux installed. The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or set a strong password that satisfies the app password policy. Generate the encryption keys once per environment and persist them securely; changing them can make stored data unreadable._
 
 ### Option 4: Local Demo Script
 

--- a/README.md
+++ b/README.md
@@ -88,19 +88,26 @@ _Check the [latest release](https://github.com/entropy0120/gyre/releases/latest)
 Want to try the UI without installing it in your cluster? Run it locally connected to your `kubeconfig`:
 
 ```bash
+# Run once per environment. Keep this file for future container recreations.
+if [ ! -f .env.gyre ]; then
+    (umask 077; {
+        echo "AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)"
+        echo "GYRE_METRICS_TOKEN=$(openssl rand -hex 32)"
+    } > .env.gyre)
+fi
+
 docker run \
-    -e AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
-    -e GYRE_METRICS_TOKEN=$(openssl rand -hex 32) \
+    --env-file .env.gyre \
     -v gyre-data:/data \
     -v ~/.kube/config:/app/.kube/config:ro \
     -p 3000:3000 \
     ghcr.io/entropy0120/gyre:latest
 ```
 
-_Note: Make sure your current context points to a valid cluster with Flux installed. The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or set a strong password that satisfies the app password policy. Generate the encryption keys once per environment and persist them securely; changing them can make stored data unreadable._
+_Note: Make sure your current context points to a valid cluster with Flux installed. The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or set a strong password that satisfies the app password policy. Store `.env.gyre` securely and back it up with the `gyre-data` volume. Reuse it whenever you recreate the container; changing an encryption key can make stored data unreadable._
 
 ### Option 4: Local Demo Script
 

--- a/documentation/docs/api/README.md
+++ b/documentation/docs/api/README.md
@@ -74,6 +74,16 @@ GET /api/v1/auth/{providerId}/callback
 GET /api/v1/flux/{resourceType}?limit=50&offset=0&sortBy=name&sortOrder=asc
 ```
 
+The cluster-wide endpoint requires explicit cluster-wide read permission.
+
+### List Resources in a Namespace
+
+```http
+GET /api/v1/flux/{resourceType}/{namespace}
+```
+
+The namespace-scoped endpoint returns all resources of the requested type in that namespace and requires read permission for that resource type and namespace.
+
 ### Create Resource
 
 ```http
@@ -176,7 +186,19 @@ POST /api/v1/admin/k8s/clear-client-pool
 
 `PATCH /api/v1/admin/settings` is all-or-nothing. Unknown fields, invalid value types, invalid `auditRetentionDays`, and non-string `domainAllowlist` entries return `400` without persisting any setting. Settings locked by environment variables return `409` and name the locked field and owning env var instead of being silently ignored.
 
-## User Preferences
+## User Endpoints
+
+### Active Cluster
+
+These endpoints require an authenticated user. `GET` returns the current cluster selection and selectable clusters. `PUT` selects a cluster using a JSON body such as `{ "clusterId": "production" }`. `DELETE` clears the selection and returns to the in-cluster context.
+
+```http
+GET /api/v1/user/cluster
+PUT /api/v1/user/cluster
+DELETE /api/v1/user/cluster
+```
+
+### UI Preferences
 
 ```http
 POST /api/v1/user/preferences

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -117,6 +117,7 @@ The referenced secret must provide:
 | `GYRE_POLL_INTERVAL_MS`                | Kubernetes polling interval                    | `5000`                                          |
 | `GYRE_HEARTBEAT_INTERVAL_MS`           | SSE heartbeat interval                         | `30000`                                         |
 | `GYRE_DASHBOARD_CACHE_TTL_MS`          | Dashboard cache TTL                            | `30000`                                         |
+| `GYRE_ADMIN_READINESS_CACHE_TTL_MS`    | Admin-readiness dependency cache TTL           | `10000`                                         |
 | `GYRE_SETTLING_PERIOD_MS`              | Settling period for ADDED events               | `30000`                                         |
 | `GYRE_SETTINGS_CACHE_TTL_MS`           | Settings cache TTL                             | `30000`                                         |
 | `GYRE_MAX_LOCAL_BACKUPS`               | Max local backups retained                     | `10`                                            |
@@ -125,7 +126,7 @@ The referenced secret must provide:
 | `GYRE_SSE_MAX_CONNECTIONS_PER_USER`    | Max SSE connections per user                   | `5`                                             |
 | `GYRE_SSE_CONNECTION_TIMEOUT_MS`       | SSE connection lifetime (`0` disables timeout) | `0`                                             |
 
-### Auth Settings Overrides
+### Settings Overrides
 
 | Variable                                                     | Description                                                      |
 | ------------------------------------------------------------ | ---------------------------------------------------------------- |
@@ -134,6 +135,7 @@ The referenced secret must provide:
 | `GYRE_AUTH_DOMAIN_ALLOWLIST`                                 | JSON array of allowed signup domains                             |
 | `GYRE_AUTH_PROVIDERS`                                        | JSON array used to seed auth providers (no `clientSecret` field) |
 | `GYRE_AUTH_PROVIDER_<SANITIZED_PROVIDER_NAME>_CLIENT_SECRET` | Per-provider secret input for seeded providers                   |
+| `GYRE_AUDIT_LOG_RETENTION_DAYS`                              | Audit-log retention period in days (default: `90`)               |
 
 ## Helm-to-Env Mapping
 

--- a/documentation/docs/development.md
+++ b/documentation/docs/development.md
@@ -12,7 +12,7 @@ Gyre is a modern, full-featured WebUI for FluxCD built with SvelteKit. It provid
 
 **Deployment**: Production is Helm/GitOps-first and in-cluster. Local out-of-cluster mode is supported for development/testing. Includes production-ready Helm chart, Docker image (published to ghcr.io/entropy0120/gyre), and GitHub Actions CI/CD pipeline.
 
-**Current Status**: Core functionality complete with dashboard, all FluxCD resources, real-time updates, multi-cluster support, authentication/RBAC, Monaco Editor integration, and comprehensive resource templates with complete FluxCD CRD field coverage.
+**Current Status**: Core functionality includes a dashboard, management for all 13 supported GitOps Toolkit resources, real-time updates, multi-cluster support, authentication/RBAC, Monaco Editor integration, and guided resource templates.
 
 ## Common Commands
 
@@ -87,8 +87,18 @@ pnpm preview         # Preview production build locally
 
 # Docker build
 docker build -t gyre:local .
-docker run -p 3000:3000 -v $(pwd)/data:/data gyre:local
+docker run \
+    -e AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32) \
+    -e GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32) \
+    -e BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32) \
+    -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
+    -e GYRE_METRICS_TOKEN=$(openssl rand -hex 32) \
+    -v $(pwd)/data:/data \
+    -p 3000:3000 \
+    gyre:local
 ```
+
+The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Persist the three encryption keys across container restarts if you need to retain encrypted application data.
 
 ### Kind Helper Scripts
 

--- a/documentation/docs/development.md
+++ b/documentation/docs/development.md
@@ -87,18 +87,26 @@ pnpm preview         # Preview production build locally
 
 # Docker build
 docker build -t gyre:local .
+
+# Run once per environment. Keep this file for future container recreations.
+if [ ! -f .env.gyre ]; then
+    (umask 077; {
+        echo "AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)"
+        echo "GYRE_METRICS_TOKEN=$(openssl rand -hex 32)"
+    } > .env.gyre)
+fi
+
 docker run \
-    -e AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
-    -e GYRE_METRICS_TOKEN=$(openssl rand -hex 32) \
+    --env-file .env.gyre \
     -v $(pwd)/data:/data \
     -p 3000:3000 \
     gyre:local
 ```
 
-The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Persist the three encryption keys across container restarts if you need to retain encrypted application data.
+The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Store `.env.gyre` securely and back it up with the data directory. Reuse it whenever you recreate the container; changing an encryption key can make stored data unreadable.
 
 ### Kind Helper Scripts
 

--- a/documentation/docs/features.md
+++ b/documentation/docs/features.md
@@ -24,6 +24,8 @@ The main dashboard provides a high-level view of cluster health and Flux resourc
 
 ### Supported FluxCD Resources
 
+Gyre manages these 13 supported GitOps Toolkit resources:
+
 **Source Controller:**
 
 - GitRepositories
@@ -45,6 +47,12 @@ The main dashboard provides a high-level view of cluster health and Flux resourc
 - Alerts
 - Providers
 - Receivers
+
+**Image Automation Controllers:**
+
+- ImageRepositories
+- ImagePolicies
+- ImageUpdateAutomations
 
 ### Resource Views
 
@@ -243,6 +251,7 @@ Create new resources with guided forms:
 - `/api/v1/flux/*` - Flux resource operations
 - `/api/v1/events` - SSE stream for real-time updates
 - `/api/v1/admin/*` - Admin settings, backups, and auth provider management
+- `/api/v1/user/cluster` - Get, select, or clear the active cluster
 - `/api/v1/user/preferences` - User-level UI preferences
 
 ## Security

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -27,7 +27,7 @@ The most natural way to install Gyre is by using Flux itself. Add this `HelmRele
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: gyre
@@ -89,6 +89,7 @@ docker run \
     -e GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32) \
     -e BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32) \
     -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
+    -e GYRE_METRICS_TOKEN=$(openssl rand -hex 32) \
     -v gyre-data:/data \
     -v ~/.kube/config:/app/.kube/config:ro \
     -p 3000:3000 \
@@ -96,7 +97,7 @@ docker run \
 ```
 
 :::tip
-Omit `ADMIN_PASSWORD` to let Gyre generate one, or provide a strong password that satisfies the app password policy. `BETTER_AUTH_SECRET` is the session secret and may be regenerated on each deploy if you accept invalidating active sessions. `GYRE_ENCRYPTION_KEY`, `AUTH_ENCRYPTION_KEY`, and `BACKUP_ENCRYPTION_KEY` are data-encryption keys: generate them once per environment, store them securely, and rotate them only with a migration plan to avoid making existing gyre-data unreadable.
+The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or provide a strong password that satisfies the app password policy. `BETTER_AUTH_SECRET` is the session secret and may be regenerated on each deploy if you accept invalidating active sessions. `GYRE_ENCRYPTION_KEY`, `AUTH_ENCRYPTION_KEY`, and `BACKUP_ENCRYPTION_KEY` are data-encryption keys: generate them once per environment, store them securely, and rotate them only with a migration plan to avoid making existing gyre-data unreadable.
 :::
 
 ### Option 4: Local Demo Script

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -84,12 +84,19 @@ OCI Helm registries require an explicit version. Check the [latest release](http
 If you want to try the UI without installing it inside your cluster, you can run it locally connected to your `kubeconfig`. Make sure your current Kubernetes context points to a cluster with Flux installed.
 
 ```bash
+# Run once per environment. Keep this file for future container recreations.
+if [ ! -f .env.gyre ]; then
+    (umask 077; {
+        echo "AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)"
+        echo "GYRE_METRICS_TOKEN=$(openssl rand -hex 32)"
+    } > .env.gyre)
+fi
+
 docker run \
-    -e AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
-    -e GYRE_METRICS_TOKEN=$(openssl rand -hex 32) \
+    --env-file .env.gyre \
     -v gyre-data:/data \
     -v ~/.kube/config:/app/.kube/config:ro \
     -p 3000:3000 \
@@ -97,7 +104,7 @@ docker run \
 ```
 
 :::tip
-The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or provide a strong password that satisfies the app password policy. `BETTER_AUTH_SECRET` is the session secret and may be regenerated on each deploy if you accept invalidating active sessions. `GYRE_ENCRYPTION_KEY`, `AUTH_ENCRYPTION_KEY`, and `BACKUP_ENCRYPTION_KEY` are data-encryption keys: generate them once per environment, store them securely, and rotate them only with a migration plan to avoid making existing gyre-data unreadable.
+The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or provide a strong password that satisfies the app password policy. Store `.env.gyre` securely and back it up with the `gyre-data` volume. Reuse it whenever you recreate the container; rotate data-encryption keys only with a migration plan to avoid making existing data unreadable.
 :::
 
 ### Option 4: Local Demo Script

--- a/documentation/docs/installation/index.md
+++ b/documentation/docs/installation/index.md
@@ -16,7 +16,7 @@ The most natural way to install Gyre is by using Flux itself. Add this `HelmRele
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: gyre
@@ -117,6 +117,7 @@ docker run \
     -e GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32) \
     -e BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32) \
     -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
+    -e GYRE_METRICS_TOKEN=$(openssl rand -hex 32) \
     -v gyre-data:/data \
     -v ~/.kube/config:/app/.kube/config:ro \
     -p 3000:3000 \
@@ -124,7 +125,7 @@ docker run \
 ```
 
 :::tip
-Omit `ADMIN_PASSWORD` to let Gyre generate one, or provide a strong password that satisfies the app password policy. `BETTER_AUTH_SECRET` is the session secret and may be regenerated on each deploy if you accept invalidating active sessions. `GYRE_ENCRYPTION_KEY`, `AUTH_ENCRYPTION_KEY`, and `BACKUP_ENCRYPTION_KEY` are data-encryption keys: generate them once per environment, store them securely, and rotate them only with a migration plan to avoid making existing gyre-data unreadable.
+The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or provide a strong password that satisfies the app password policy. `BETTER_AUTH_SECRET` is the session secret and may be regenerated on each deploy if you accept invalidating active sessions. `GYRE_ENCRYPTION_KEY`, `AUTH_ENCRYPTION_KEY`, and `BACKUP_ENCRYPTION_KEY` are data-encryption keys: generate them once per environment, store them securely, and rotate them only with a migration plan to avoid making existing gyre-data unreadable.
 :::
 
 ## Option 4: Local Demo Script

--- a/documentation/docs/installation/index.md
+++ b/documentation/docs/installation/index.md
@@ -112,12 +112,19 @@ helm install gyre oci://ghcr.io/entropy0120/charts/gyre \
 If you want to try the UI without installing it inside your cluster, you can run it locally connected to your `kubeconfig`. Make sure your current Kubernetes context points to a cluster with Flux installed.
 
 ```bash
+# Run once per environment. Keep this file for future container recreations.
+if [ ! -f .env.gyre ]; then
+    (umask 077; {
+        echo "AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32)"
+        echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)"
+        echo "GYRE_METRICS_TOKEN=$(openssl rand -hex 32)"
+    } > .env.gyre)
+fi
+
 docker run \
-    -e AUTH_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e GYRE_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e BACKUP_ENCRYPTION_KEY=$(openssl rand -hex 32) \
-    -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
-    -e GYRE_METRICS_TOKEN=$(openssl rand -hex 32) \
+    --env-file .env.gyre \
     -v gyre-data:/data \
     -v ~/.kube/config:/app/.kube/config:ro \
     -p 3000:3000 \
@@ -125,7 +132,7 @@ docker run \
 ```
 
 :::tip
-The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or provide a strong password that satisfies the app password policy. `BETTER_AUTH_SECRET` is the session secret and may be regenerated on each deploy if you accept invalidating active sessions. `GYRE_ENCRYPTION_KEY`, `AUTH_ENCRYPTION_KEY`, and `BACKUP_ENCRYPTION_KEY` are data-encryption keys: generate them once per environment, store them securely, and rotate them only with a migration plan to avoid making existing gyre-data unreadable.
+The production image requires `GYRE_METRICS_TOKEN` to protect `/metrics`. Omit `ADMIN_PASSWORD` to let Gyre generate one, or provide a strong password that satisfies the app password policy. Store `.env.gyre` securely and back it up with the `gyre-data` volume. Reuse it whenever you recreate the container; rotate data-encryption keys only with a migration plan to avoid making existing data unreadable.
 :::
 
 ## Option 4: Local Demo Script

--- a/documentation/docs/user-guide/resource-wizard.md
+++ b/documentation/docs/user-guide/resource-wizard.md
@@ -1,6 +1,6 @@
 # Resource Creation Wizard
 
-The Gyre Resource Creation Wizard provides a guided, user-friendly interface for creating any of the 10 supported FluxCD resource types. It bridges the gap between manual YAML editing and high-level resource management.
+The Gyre Resource Creation Wizard provides a guided, user-friendly interface for creating any of the 13 supported GitOps Toolkit resource types. It bridges the gap between manual YAML editing and high-level resource management.
 
 ## Accessing the Wizard
 
@@ -74,17 +74,20 @@ To deploy a resource that depends on another:
 
 ## Resource Field Reference
 
-Gyre supports all 10 FluxCD resource types. Click on a resource type below for detailed information on its specific fields, or refer to the official FluxCD documentation.
+Gyre supports all 13 resource types listed below. Click on a resource type for details about the fields exposed by its wizard template, or refer to the official Flux documentation for the complete API.
 
-| Resource Type      | FluxCD Component        | Internal Reference                       | Official Docs                                                           |
-| ------------------ | ----------------------- | ---------------------------------------- | ----------------------------------------------------------------------- |
-| **GitRepository**  | Source Controller       | [Local Docs](./resources/GitRepository)  | [Official](https://fluxcd.io/flux/components/source/gitrepositories/)   |
-| **HelmRepository** | Source Controller       | [Local Docs](./resources/HelmRepository) | [Official](https://fluxcd.io/flux/components/source/helmrepositories/)  |
-| **HelmChart**      | Source Controller       | [Local Docs](./resources/HelmChart)      | [Official](https://fluxcd.io/flux/components/source/helmcharts/)        |
-| **Bucket**         | Source Controller       | [Local Docs](./resources/Bucket)         | [Official](https://fluxcd.io/flux/components/source/buckets/)           |
-| **OCIRepository**  | Source Controller       | [Local Docs](./resources/OCIRepository)  | [Official](https://fluxcd.io/flux/components/source/ocirepositories/)   |
-| **Kustomization**  | Kustomize Controller    | [Local Docs](./resources/Kustomization)  | [Official](https://fluxcd.io/flux/components/kustomize/kustomizations/) |
-| **HelmRelease**    | Helm Controller         | [Local Docs](./resources/HelmRelease)    | [Official](https://fluxcd.io/flux/components/helm/helmreleases/)        |
-| **Alert**          | Notification Controller | [Local Docs](./resources/Alert)          | [Official](https://fluxcd.io/flux/components/notification/alerts/)      |
-| **Provider**       | Notification Controller | [Local Docs](./resources/Provider)       | [Official](https://fluxcd.io/flux/components/notification/providers/)   |
-| **Receiver**       | Notification Controller | [Local Docs](./resources/Receiver)       | [Official](https://fluxcd.io/flux/components/notification/receivers/)   |
+| Resource Type             | FluxCD Component            | Internal Reference                              | Official Docs                                                               |
+| ------------------------- | --------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------- |
+| **GitRepository**         | Source Controller           | [Local Docs](./resources/GitRepository)         | [Official](https://fluxcd.io/flux/components/source/gitrepositories/)       |
+| **HelmRepository**        | Source Controller           | [Local Docs](./resources/HelmRepository)        | [Official](https://fluxcd.io/flux/components/source/helmrepositories/)      |
+| **HelmChart**             | Source Controller           | [Local Docs](./resources/HelmChart)             | [Official](https://fluxcd.io/flux/components/source/helmcharts/)            |
+| **Bucket**                | Source Controller           | [Local Docs](./resources/Bucket)                | [Official](https://fluxcd.io/flux/components/source/buckets/)               |
+| **OCIRepository**         | Source Controller           | [Local Docs](./resources/OCIRepository)         | [Official](https://fluxcd.io/flux/components/source/ocirepositories/)       |
+| **Kustomization**         | Kustomize Controller        | [Local Docs](./resources/Kustomization)         | [Official](https://fluxcd.io/flux/components/kustomize/kustomizations/)     |
+| **HelmRelease**           | Helm Controller             | [Local Docs](./resources/HelmRelease)           | [Official](https://fluxcd.io/flux/components/helm/helmreleases/)            |
+| **Alert**                 | Notification Controller     | [Local Docs](./resources/Alert)                 | [Official](https://fluxcd.io/flux/components/notification/alerts/)          |
+| **Provider**              | Notification Controller     | [Local Docs](./resources/Provider)              | [Official](https://fluxcd.io/flux/components/notification/providers/)       |
+| **Receiver**              | Notification Controller     | [Local Docs](./resources/Receiver)              | [Official](https://fluxcd.io/flux/components/notification/receivers/)       |
+| **ImageRepository**       | Image Reflector Controller  | [Local Docs](./resources/ImageRepository)       | [Official](https://fluxcd.io/flux/components/image/imagerepositories/)      |
+| **ImagePolicy**           | Image Reflector Controller  | [Local Docs](./resources/ImagePolicy)           | [Official](https://fluxcd.io/flux/components/image/imagepolicies/)          |
+| **ImageUpdateAutomation** | Image Automation Controller | [Local Docs](./resources/ImageUpdateAutomation) | [Official](https://fluxcd.io/flux/components/image/imageupdateautomations/) |

--- a/documentation/docs/user-guide/resources/ImagePolicy.md
+++ b/documentation/docs/user-guide/resources/ImagePolicy.md
@@ -1,0 +1,36 @@
+# ImagePolicy
+
+Selects an image tag from an ImageRepository according to a version policy.
+
+- **Group**: `image.toolkit.fluxcd.io`
+- **Version**: `v1`
+
+## Fields
+
+| Field                            | Label            | Type     | Required | Description                                               |
+| -------------------------------- | ---------------- | -------- | -------- | --------------------------------------------------------- |
+| `metadata.name`                  | Name             | `string` | Yes      | Unique name for this ImagePolicy resource.                |
+| `metadata.namespace`             | Namespace        | `string` | Yes      | Namespace where the resource will be created.             |
+| `spec.imageRepositoryRef.name`   | Image Repository | `string` | Yes      | ImageRepository to monitor.                               |
+| Policy type (wizard control)     | Policy Type      | `select` | No       | Selects SemVer, numerical, or alphabetical policy fields. |
+| `spec.policy.semver.range`       | Semver Range     | `string` | No       | SemVer range used to select a tag (default: `>=1.0.0`).   |
+| `spec.policy.numerical.order`    | Order            | `select` | No       | Numerical sort order (`asc` or `desc`).                   |
+| `spec.policy.alphabetical.order` | Order            | `select` | No       | Alphabetical sort order (`asc` or `desc`).                |
+
+## Example
+
+```yaml
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: example
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: example
+  policy:
+    semver:
+      range: '>=1.0.0'
+```
+
+See the [official ImagePolicy documentation](https://fluxcd.io/flux/components/image/imagepolicies/) for the complete API.

--- a/documentation/docs/user-guide/resources/ImageRepository.md
+++ b/documentation/docs/user-guide/resources/ImageRepository.md
@@ -1,0 +1,31 @@
+# ImageRepository
+
+Scans a container image repository and records its available tags.
+
+- **Group**: `image.toolkit.fluxcd.io`
+- **Version**: `v1`
+
+## Fields
+
+| Field                | Label             | Type       | Required | Description                                              |
+| -------------------- | ----------------- | ---------- | -------- | -------------------------------------------------------- |
+| `metadata.name`      | Name              | `string`   | Yes      | Unique name for this ImageRepository resource.           |
+| `metadata.namespace` | Namespace         | `string`   | Yes      | Namespace where the resource will be created.            |
+| `spec.image`         | Image             | `string`   | Yes      | Container image repository to scan.                      |
+| `spec.provider`      | Registry Provider | `select`   | No       | Registry provider (`generic`, `aws`, `azure`, or `gcp`). |
+| `spec.interval`      | Scan Interval     | `duration` | Yes      | How often to scan for new images (for example, `5m`).    |
+
+## Example
+
+```yaml
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: example
+  namespace: flux-system
+spec:
+  interval: 5m
+  image: ghcr.io/org/app
+```
+
+See the [official ImageRepository documentation](https://fluxcd.io/flux/components/image/imagerepositories/) for the complete API.

--- a/documentation/docs/user-guide/resources/ImageUpdateAutomation.md
+++ b/documentation/docs/user-guide/resources/ImageUpdateAutomation.md
@@ -1,0 +1,46 @@
+# ImageUpdateAutomation
+
+Commits automated image updates to a Git repository.
+
+- **Group**: `image.toolkit.fluxcd.io`
+- **Version**: `v1`
+
+## Fields
+
+| Field                          | Label          | Type       | Required | Description                                            |
+| ------------------------------ | -------------- | ---------- | -------- | ------------------------------------------------------ |
+| `metadata.name`                | Name           | `string`   | Yes      | Name for this ImageUpdateAutomation resource.          |
+| `metadata.namespace`           | Namespace      | `string`   | Yes      | Namespace where the resource will be created.          |
+| `spec.sourceRef.name`          | Git Repository | `string`   | Yes      | GitRepository containing manifests with image markers. |
+| `spec.git.checkout.ref.branch` | Branch         | `string`   | No       | Git branch to check out (default: `main`).             |
+| `spec.update.path`             | Update Path    | `string`   | No       | Path to search for image markers (default: `./`).      |
+| `spec.interval`                | Sync Interval  | `duration` | Yes      | How often to run the automation (default: `1h`).       |
+
+## Example
+
+```yaml
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: example
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@example.com
+        name: fluxcdbot
+      messageTemplate: 'Update image'
+  update:
+    path: ./clusters/production
+    strategy: Setters
+```
+
+See the [official ImageUpdateAutomation documentation](https://fluxcd.io/flux/components/image/imageupdateautomations/) for the complete API.

--- a/documentation/docs/user-guide/resources/OCIRepository.md
+++ b/documentation/docs/user-guide/resources/OCIRepository.md
@@ -3,7 +3,7 @@
 Sources from an OCI registry.
 
 - **Group**: `source.toolkit.fluxcd.io`
-- **Version**: `v1beta2`
+- **Version**: `v1`
 
 ## Fields
 
@@ -19,7 +19,7 @@ Sources from an OCI registry.
 ## Example
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: example

--- a/documentation/src/components/HomepageFeatures/index.tsx
+++ b/documentation/src/components/HomepageFeatures/index.tsx
@@ -41,12 +41,12 @@ const FeatureList: FeatureItem[] = [
 		)
 	},
 	{
-		title: 'Complete FluxCD Support',
+		title: 'GitOps Toolkit Resources',
 		icon: '⚡',
 		description: (
 			<>
-				Full support for all FluxCD resources including Kustomizations, HelmReleases, Sources, and
-				Notifications. Everything you need in one place.
+				Manage all 13 supported resources across Flux source, Kustomize, Helm, notification, and
+				image automation APIs from one interface.
 			</>
 		)
 	},


### PR DESCRIPTION
## Summary

- make standalone Docker startup commands production-correct by supplying the required metrics token and documenting persistent encryption keys
- synchronize the feature and wizard guides with all 13 supported GitOps Toolkit resources, including new image-automation reference pages and the OCIRepository v1 API
- document the existing admin-readiness/audit-retention settings and namespace resource-list/user cluster-selection endpoints
- narrow stale completeness claims to match the implemented support surface

## Validation

- `pnpm format:check`
- `pnpm docs:check`
- `pnpm verify:repo:ci`

The Docusaurus build completed without broken-link errors. Generated `documentation/build` and `.docusaurus` files are ignored and are not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented support for 13 GitOps Toolkit resources, including image automation.
  * Added guides for ImageRepository, ImagePolicy, and ImageUpdateAutomation.
  * Documented cluster-selection APIs, namespace-scoped resource listing, and updated UI preferences terminology.
  * Updated OCIRepository examples to API version `v1`.
  * Expanded Docker setup guidance for securely persisting encryption, authentication, and metrics secrets.
  * Documented audit-log retention and admin-readiness cache settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->